### PR TITLE
Add :dev Docker tag for ArgoCD Image Updater

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=latest
+            type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=
 
       - name: Create manifest list and push


### PR DESCRIPTION
## Summary
- ArgoCD Image Updater watches the `:dev` tag to auto-deploy main branch pushes
- The web CI was only pushing `:latest` and `:sha` tags, so the Image Updater never picked up new images
- Align with the backend workflow tag strategy: `:dev` for main pushes, `:latest` only for stable releases

## Test plan
- [ ] CI pushes `:dev` tag on main branch push
- [ ] ArgoCD Image Updater detects new digest and rolls out