### PR TITLE
chore: bump to 1.1.0-rc.2 with SDK update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "artifact-keeper-web",
-  "version": "1.1.0-rc.1",
+  "version": "1.1.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artifact-keeper-web",
-      "version": "1.1.0-rc.1",
+      "version": "1.1.0-rc.2",
       "hasInstallScript": true,
       "dependencies": {
-        "@artifact-keeper/sdk": "^1.1.0-dev.2",
+        "@artifact-keeper/sdk": "^1.1.0-rc.2",
         "@hookform/resolvers": "^5.2.2",
         "@tanstack/react-query": "^5.90.21",
         "class-variance-authority": "^0.7.1",
@@ -56,9 +56,9 @@
       }
     },
     "node_modules/@artifact-keeper/sdk": {
-      "version": "1.1.0-dev.2",
-      "resolved": "https://registry.npmjs.org/@artifact-keeper/sdk/-/sdk-1.1.0-dev.2.tgz",
-      "integrity": "sha512-34VFMdJV4l22ZiCMK4LdkXCjzQYmymzksbSxFmlgnjCOR8sD9qHs807bdN2wpOrd78YvZv1jYHpHcrpgVe1e9g==",
+      "version": "1.1.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@artifact-keeper/sdk/-/sdk-1.1.0-rc.2.tgz",
+      "integrity": "sha512-VlN7TO3MjmGBERLy9yRDhzH5+WMjuF2MrszLUXOWENtaRbIMkxkuOxTeJKCmNz4L3VTi7e5m9kn9LEKJlm3GoA==",
       "license": "MIT",
       "dependencies": {
         "@hey-api/client-fetch": "^0.13.0"
@@ -5684,6 +5684,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-keeper-web",
-  "version": "1.1.0-rc.1",
+  "version": "1.1.0-rc.2",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -13,7 +13,7 @@
     "postinstall": "node scripts/patch-sdk.js"
   },
   "dependencies": {
-    "@artifact-keeper/sdk": "^1.1.0-dev.2",
+    "@artifact-keeper/sdk": "^1.1.0-rc.2",
     "@hookform/resolvers": "^5.2.2",
     "@tanstack/react-query": "^5.90.21",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
## Summary
- Bump version from 1.1.0-rc.1 to 1.1.0-rc.2
- Update `@artifact-keeper/sdk` from `^1.1.0-dev.2` to `^1.1.0-rc.2`