### PR TITLE
Fix demo auto-login password to match seed data

### DIFF
--- a/src/providers/auth-provider.tsx
+++ b/src/providers/auth-provider.tsx
@@ -204,7 +204,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         if (health.demo_mode !== true) return;
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const { data, error } = await sdkLogin({ body: { username: "admin", password: "demo-password-readonly" } as any });
+        const { data, error } = await sdkLogin({ body: { username: "admin", password: "demo" } as any });
         if (error) return;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         storeTokens(data as any);


### PR DESCRIPTION
## Summary
- Fix demo mode auto-login: auth provider was sending `demo-password-readonly` but the seed script sets the admin password to `demo`

## Test plan
- [ ] Deploy to demo.artifactkeeper.com and verify auto-login works