### PR TITLE
Add STIG hardening and update base images to latest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "artifact-keeper/maintainers"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "artifact-keeper/maintainers"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "artifact-keeper/maintainers"
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
## Summary
- Update all base images from pinned `ubi9:9.5` to `ubi9:latest` / `ubi-micro:latest`
- Apply DISA STIG hardening controls to container rootfs (same controls as backend/openscap containers)

## STIG controls applied
| Control | XCCDF Rule | Effect |
|---------|-----------|--------|
| FIPS OpenSSL | `configure_crypto_policy` | `fips=yes` in openssl.cnf |
| Core dump disable | `disable_users_coredumps` | `* hard core 0` |
| Max logins | `accounts_max_concurrent_login_sessions` | `* hard maxlogins 10` |
| No empty passwords | `no_empty_passwords` | Strip `nullok` from PAM |
| Restrictive umask | `accounts_umask_etc_login_defs` | UMASK 077 |
| Machine-id cleanup | — | Read-only, regenerated at runtime |
| GPG package check | `ensure_gpgcheck_local_packages` | `localpkg_gpgcheck=1` |

## Test plan
- [ ] `docker build -t ak-web-test .` builds successfully
- [ ] Container starts and serves on port 3000
- [ ] Verify STIG controls applied: `docker run --rm ak-web-test cat /etc/security/limits.d/50-coredump.conf`