### PR TITLE
fix: correct settings page URL in E2E test

### DIFF
--- a/e2e/api-integration.spec.ts
+++ b/e2e/api-integration.spec.ts
@@ -71,7 +71,7 @@ test.describe('API Integration', () => {
       }
     });
 
-    const pages = ['/', '/repositories', '/profile', '/admin/settings'];
+    const pages = ['/', '/repositories', '/profile', '/settings'];
     for (const url of pages) {
       await page.goto(url);
       await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});


### PR DESCRIPTION
## Summary
- Fix `/admin/settings` → `/settings` in E2E page navigation test
- Next.js App Router route groups `(admin)` don't appear in URLs

## Test plan
- [ ] Run `npm run test:e2e` — settings page test should pass (200 instead of 404)