### PR TITLE
fix(ci): Use dev tag for main builds, latest only on release tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -116,7 +116,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Create manifest list and push


### PR DESCRIPTION
## Summary
- Push to main now tags Docker images as `dev` instead of `latest`
- Only version tag pushes (`v*`) set the `latest` tag

## Why
Prevents dev builds from overwriting `:latest`. Now `:latest` always means the most recent release.