### PR TITLE
chore: bump version to 1.1.0-rc.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artifact-keeper-web",
-  "version": "1.1.0-rc.1",
+  "version": "1.1.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artifact-keeper-web",
-      "version": "1.1.0-rc.1",
+      "version": "1.1.0-rc.2",
       "hasInstallScript": true,
       "dependencies": {
         "@artifact-keeper/sdk": "^1.1.0-dev.2",
@@ -5684,6 +5684,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-keeper-web",
-  "version": "1.1.0-rc.1",
+  "version": "1.1.0-rc.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Bumps version from `1.1.0-rc.1` to `1.1.0-rc.2`

## Changes since v1.1.0-rc.1
- UBI 9 Micro container migration with STIG hardening
- Package browser: files, dependencies, metadata tabs
- Approval queue and rejection workflow UI
- Quality gates admin dashboard
- Health score dashboard
- Health page route fix (renamed to /system-health to avoid backend proxy conflict)
- E2E test resilience improvements
- ArgoCD :dev Docker tag for Image Updater
- Dependabot: GHA + npm dependency bumps