### PR TITLE
chore: simplify and consolidate frontend code

### DIFF
--- a/src/app/(app)/(admin)/approvals/page.tsx
+++ b/src/app/(app)/(admin)/approvals/page.tsx
@@ -152,14 +152,18 @@ export default function ApprovalsPage() {
 
   // -- mutations --
 
+  function resetActionDialog() {
+    setActionDialog(null);
+    setActionNotes("");
+  }
+
   const approveMutation = useMutation({
     mutationFn: ({ id, notes }: { id: string; notes?: string }) =>
       approvalsApi.approve(id, notes),
     onSuccess: () => {
       toast.success("Approval request approved");
       queryClient.invalidateQueries({ queryKey: ["approvals"] });
-      setActionDialog(null);
-      setActionNotes("");
+      resetActionDialog();
     },
     onError: () => toast.error("Failed to approve request"),
   });
@@ -170,8 +174,7 @@ export default function ApprovalsPage() {
     onSuccess: () => {
       toast.success("Approval request rejected");
       queryClient.invalidateQueries({ queryKey: ["approvals"] });
-      setActionDialog(null);
-      setActionNotes("");
+      resetActionDialog();
     },
     onError: () => toast.error("Failed to reject request"),
   });
@@ -204,31 +207,37 @@ export default function ApprovalsPage() {
     );
   }
 
