### PR TITLE
Add health score dashboard and artifact health display

### DIFF
--- a/src/app/(app)/(admin)/health/page.tsx
+++ b/src/app/(app)/(admin)/health/page.tsx
@@ -1,0 +1,452 @@
+"use client";
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  HeartPulse,
+  ShieldCheck,
+  Package,
+  AlertTriangle,
+  AlertCircle,
+  RefreshCw,
+} from "lucide-react";
+import { useAuth } from "@/providers/auth-provider";
+import qualityGatesApi from "@/lib/api/quality-gates";
+import type { RepoHealth } from "@/types/quality-gates";
+
+import { PageHeader } from "@/components/common/page-header";
+import { StatCard } from "@/components/common/stat-card";
+import { DataTable, type DataTableColumn } from "@/components/common/data-table";
+import { HealthBadge } from "@/components/health-badge";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Alert, AlertTitle } from "@/components/ui/alert";
+
+// -- Grade distribution segment bar --
+
+const GRADE_BAR_COLORS: Record<string, string> = {
+  A: "bg-emerald-500",
+  B: "bg-blue-500",
+  C: "bg-amber-500",
+  D: "bg-orange-500",
+  F: "bg-red-500",
+};
+
+const GRADE_TEXT_COLORS: Record<string, string> = {
+  A: "text-emerald-600 dark:text-emerald-400",
+  B: "text-blue-600 dark:text-blue-400",
+  C: "text-amber-600 dark:text-amber-400",
+  D: "text-orange-600 dark:text-orange-400",
+  F: "text-red-600 dark:text-red-400",
+};
+
+function GradeDistributionBar({
+  distribution,
+}: {
+  distribution: Record<string, number>;
+}) {
+  const grades = ["A", "B", "C", "D", "F"];
+  const total = grades.reduce((sum, g) => sum + (distribution[g] ?? 0), 0);
+
+  if (total === 0) {
+    return (
+      <div className="text-sm text-muted-foreground text-center py-4">
+        No artifacts evaluated yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Segment bar */}
+      <div className="flex h-8 w-full overflow-hidden rounded-lg border">
+        {grades.map((grade) => {
+          const count = distribution[grade] ?? 0;
+          if (count === 0) return null;
+          const pct = (count / total) * 100;
+          return (
+            <div
+              key={grade}
+              className={`${GRADE_BAR_COLORS[grade]} flex items-center justify-center text-white text-xs font-bold transition-all`}
+              style={{ width: `${pct}%`, minWidth: pct > 0 ? "24px" : "0" }}
+              title={`Grade ${grade}: ${count} repositories (${pct.toFixed(1)}%)`}
+            >
+              {pct >= 8 ? grade : ""}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Legend */}
+      <div className="flex flex-wrap gap-4">
+        {grades.map((grade) => {
+          const count = distribution[grade] ?? 0;
+          return (
+            <div key={grade} className="flex items-center gap-1.5">
+              <div
+                className={`size-3 rounded-sm ${GRADE_BAR_COLORS[grade]}`}
+              />
+              <span className="text-sm text-muted-foreground">
+                Grade{" "}
+                <span className={`font-semibold ${GRADE_TEXT_COLORS[grade]}`}>
+                  {grade}
+                </span>
+              </span>
+              <span className="text-sm font-medium">{count}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// -- Overall health score display --
+
+function OverallHealthScore({
+  score,
+  grade,
+}: {
+  score: number;
+  grade: string;
+}) {
+  return (
+    <div className="flex items-center gap-5">
+      <div className="relative flex size-28 items-center justify-center">
+        <svg className="size-28 -rotate-90" viewBox="0 0 100 100">
+          <circle
+            cx="50"
+            cy="50"
+            r="42"
+            fill="none"
+            strokeWidth="8"
+            className="stroke-muted"
+          />
+          <circle
+            cx="50"
+            cy="50"
+            r="42"
+            fill="none"
+            strokeWidth="8"
+            strokeLinecap="round"
+            strokeDasharray={`${score * 2.64} ${264 - score * 2.64}`}
+            className={
+              score >= 90
+                ? "stroke-emerald-500"
+                : score >= 80
+                  ? "stroke-blue-500"
+                  : score >= 70
+                    ? "stroke-amber-500"
+                    : score >= 60
+                      ? "stroke-orange-500"
+                      : "stroke-red-500"
+            }
+          />
+        </svg>
+        <div className="absolute inset-0 flex flex-col items-center justify-center">
+          <span className="text-3xl font-bold tracking-tight">
+            {Math.round(score)}
+          </span>
+          <span className="text-xs text-muted-foreground">/100</span>
+        </div>
+      </div>
+      <div className="space-y-1">
+        <HealthBadge grade={grade} score={score} size="lg" />
+        <p className="text-sm text-muted-foreground mt-1">
+          Average health score across all repositories
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// -- Score-to-grade helper --
+
+function scoreToGrade(score: number): string {
+  if (score >= 90) return "A";
+  if (score >= 80) return "B";
+  if (score >= 70) return "C";
+  if (score >= 60) return "D";
+  return "F";
+}
+
+// -- Main page --
+
+export default function HealthDashboardPage() {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+
+  const { data: dashboard, isLoading } = useQuery({
+    queryKey: ["health-dashboard"],
+    queryFn: qualityGatesApi.getHealthDashboard,
+    enabled: !!user?.is_admin,
+  });
+
+  if (!user?.is_admin) {
+    return (
+      <div className="space-y-6">
+        <PageHeader title="Health Dashboard" />
+        <Alert variant="destructive">
+          <AlertTitle>Access Denied</AlertTitle>
+        </Alert>
+      </div>
+    );
+  }
+
+  const gradeDistribution: Record<string, number> = dashboard
+    ? {
+        A: dashboard.repos_grade_a,
+        B: dashboard.repos_grade_b,
+        C: dashboard.repos_grade_c,
+        D: dashboard.repos_grade_d,
+        F: dashboard.repos_grade_f,
+      }
+    : {};
+
+  const reposBelowThreshold = (dashboard?.repos_grade_d ?? 0) + (dashboard?.repos_grade_f ?? 0);
+  const totalCriticalIssues =
+    dashboard?.repositories?.reduce(
+      (sum, r) => sum + (r.artifacts_failing ?? 0),
+      0
+    ) ?? 0;
+
+  // -- table columns --
+  const columns: DataTableColumn<RepoHealth>[] = [
+    {
+      id: "repository_key",
+      header: "Repository",
+      accessor: (r) => r.repository_key,
+      sortable: true,
+      cell: (r) => (
+        <span className="text-sm font-medium">{r.repository_key}</span>
+      ),
+    },
+    {
+      id: "grade",
+      header: "Grade",
+      accessor: (r) => r.health_score,
+      sortable: true,
+      cell: (r) => (
+        <HealthBadge grade={r.health_grade} score={r.health_score} />
+      ),
+    },
+    {
+      id: "health_score",
+      header: "Score",
+      accessor: (r) => r.health_score,
+      sortable: true,
+      cell: (r) => (
+        <span className="text-sm font-medium tabular-nums">
+          {Math.round(r.health_score)}/100
+        </span>
+      ),
+    },
+    {
+      id: "security",
+      header: "Security",
+      accessor: (r) => r.avg_security_score ?? 0,
+      sortable: true,
+      cell: (r) =>
+        r.avg_security_score != null ? (
+          <span className="text-sm text-muted-foreground tabular-nums">
+            {Math.round(r.avg_security_score)}
+          </span>
+        ) : (
+          <span className="text-sm text-muted-foreground">-</span>
+        ),
+    },
+    {
+      id: "quality",
+      header: "Quality",
+      accessor: (r) => r.avg_quality_score ?? 0,
+      sortable: true,
+      cell: (r) =>
+        r.avg_quality_score != null ? (
+          <span className="text-sm text-muted-foreground tabular-nums">
+            {Math.round(r.avg_quality_score)}
+          </span>
+        ) : (
+          <span className="text-sm text-muted-foreground">-</span>
+        ),
+    },
+    {
+      id: "license",
+      header: "License",
+      accessor: (r) => r.avg_license_score ?? 0,
+      sortable: true,
+      cell: (r) =>
+        r.avg_license_score != null ? (
+          <span className="text-sm text-muted-foreground tabular-nums">
+            {Math.round(r.avg_license_score)}
+          </span>
+        ) : (
+          <span className="text-sm text-muted-foreground">-</span>
+        ),
+    },
+    {
+      id: "metadata",
+      header: "Metadata",
+      accessor: (r) => r.avg_metadata_score ?? 0,
+      sortable: true,
+      cell: (r) =>
+        r.avg_metadata_score != null ? (
+          <span className="text-sm text-muted-foreground tabular-nums">
+            {Math.round(r.avg_metadata_score)}
+          </span>
+        ) : (
+          <span className="text-sm text-muted-foreground">-</span>
+        ),
+    },
+    {
+      id: "artifacts",
+      header: "Artifacts",
+      accessor: (r) => r.artifacts_evaluated,
+      sortable: true,
+      cell: (r) => (
+        <span className="text-sm text-muted-foreground tabular-nums">
+          {r.artifacts_evaluated}
+        </span>
+      ),
+    },
+    {
+      id: "passing",
+      header: "Passing",
+      accessor: (r) => r.artifacts_passing,
+      sortable: true,
+      cell: (r) => (
+        <span className="text-sm tabular-nums">
+          <span className="text-emerald-600 dark:text-emerald-400">
+            {r.artifacts_passing}
+          </span>
+          <span className="text-muted-foreground">
+            /{r.artifacts_evaluated}
+          </span>
+        </span>
+      ),
+    },
+    {
+      id: "failing",
+      header: "Failing",
+      accessor: (r) => r.artifacts_failing,
+      sortable: true,
+      cell: (r) =>
+        r.artifacts_failing > 0 ? (
+          <span className="text-sm font-medium text-red-600 dark:text-red-400 tabular-nums">
+            {r.artifacts_failing}
+          </span>
+        ) : (
+          <span className="text-sm text-muted-foreground">0</span>
+        ),
+    },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Health Dashboard"
+        description="Monitor artifact health scores, quality metrics, and grade distribution across all repositories."
+        actions={
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() =>
+              queryClient.invalidateQueries({ queryKey: ["health-dashboard"] })
+            }
+          >
+            <RefreshCw className="size-4" />
+          </Button>
+        }
+      />
+
+      {/* Loading state */}
+      {isLoading && (
+        <div className="space-y-6">
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Skeleton key={i} className="h-24 rounded-lg" />
+            ))}
+          </div>
+          <Skeleton className="h-48 rounded-lg" />
+          <Skeleton className="h-64 rounded-lg" />
+        </div>
+      )}
+
+      {dashboard && (
+        <>
+          {/* Overall score + stat cards */}
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-[auto_1fr]">
+            <Card>
+              <CardContent className="flex items-center justify-center py-6 px-8">
+                <OverallHealthScore
+                  score={dashboard.avg_health_score}
+                  grade={scoreToGrade(dashboard.avg_health_score)}
+                />
+              </CardContent>
+            </Card>
+
+            <div className="grid grid-cols-2 gap-4 lg:grid-cols-2 xl:grid-cols-3">
+              <StatCard
+                icon={Package}
+                label="Artifacts Evaluated"
+                value={dashboard.total_artifacts_evaluated}
+                color="blue"
+              />
+              <StatCard
+                icon={HeartPulse}
+                label="Repositories"
+                value={dashboard.total_repositories}
+                color="green"
+              />
+              <StatCard
+                icon={ShieldCheck}
+                label="Grade A Repos"
+                value={dashboard.repos_grade_a}
+                color="green"
+              />
+              <StatCard
+                icon={AlertTriangle}
+                label="Below Threshold"
+                value={reposBelowThreshold}
+                description="Grade D or F"
+                color={reposBelowThreshold > 0 ? "red" : "green"}
+              />
+              <StatCard
+                icon={AlertCircle}
+                label="Failing Artifacts"
+                value={totalCriticalIssues}
+                color={totalCriticalIssues > 0 ? "red" : "green"}
+              />
+            </div>
+          </div>
+
+          {/* Grade Distribution */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">
+                Grade Distribution
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <GradeDistributionBar distribution={gradeDistribution} />
+            </CardContent>
+          </Card>
+
+          {/* Repository Health Table */}
+          <div>
+            <h2 className="text-lg font-semibold tracking-tight mb-4">
+              Repository Health Scores
+            </h2>
+            <DataTable
+              columns={columns}
+              data={dashboard.repositories ?? []}
+              loading={false}
+              emptyMessage="No repositories have been evaluated yet. Health scores are computed after artifact scans complete."
+              rowKey={(r) => r.repository_id}
+            />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/repositories/_components/health-tab-content.tsx
+++ b/src/app/(app)/repositories/_components/health-tab-content.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { HeartPulse, ShieldCheck, Scale, Sparkles, FileText } from "lucide-react";
+import qualityGatesApi from "@/lib/api/quality-gates";
+import type { Artifact } from "@/types";
+import { HealthBadge } from "@/components/health-badge";
+
+import { Progress } from "@/components/ui/progress";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface HealthTabContentProps {
+  artifact: Artifact;
+}
+
+const SCORE_COMPONENTS = [
+  {
+    key: "security_score" as const,
+    label: "Security",
+    weight: "40%",
+    icon: ShieldCheck,
+    color: "text-emerald-600 dark:text-emerald-400",
+    progressColor:
+      "[&_[data-slot=progress-indicator]]:bg-emerald-500",
+  },
+  {
+    key: "quality_score" as const,
+    label: "Quality",
+    weight: "25%",
+    icon: Sparkles,
+    color: "text-blue-600 dark:text-blue-400",
+    progressColor:
+      "[&_[data-slot=progress-indicator]]:bg-blue-500",
+  },
+  {
+    key: "license_score" as const,
+    label: "License",
+    weight: "20%",
+    icon: Scale,
+    color: "text-amber-600 dark:text-amber-400",
+    progressColor:
+      "[&_[data-slot=progress-indicator]]:bg-amber-500",
+  },
+  {
+    key: "metadata_score" as const,
+    label: "Metadata",
+    weight: "15%",
+    icon: FileText,
+    color: "text-purple-600 dark:text-purple-400",
+    progressColor:
+      "[&_[data-slot=progress-indicator]]:bg-purple-500",
+  },
+];
+
+export function HealthTabContent({ artifact }: HealthTabContentProps) {
+  const { data: health, isLoading, error } = useQuery({
+    queryKey: ["artifact-health", artifact.id],
+    queryFn: () => qualityGatesApi.getArtifactHealth(artifact.id),
+    retry: false,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-16 w-full" />
+        <Skeleton className="h-12 w-full" />
+        <Skeleton className="h-12 w-full" />
+        <Skeleton className="h-12 w-full" />
+        <Skeleton className="h-12 w-full" />
+      </div>
+    );
+  }
+
+  if (error || !health) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+        <HeartPulse className="size-8 mb-2 opacity-40" />
+        <p className="text-sm font-medium">No health data available</p>
+        <p className="text-xs mt-1">
+          Health scores are computed after quality checks complete.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Overall score header */}
+      <div className="flex items-center gap-4 rounded-lg border p-4">
+        <div className="flex flex-col items-center gap-1">
+          <HealthBadge grade={health.health_grade} score={health.health_score} size="lg" />
+          <span className="text-xs text-muted-foreground">Grade</span>
+        </div>
+        <div className="flex-1 space-y-1">
+          <div className="flex items-baseline justify-between">
+            <span className="text-sm font-medium">Overall Health</span>
+            <span className="text-2xl font-bold tabular-nums">
+              {Math.round(health.health_score)}
+              <span className="text-sm font-normal text-muted-foreground">/100</span>
+            </span>
+          </div>
+          <Progress value={health.health_score} className="h-2.5" />
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>
+              {health.checks_passed}/{health.checks_total} checks passed
+            </span>
+            {health.total_issues > 0 && (
+              <span>
+                {health.total_issues} issue{health.total_issues !== 1 ? "s" : ""}
+                {health.critical_issues > 0 && (
+                  <span className="text-red-600 dark:text-red-400 font-medium ml-1">
+                    ({health.critical_issues} critical)
+                  </span>
+                )}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Score breakdown */}
+      <div className="space-y-4">
+        <h4 className="text-sm font-medium">Score Breakdown</h4>
+        {SCORE_COMPONENTS.map((comp) => {
+          const score = health[comp.key];
+          const value = score != null ? Math.round(score) : null;
+          const Icon = comp.icon;
+          return (
+            <div key={comp.key} className="space-y-1.5">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <Icon className={`size-4 ${comp.color}`} />
+                  <span className="text-sm font-medium">{comp.label}</span>
+                  <span className="text-xs text-muted-foreground">
+                    ({comp.weight} weight)
+                  </span>
+                </div>
+                <span className="text-sm font-semibold tabular-nums">
+                  {value != null ? (
+                    <>
+                      {value}
+                      <span className="text-muted-foreground font-normal">/100</span>
+                    </>
+                  ) : (
+                    <span className="text-muted-foreground font-normal">N/A</span>
+                  )}
+                </span>
+              </div>
+              <Progress
+                value={value ?? 0}
+                className={`h-2 ${comp.progressColor}`}
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Last checked timestamp */}
+      {health.last_checked_at && (
+        <p className="text-xs text-muted-foreground">
+          Last evaluated:{" "}
+          {new Date(health.last_checked_at).toLocaleString()}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/repositories/_components/repo-detail-content.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.tsx
@@ -12,6 +12,7 @@ import {
   Info,
   Shield,
   ExternalLink,
+  HeartPulse,
   Layers,
   Package as PackageIcon,
 } from "lucide-react";
@@ -23,6 +24,7 @@ import type { Artifact } from "@/types";
 import type { UpsertScanConfigRequest } from "@/types/security";
 import { SbomTabContent } from "./sbom-tab-content";
 import { SecurityTabContent } from "./security-tab-content";
+import { HealthTabContent } from "./health-tab-content";
 import { VirtualMembersPanel } from "./virtual-members-panel";
 import { PackagesTabContent } from "./packages-tab-content";
 import { formatBytes, REPO_TYPE_COLORS } from "@/lib/utils";
@@ -700,6 +702,10 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
                   <Shield className="size-3.5 mr-1" />
                   Security
                 </TabsTrigger>
+                <TabsTrigger value="health">
+                  <HeartPulse className="size-3.5 mr-1" />
+                  Health
+                </TabsTrigger>
               </TabsList>
 
               <TabsContent value="details" className="flex-1 overflow-y-auto mt-4">
@@ -757,6 +763,10 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
 
               <TabsContent value="security" className="flex-1 overflow-y-auto mt-4">
                 <SecurityTabContent artifact={selectedArtifact} />
+              </TabsContent>
+
+              <TabsContent value="health" className="flex-1 overflow-y-auto mt-4">
+                <HealthTabContent artifact={selectedArtifact} />
               </TabsContent>
             </Tabs>
           )}

--- a/src/components/health-badge.tsx
+++ b/src/components/health-badge.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { GRADE_COLORS } from "@/types/quality-gates";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+interface HealthBadgeProps {
+  grade: string;
+  score?: number | null;
+  size?: "sm" | "md" | "lg";
+  className?: string;
+}
+
+const sizeClasses = {
+  sm: "px-1.5 py-0.5 text-xs",
+  md: "px-2.5 py-0.5 text-sm",
+  lg: "px-3 py-1 text-base",
+};
+
+export function HealthBadge({
+  grade,
+  score,
+  size = "md",
+  className,
+}: HealthBadgeProps) {
+  const badge = (
+    <span
+      className={cn(
+        "inline-flex items-center justify-center rounded-md font-bold",
+        sizeClasses[size],
+        GRADE_COLORS[grade] ?? "bg-muted text-muted-foreground",
+        className
+      )}
+    >
+      {grade}
+    </span>
+  );
+
+  if (score != null) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>{badge}</TooltipTrigger>
+        <TooltipContent>Score: {Math.round(score)}/100</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return badge;
+}

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -28,6 +28,7 @@ import {
   Recycle,
   Radio,
   Activity,
+  HeartPulse,
   Scale,
   FolderSearch,
 } from "lucide-react";
@@ -82,6 +83,7 @@ const securityItems: NavItem[] = [
 
 const operationsItems: NavItem[] = [
   { title: "Analytics", href: "/analytics", icon: BarChart3 },
+  { title: "Health", href: "/health", icon: HeartPulse },
   { title: "Lifecycle", href: "/lifecycle", icon: Recycle },
   { title: "Monitoring", href: "/monitoring", icon: Activity },
   { title: "Telemetry", href: "/telemetry", icon: Radio },

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -18,6 +18,7 @@ export { default as analyticsApi } from './analytics';
 export { default as lifecycleApi } from './lifecycle';
 export { default as telemetryApi } from './telemetry';
 export { default as monitoringApi } from './monitoring';
+export { default as qualityGatesApi } from './quality-gates';
 
 export type { LoginCredentials } from './auth';
 export type { ListRepositoriesParams } from './repositories';

--- a/src/lib/api/quality-gates.ts
+++ b/src/lib/api/quality-gates.ts
@@ -1,0 +1,73 @@
+import { getActiveInstanceBaseUrl } from '@/lib/sdk-client';
+import type {
+  QualityGate,
+  CreateQualityGateRequest,
+  UpdateQualityGateRequest,
+  ArtifactHealth,
+  RepoHealth,
+  HealthDashboard,
+} from '@/types/quality-gates';
+
+async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const baseUrl = getActiveInstanceBaseUrl();
+  const response = await fetch(`${baseUrl}${path}`, {
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init?.headers ?? {}),
+    },
+    ...init,
+  });
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`API error ${response.status}: ${body}`);
+  }
+  if (response.status === 204) return undefined as T;
+  return response.json() as Promise<T>;
+}
+
+const qualityGatesApi = {
+  // Quality gate CRUD
+  listGates: async (): Promise<QualityGate[]> => {
+    return apiFetch<QualityGate[]>('/api/v1/quality/gates');
+  },
+
+  getGate: async (id: string): Promise<QualityGate> => {
+    return apiFetch<QualityGate>(`/api/v1/quality/gates/${id}`);
+  },
+
+  createGate: async (req: CreateQualityGateRequest): Promise<QualityGate> => {
+    return apiFetch<QualityGate>('/api/v1/quality/gates', {
+      method: 'POST',
+      body: JSON.stringify(req),
+    });
+  },
+
+  updateGate: async (id: string, req: UpdateQualityGateRequest): Promise<QualityGate> => {
+    return apiFetch<QualityGate>(`/api/v1/quality/gates/${id}`, {
+      method: 'PUT',
+      body: JSON.stringify(req),
+    });
+  },
+
+  deleteGate: async (id: string): Promise<void> => {
+    return apiFetch<void>(`/api/v1/quality/gates/${id}`, {
+      method: 'DELETE',
+    });
+  },
+
+  // Health endpoints
+  getArtifactHealth: async (artifactId: string): Promise<ArtifactHealth> => {
+    return apiFetch<ArtifactHealth>(`/api/v1/quality/health/artifacts/${artifactId}`);
+  },
+
+  getRepoHealth: async (repoKey: string): Promise<RepoHealth> => {
+    return apiFetch<RepoHealth>(`/api/v1/quality/health/repositories/${repoKey}`);
+  },
+
+  getHealthDashboard: async (): Promise<HealthDashboard> => {
+    return apiFetch<HealthDashboard>('/api/v1/quality/health/dashboard');
+  },
+};
+
+export default qualityGatesApi;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,7 @@ export * from './telemetry';
 export * from './monitoring';
 export * from './sbom';
 export * from './promotion';
+export * from './quality-gates';
 
 export type {
   PeerInstance,

--- a/src/types/quality-gates.ts
+++ b/src/types/quality-gates.ts
@@ -1,0 +1,130 @@
+// Quality gate and health score types
+
+export interface QualityGate {
+  id: string;
+  repository_id?: string | null;
+  name: string;
+  description?: string | null;
+  min_health_score?: number | null;
+  min_security_score?: number | null;
+  min_quality_score?: number | null;
+  min_metadata_score?: number | null;
+  max_critical_issues?: number | null;
+  max_high_issues?: number | null;
+  max_medium_issues?: number | null;
+  required_checks: string[];
+  enforce_on_promotion: boolean;
+  enforce_on_download: boolean;
+  action: string; // 'allow' | 'warn' | 'block'
+  is_enabled: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateQualityGateRequest {
+  repository_id?: string | null;
+  name: string;
+  description?: string | null;
+  min_health_score?: number | null;
+  min_security_score?: number | null;
+  min_quality_score?: number | null;
+  min_metadata_score?: number | null;
+  max_critical_issues?: number | null;
+  max_high_issues?: number | null;
+  max_medium_issues?: number | null;
+  required_checks?: string[];
+  enforce_on_promotion?: boolean;
+  enforce_on_download?: boolean;
+  action?: string;
+}
+
+export interface UpdateQualityGateRequest {
+  name?: string;
+  description?: string | null;
+  min_health_score?: number | null;
+  min_security_score?: number | null;
+  min_quality_score?: number | null;
+  min_metadata_score?: number | null;
+  max_critical_issues?: number | null;
+  max_high_issues?: number | null;
+  max_medium_issues?: number | null;
+  required_checks?: string[];
+  enforce_on_promotion?: boolean;
+  enforce_on_download?: boolean;
+  action?: string;
+  is_enabled?: boolean;
+}
+
+export interface ArtifactHealth {
+  artifact_id: string;
+  health_score: number;
+  health_grade: string;
+  security_score?: number | null;
+  license_score?: number | null;
+  quality_score?: number | null;
+  metadata_score?: number | null;
+  total_issues: number;
+  critical_issues: number;
+  checks_passed: number;
+  checks_total: number;
+  last_checked_at?: string | null;
+}
+
+export interface RepoHealth {
+  repository_id: string;
+  repository_key: string;
+  health_score: number;
+  health_grade: string;
+  avg_security_score?: number | null;
+  avg_license_score?: number | null;
+  avg_quality_score?: number | null;
+  avg_metadata_score?: number | null;
+  artifacts_evaluated: number;
+  artifacts_passing: number;
+  artifacts_failing: number;
+  last_evaluated_at?: string | null;
+}
+
+export interface HealthDashboard {
+  total_repositories: number;
+  total_artifacts_evaluated: number;
+  avg_health_score: number;
+  repos_grade_a: number;
+  repos_grade_b: number;
+  repos_grade_c: number;
+  repos_grade_d: number;
+  repos_grade_f: number;
+  repositories: RepoHealth[];
+}
+
+// Action badge colors
+export const ACTION_COLORS: Record<string, string> = {
+  allow:
+    "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400 border-emerald-200 dark:border-emerald-800",
+  warn:
+    "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400 border-amber-200 dark:border-amber-800",
+  block:
+    "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 border-red-200 dark:border-red-800",
+};
+
+export const GRADE_COLORS: Record<string, string> = {
+  A: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400",
+  B: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
+  C: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
+  D: "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400",
+  F: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+};
+
+export const CHECK_TYPES = [
+  "security",
+  "license",
+  "quality",
+  "metadata",
+] as const;
+
+export const CHECK_TYPE_LABELS: Record<string, string> = {
+  security: "Security",
+  license: "License",
+  quality: "Quality",
+  metadata: "Metadata",
+};


### PR DESCRIPTION
## Summary
- Add a new **Health Dashboard** page (`/health`) under the Operations admin section showing overall health score with a radial gauge, grade distribution bar chart, key metrics stat cards, and a sortable repository health table
- Create a reusable **HealthBadge** component that displays letter grades (A-F) with color coding and optional score tooltip
- Add a **Health tab** to the artifact detail dialog with score breakdown progress bars for security (40% weight), quality (25%), license (20%), and metadata (15%)
- Create quality-gates types and API wrapper with `getHealthDashboard()`, `getArtifactHealth()`, and `getRepoHealth()` endpoints
- Add "Health" navigation link to the sidebar under the Operations section

## Test plan
- [ ] Navigate to `/health` as an admin user and verify the dashboard loads with overall score, grade distribution, stat cards, and repository table
- [ ] Verify non-admin users see an "Access Denied" message on the health page
- [ ] Open any artifact detail dialog from a repository page and verify the "Health" tab is present
- [ ] Click the Health tab and verify the score breakdown displays with progress bars or shows a graceful empty state
- [ ] Verify the HealthBadge tooltip shows the numeric score when hovering
- [ ] Verify the sidebar shows "Health" under Operations for admin users
- [ ] Verify dark mode styling works correctly across all new components
- [ ] Run `npm run lint` and `npm run build` with no new errors