+  // -- shared column definitions --
+
+  const artifactColumn: DataTableColumn<ApprovalRequest> = {
+    id: "artifact",
+    header: "Artifact",
+    accessor: (r) => r.artifact_id,
+    cell: (r) => (
+      <span className="text-sm font-medium font-mono truncate max-w-[200px] block">
+        {r.artifact_id}
+      </span>
+    ),
+  };
+
+  const promotionPathColumn: DataTableColumn<ApprovalRequest> = {
+    id: "promotion_path",
+    header: "Promotion Path",
+    accessor: (r) => r.source_repository,
+    cell: (r) => (
+      <div className="flex items-center gap-1.5 text-sm">
+        <span className="font-medium">{r.source_repository}</span>
+        <ArrowRight className="size-3.5 text-muted-foreground shrink-0" />
+        <span className="font-medium">{r.target_repository}</span>
+      </div>
+    ),
+  };
+
   // -- pending table columns --
 
   const pendingColumns: DataTableColumn<ApprovalRequest>[] = [
-    {
-      id: "artifact",
-      header: "Artifact",
-      accessor: (r) => r.artifact_id,
-      cell: (r) => (
-        <span className="text-sm font-medium font-mono truncate max-w-[200px] block">
-          {r.artifact_id}
-        </span>
-      ),
-    },
-    {
-      id: "promotion_path",
-      header: "Promotion Path",
-      accessor: (r) => r.source_repository,
-      cell: (r) => (
-        <div className="flex items-center gap-1.5 text-sm">
-          <span className="font-medium">{r.source_repository}</span>
-          <ArrowRight className="size-3.5 text-muted-foreground shrink-0" />
-          <span className="font-medium">{r.target_repository}</span>
-        </div>
-      ),
-    },
+    artifactColumn,
+    promotionPathColumn,
     {
       id: "requested_by",
       header: "Requested By",
@@ -291,28 +300,8 @@ export default function ApprovalsPage() {
   // -- history table columns --
 
   const historyColumns: DataTableColumn<ApprovalRequest>[] = [
-    {
-      id: "artifact",
-      header: "Artifact",
-      accessor: (r) => r.artifact_id,
-      cell: (r) => (
-        <span className="text-sm font-medium font-mono truncate max-w-[200px] block">
-          {r.artifact_id}
-        </span>
-      ),
-    },
-    {
-      id: "promotion_path",
-      header: "Promotion Path",
-      accessor: (r) => r.source_repository,
-      cell: (r) => (
-        <div className="flex items-center gap-1.5 text-sm">
-          <span className="font-medium">{r.source_repository}</span>
-          <ArrowRight className="size-3.5 text-muted-foreground shrink-0" />
-          <span className="font-medium">{r.target_repository}</span>
-        </div>
-      ),
-    },
+    artifactColumn,
+    promotionPathColumn,
     {
       id: "status",
       header: "Status",
@@ -513,10 +502,7 @@ export default function ApprovalsPage() {
       <Dialog
         open={!!actionDialog}
         onOpenChange={(open) => {
-          if (!open) {
-            setActionDialog(null);
-            setActionNotes("");
-          }
+          if (!open) resetActionDialog();
         }}
       >
         <DialogContent>
@@ -580,10 +566,7 @@ export default function ApprovalsPage() {
           <DialogFooter>
             <Button
               variant="outline"
-              onClick={() => {
-                setActionDialog(null);
-                setActionNotes("");
-              }}
+              onClick={resetActionDialog}
               disabled={isActioning}
             >
               Cancel

--- a/src/app/(app)/(admin)/health/page.tsx
+++ b/src/app/(app)/(admin)/health/page.tsx
@@ -131,17 +131,7 @@ function OverallHealthScore({
             strokeWidth="8"
             strokeLinecap="round"
             strokeDasharray={`${score * 2.64} ${264 - score * 2.64}`}
-            className={
-              score >= 90
-                ? "stroke-emerald-500"
-                : score >= 80
-                  ? "stroke-blue-500"
-                  : score >= 70
-                    ? "stroke-amber-500"
-                    : score >= 60
-                      ? "stroke-orange-500"
-                      : "stroke-red-500"
-            }
+            className={scoreToStrokeClass(score)}
           />
         </svg>
         <div className="absolute inset-0 flex flex-col items-center justify-center">
@@ -161,7 +151,7 @@ function OverallHealthScore({
   );
 }
 
-// -- Score-to-grade helper --
+// -- Score helpers --
 
 function scoreToGrade(score: number): string {
   if (score >= 90) return "A";
@@ -169,6 +159,14 @@ function scoreToGrade(score: number): string {
   if (score >= 70) return "C";
   if (score >= 60) return "D";
   return "F";
+}
+
+function scoreToStrokeClass(score: number): string {
+  if (score >= 90) return "stroke-emerald-500";
+  if (score >= 80) return "stroke-blue-500";
+  if (score >= 70) return "stroke-amber-500";
+  if (score >= 60) return "stroke-orange-500";
+  return "stroke-red-500";
 }
 
 // -- Main page --
@@ -211,6 +209,17 @@ export default function HealthDashboardPage() {
       0
     ) ?? 0;
 
+  function OptionalScore({ value }: { value: number | null | undefined }) {
+    if (value != null) {
+      return (
+        <span className="text-sm text-muted-foreground tabular-nums">
+          {Math.round(value)}
+        </span>
+      );
+    }
+    return <span className="text-sm text-muted-foreground">-</span>;
+  }
+
   // -- table columns --
   const columns: DataTableColumn<RepoHealth>[] = [
     {
@@ -247,56 +256,28 @@ export default function HealthDashboardPage() {
       header: "Security",
       accessor: (r) => r.avg_security_score ?? 0,
       sortable: true,
-      cell: (r) =>
-        r.avg_security_score != null ? (
-          <span className="text-sm text-muted-foreground tabular-nums">
-            {Math.round(r.avg_security_score)}
-          </span>
-        ) : (
-          <span className="text-sm text-muted-foreground">-</span>
-        ),
+      cell: (r) => <OptionalScore value={r.avg_security_score} />,
     },
     {
       id: "quality",
       header: "Quality",
       accessor: (r) => r.avg_quality_score ?? 0,
       sortable: true,
-      cell: (r) =>
-        r.avg_quality_score != null ? (
-          <span className="text-sm text-muted-foreground tabular-nums">
-            {Math.round(r.avg_quality_score)}
-          </span>
-        ) : (
-          <span className="text-sm text-muted-foreground">-</span>
-        ),
+      cell: (r) => <OptionalScore value={r.avg_quality_score} />,
     },
     {
       id: "license",
       header: "License",
       accessor: (r) => r.avg_license_score ?? 0,
       sortable: true,
-      cell: (r) =>
-        r.avg_license_score != null ? (
-          <span className="text-sm text-muted-foreground tabular-nums">
-            {Math.round(r.avg_license_score)}
-          </span>
-        ) : (
-          <span className="text-sm text-muted-foreground">-</span>
-        ),
+      cell: (r) => <OptionalScore value={r.avg_license_score} />,
     },
     {
       id: "metadata",
       header: "Metadata",
       accessor: (r) => r.avg_metadata_score ?? 0,
       sortable: true,
-      cell: (r) =>
-        r.avg_metadata_score != null ? (
-          <span className="text-sm text-muted-foreground tabular-nums">
-            {Math.round(r.avg_metadata_score)}
-          </span>
-        ) : (
-          <span className="text-sm text-muted-foreground">-</span>
-        ),
+      cell: (r) => <OptionalScore value={r.avg_metadata_score} />,
     },
     {
       id: "artifacts",

--- a/src/app/(app)/(admin)/quality-gates/page.tsx
+++ b/src/app/(app)/(admin)/quality-gates/page.tsx
@@ -102,17 +102,27 @@ const emptyForm: GateFormState = {
   action: "warn",
 };
 
+/** Convert a nullable number to a form string ("" when null). */
+function numToStr(value: number | null | undefined): string {
+  return value != null ? String(value) : "";
+}
+
+/** Convert a form string to a number, returning the fallback when empty. */
+function strToNum<T>(value: string, fallback: T): number | T {
+  return value ? Number(value) : fallback;
+}
+
 function gateToForm(gate: QualityGate): GateFormState {
   return {
     name: gate.name,
     description: gate.description ?? "",
-    min_health_score: gate.min_health_score != null ? String(gate.min_health_score) : "",
-    min_security_score: gate.min_security_score != null ? String(gate.min_security_score) : "",
-    min_quality_score: gate.min_quality_score != null ? String(gate.min_quality_score) : "",
-    min_metadata_score: gate.min_metadata_score != null ? String(gate.min_metadata_score) : "",
-    max_critical_issues: gate.max_critical_issues != null ? String(gate.max_critical_issues) : "",
-    max_high_issues: gate.max_high_issues != null ? String(gate.max_high_issues) : "",
-    max_medium_issues: gate.max_medium_issues != null ? String(gate.max_medium_issues) : "",
+    min_health_score: numToStr(gate.min_health_score),
+    min_security_score: numToStr(gate.min_security_score),
+    min_quality_score: numToStr(gate.min_quality_score),
+    min_metadata_score: numToStr(gate.min_metadata_score),
+    max_critical_issues: numToStr(gate.max_critical_issues),
+    max_high_issues: numToStr(gate.max_high_issues),
+    max_medium_issues: numToStr(gate.max_medium_issues),
     required_checks: gate.required_checks ?? [],
     enforce_on_promotion: gate.enforce_on_promotion,
     enforce_on_download: gate.enforce_on_download,
@@ -124,13 +134,13 @@ function formToCreateRequest(form: GateFormState): CreateQualityGateRequest {
   return {
     name: form.name,
     description: form.description || undefined,
-    min_health_score: form.min_health_score ? Number(form.min_health_score) : undefined,
-    min_security_score: form.min_security_score ? Number(form.min_security_score) : undefined,
-    min_quality_score: form.min_quality_score ? Number(form.min_quality_score) : undefined,
-    min_metadata_score: form.min_metadata_score ? Number(form.min_metadata_score) : undefined,
-    max_critical_issues: form.max_critical_issues ? Number(form.max_critical_issues) : undefined,
-    max_high_issues: form.max_high_issues ? Number(form.max_high_issues) : undefined,
-    max_medium_issues: form.max_medium_issues ? Number(form.max_medium_issues) : undefined,
+    min_health_score: strToNum(form.min_health_score, undefined),
+    min_security_score: strToNum(form.min_security_score, undefined),
+    min_quality_score: strToNum(form.min_quality_score, undefined),
+    min_metadata_score: strToNum(form.min_metadata_score, undefined),
+    max_critical_issues: strToNum(form.max_critical_issues, undefined),
+    max_high_issues: strToNum(form.max_high_issues, undefined),
+    max_medium_issues: strToNum(form.max_medium_issues, undefined),
     required_checks: form.required_checks.length > 0 ? form.required_checks : undefined,
     enforce_on_promotion: form.enforce_on_promotion,
     enforce_on_download: form.enforce_on_download,
@@ -142,13 +152,13 @@ function formToUpdateRequest(form: GateFormState): UpdateQualityGateRequest {
   return {
     name: form.name,
     description: form.description || undefined,
-    min_health_score: form.min_health_score ? Number(form.min_health_score) : null,
-    min_security_score: form.min_security_score ? Number(form.min_security_score) : null,
-    min_quality_score: form.min_quality_score ? Number(form.min_quality_score) : null,
-    min_metadata_score: form.min_metadata_score ? Number(form.min_metadata_score) : null,
-    max_critical_issues: form.max_critical_issues ? Number(form.max_critical_issues) : null,
-    max_high_issues: form.max_high_issues ? Number(form.max_high_issues) : null,
-    max_medium_issues: form.max_medium_issues ? Number(form.max_medium_issues) : null,
+    min_health_score: strToNum(form.min_health_score, null),
+    min_security_score: strToNum(form.min_security_score, null),
+    min_quality_score: strToNum(form.min_quality_score, null),
+    min_metadata_score: strToNum(form.min_metadata_score, null),
+    max_critical_issues: strToNum(form.max_critical_issues, null),
+    max_high_issues: strToNum(form.max_high_issues, null),
+    max_medium_issues: strToNum(form.max_medium_issues, null),
     required_checks: form.required_checks,
     enforce_on_promotion: form.enforce_on_promotion,
     enforce_on_download: form.enforce_on_download,

--- a/src/app/(app)/staging/_components/artifact-list-preview.tsx
+++ b/src/app/(app)/staging/_components/artifact-list-preview.tsx
@@ -1,0 +1,53 @@
+import type { StagingArtifact } from "@/types/promotion";
+import { formatBytes } from "@/lib/utils";
+
+import { Badge } from "@/components/ui/badge";
+import { Label } from "@/components/ui/label";
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+interface ArtifactListPreviewProps {
+  artifacts: StagingArtifact[];
+  height?: string;
+  /** Optional content rendered on the right side of each artifact row. */
+  renderTrailing?: (artifact: StagingArtifact) => React.ReactNode;
+}
+
+export function ArtifactListPreview({
+  artifacts,
+  height = "h-32",
+  renderTrailing,
+}: ArtifactListPreviewProps) {
+  return (
+    <div className="space-y-2">
+      <Label>Selected Artifacts</Label>
+      <ScrollArea className={`${height} rounded-md border`}>
+        <div className="p-2 space-y-1">
+          {artifacts.map((artifact) => (
+            <div
+              key={artifact.id}
+              className="flex items-center justify-between text-sm py-1"
+            >
+              <div className="flex items-center gap-2 min-w-0 flex-1">
+                <span className="truncate font-medium">{artifact.name}</span>
+                {artifact.version && (
+                  <Badge
+                    variant="outline"
+                    className="text-[10px] font-normal shrink-0"
+                  >
+                    {artifact.version}
+                  </Badge>
+                )}
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                <span className="text-xs text-muted-foreground">
+                  {formatBytes(artifact.size_bytes)}
+                </span>
+                {renderTrailing?.(artifact)}
+              </div>
+            </div>
+          ))}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}

--- a/src/app/(app)/staging/_components/promotion-dialog.tsx
+++ b/src/app/(app)/staging/_components/promotion-dialog.tsx
@@ -9,7 +9,6 @@ import { promotionApi } from "@/lib/api/promotion";
 import type { StagingArtifact, BulkPromoteRequest, PolicyViolation } from "@/types/promotion";
 import type { Repository } from "@/types";
 import { useAuth } from "@/providers/auth-provider";
-import { formatBytes } from "@/lib/utils";
 
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
@@ -33,6 +32,8 @@ import {
   SelectItem,
 } from "@/components/ui/select";
 import { SEVERITY_COLORS } from "@/types/promotion";
+
+import { ArtifactListPreview } from "./artifact-list-preview";
 
 interface PromotionDialogProps {
   open: boolean;
@@ -161,42 +162,17 @@ export function PromotionDialog({
           </div>
 
           {/* Selected Artifacts Summary */}
-          <div className="space-y-2">
-            <Label>Selected Artifacts</Label>
-            <ScrollArea className="h-32 rounded-md border">
-              <div className="p-2 space-y-1">
-                {selectedArtifacts.map((artifact) => (
-                  <div
-                    key={artifact.id}
-                    className="flex items-center justify-between text-sm py-1"
-                  >
-                    <div className="flex items-center gap-2 min-w-0 flex-1">
-                      <span className="truncate font-medium">{artifact.name}</span>
-                      {artifact.version && (
-                        <Badge variant="outline" className="text-[10px] font-normal shrink-0">
-                          {artifact.version}
-                        </Badge>
-                      )}
-                    </div>
-                    <div className="flex items-center gap-2 shrink-0">
-                      <span className="text-xs text-muted-foreground">
-                        {formatBytes(artifact.size_bytes)}
-                      </span>
-                      {artifact.policy_status === "passing" && (
-                        <CheckCircle className="size-3.5 text-green-500" />
-                      )}
-                      {artifact.policy_status === "failing" && (
-                        <XCircle className="size-3.5 text-red-500" />
-                      )}
-                      {artifact.policy_status === "warning" && (
-                        <AlertTriangle className="size-3.5 text-yellow-500" />
-                      )}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </ScrollArea>
-          </div>
+          <ArtifactListPreview
+            artifacts={selectedArtifacts}
+            renderTrailing={(artifact) => {
+              const icons: Record<string, React.ReactNode> = {
+                passing: <CheckCircle className="size-3.5 text-green-500" />,
+                failing: <XCircle className="size-3.5 text-red-500" />,
+                warning: <AlertTriangle className="size-3.5 text-yellow-500" />,
+              };
+              return artifact.policy_status ? icons[artifact.policy_status] : null;
+            }}
+          />
 
           {/* Policy Violations Warning */}
           {allViolations.length > 0 && (

--- a/src/app/(app)/staging/_components/promotion-history.tsx
+++ b/src/app/(app)/staging/_components/promotion-history.tsx
@@ -192,9 +192,7 @@ function PromotionHistoryItem({ entry }: { entry: PromotionHistoryEntry }) {
   const [expanded, setExpanded] = useState(false);
   const hasViolations = (entry.policy_result?.violations?.length ?? 0) > 0;
 
-  // Determine status, falling back based on policy result for backward compatibility
-  const status: PromotionHistoryStatus =
-    entry.status ?? (entry.policy_result?.passed !== false ? "promoted" : "promoted");
+  const status: PromotionHistoryStatus = entry.status ?? "promoted";
 
   const statusMeta = STATUS_ICON[status] ?? STATUS_ICON.promoted;
   const StatusIcon = statusMeta.icon;

--- a/src/app/(app)/staging/_components/rejection-dialog.tsx
+++ b/src/app/(app)/staging/_components/rejection-dialog.tsx
@@ -7,13 +7,10 @@ import { toast } from "sonner";
 
 import { promotionApi } from "@/lib/api/promotion";
 import type { StagingArtifact } from "@/types/promotion";
-import { formatBytes } from "@/lib/utils";
 
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { Badge } from "@/components/ui/badge";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Dialog,
   DialogContent,
@@ -22,6 +19,8 @@ import {
   DialogDescription,
   DialogFooter,
 } from "@/components/ui/dialog";
+
+import { ArtifactListPreview } from "./artifact-list-preview";
 
 interface RejectionDialogProps {
   open: boolean;
@@ -102,37 +101,7 @@ export function RejectionDialog({
         </DialogHeader>
 
         <div className="space-y-4">
-          {/* Selected Artifacts Summary */}
-          <div className="space-y-2">
-            <Label>Selected Artifacts</Label>
-            <ScrollArea className="h-32 rounded-md border">
-              <div className="p-2 space-y-1">
-                {selectedArtifacts.map((artifact) => (
-                  <div
-                    key={artifact.id}
-                    className="flex items-center justify-between text-sm py-1"
-                  >
-                    <div className="flex items-center gap-2 min-w-0 flex-1">
-                      <span className="truncate font-medium">
-                        {artifact.name}
-                      </span>
-                      {artifact.version && (
-                        <Badge
-                          variant="outline"
-                          className="text-[10px] font-normal shrink-0"
-                        >
-                          {artifact.version}
-                        </Badge>
-                      )}
-                    </div>
-                    <span className="text-xs text-muted-foreground shrink-0">
-                      {formatBytes(artifact.size_bytes)}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </ScrollArea>
-          </div>
+          <ArtifactListPreview artifacts={selectedArtifacts} />
 
           {/* Reason (required) */}
           <div className="space-y-2">

--- a/src/lib/api/approvals.ts
+++ b/src/lib/api/approvals.ts
@@ -1,23 +1,5 @@
-import { getActiveInstanceBaseUrl } from '@/lib/sdk-client';
+import { apiFetch } from '@/lib/api/fetch';
 import type { ApprovalRequest, ApprovalListResponse } from '@/types/promotion';
-
-async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
-  const baseUrl = getActiveInstanceBaseUrl();
-  const response = await fetch(`${baseUrl}${path}`, {
-    credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(init?.headers ?? {}),
-    },
-    ...init,
-  });
-  if (!response.ok) {
-    const body = await response.text().catch(() => '');
-    throw new Error(`API error ${response.status}: ${body}`);
-  }
-  if (response.status === 204) return undefined as T;
-  return response.json() as Promise<T>;
-}
 
 const approvalsApi = {
   /**

--- a/src/lib/api/fetch.ts
+++ b/src/lib/api/fetch.ts
@@ -1,0 +1,23 @@
+import { getActiveInstanceBaseUrl } from '@/lib/sdk-client';
+
+/**
+ * Shared fetch wrapper for API modules that don't use the generated SDK.
+ * Adds base URL resolution, JSON headers, credentials, and error handling.
+ */
+export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const baseUrl = getActiveInstanceBaseUrl();
+  const response = await fetch(`${baseUrl}${path}`, {
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init?.headers ?? {}),
+    },
+    ...init,
+  });
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`API error ${response.status}: ${body}`);
+  }
+  if (response.status === 204) return undefined as T;
+  return response.json() as Promise<T>;
+}

--- a/src/lib/api/quality-gates.ts
+++ b/src/lib/api/quality-gates.ts
@@ -1,4 +1,4 @@
-import { getActiveInstanceBaseUrl } from '@/lib/sdk-client';
+import { apiFetch } from '@/lib/api/fetch';
 import type {
   QualityGate,
   CreateQualityGateRequest,
@@ -7,24 +7,6 @@ import type {
   RepoHealth,
   HealthDashboard,
 } from '@/types/quality-gates';
-
-async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
-  const baseUrl = getActiveInstanceBaseUrl();
-  const response = await fetch(`${baseUrl}${path}`, {
-    credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(init?.headers ?? {}),
-    },
-    ...init,
-  });
-  if (!response.ok) {
-    const body = await response.text().catch(() => '');
-    throw new Error(`API error ${response.status}: ${body}`);
-  }
-  if (response.status === 204) return undefined as T;
-  return response.json() as Promise<T>;
-}
 
 const qualityGatesApi = {
   // Quality gate CRUD


### PR DESCRIPTION
## Summary

- Extract shared `apiFetch` into `lib/api/fetch.ts` (was duplicated in approvals + quality-gates API clients)
- Extract `ArtifactListPreview` component (was duplicated in promotion + rejection dialogs)
- Extract `scoreToStrokeClass` and `OptionalScore` helpers in health dashboard
- Consolidate duplicate column definitions (`artifactColumn`, `promotionPathColumn`) in approvals page
- Add `numToStr`/`strToNum` helpers for quality-gates form conversion boilerplate
- Extract `repoMetaBadges` JSX fragment in staging detail (was duplicated for standalone/inline modes)
- Replace duplicated `Set` toggle logic with shared `toggleSetItem` helper
- Fix dead-code ternary in promotion-history status fallback
- Import shared `POLICY_STATUS_LABELS` instead of inline duplicate in artifact row

**Net: -71 lines** across 11 files. No behavior changes.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `npm run build` passes (all pages compile)
- [x] No new lint warnings introduced
- [ ] Verify health dashboard, quality gates, approvals, and staging pages render correctly