### PR TITLE
feat: add Incus/LXC format to web UI

### DIFF
--- a/src/app/(app)/repositories/_lib/constants.ts
+++ b/src/app/(app)/repositories/_lib/constants.ts
@@ -25,6 +25,8 @@ export const FORMAT_OPTIONS: { value: RepositoryFormat; label: string; group: st
   { value: "oras", label: "ORAS", group: "Container" },
   { value: "wasm_oci", label: "WASM OCI", group: "Container" },
   { value: "helm_oci", label: "Helm OCI", group: "Container" },
+  { value: "incus", label: "Incus", group: "Container" },
+  { value: "lxc", label: "LXC", group: "Container" },
   // Linux distro packages
   { value: "debian", label: "Debian/APT", group: "Linux" },
   { value: "rpm", label: "RPM/YUM", group: "Linux" },

--- a/src/app/(app)/setup/page.tsx
+++ b/src/app/(app)/setup/page.tsx
@@ -160,6 +160,30 @@ trusted-host = ${REGISTRY_HOST}`,
           code: `docker pull ${REGISTRY_HOST}/${repoKey}/my-image:latest`,
         },
       ];
+    case "incus":
+    case "lxc":
+      return [
+        {
+          title: "Add as SimpleStreams remote",
+          code: `incus remote add ${repoKey} ${REGISTRY_URL}/incus/${repoKey} \\
+  --protocol simplestreams --public`,
+        },
+        {
+          title: "Upload an image",
+          code: `curl -X PUT -u admin:password \\
+  -H "Content-Type: application/x-xz" \\
+  --data-binary @image.tar.xz \\
+  ${REGISTRY_URL}/incus/${repoKey}/images/ubuntu-noble/20240215/incus.tar.xz`,
+        },
+        {
+          title: "List images",
+          code: `incus image list ${repoKey}:`,
+        },
+        {
+          title: "Launch a container",
+          code: `incus launch ${repoKey}:ubuntu-noble my-container`,
+        },
+      ];
     case "cargo":
       return [
         {
@@ -467,7 +491,7 @@ const FORMAT_CATEGORIES: { key: string; label: string; formats: string[] }[] = [
   {
     key: "container",
     label: "Container",
-    formats: ["docker", "helm", "helm_oci", "podman", "buildx", "oras", "wasm_oci"],
+    formats: ["docker", "helm", "helm_oci", "podman", "buildx", "oras", "wasm_oci", "incus", "lxc"],
   },
   {
     key: "linux",

--- a/src/lib/package-utils.ts
+++ b/src/lib/package-utils.ts
@@ -28,6 +28,9 @@ export function getInstallCommand(
     case "podman":
     case "buildx":
       return `docker pull ${packageName}:${v}`;
+    case "incus":
+    case "lxc":
+      return `incus image copy ${packageName} local: --alias ${packageName}`;
     case "helm":
     case "helm_oci":
       return `helm install ${packageName} --version ${v}`;
@@ -148,4 +151,6 @@ export const FORMAT_OPTIONS: string[] = [
   "p2",
   "bazel",
   "protobuf",
+  "incus",
+  "lxc",
 ];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -117,7 +117,9 @@ export type RepositoryFormat =
   | 'opkg'
   | 'p2'
   | 'bazel'
-  | 'protobuf';
+  | 'protobuf'
+  | 'incus'
+  | 'lxc';
 
 export type RepositoryType = 'local' | 'remote' | 'virtual' | 'staging';
 

--- a/src/types/packages.ts
+++ b/src/types/packages.ts
@@ -47,7 +47,9 @@ export type PackageType =
   | 'vagrant'
   | 'opkg'
   | 'p2'
-  | 'bazel';
+  | 'bazel'
+  | 'incus'
+  | 'lxc';
 
 export interface Package {
   id: string;


### PR DESCRIPTION
## Summary
- Add `incus` and `lxc` to `RepositoryFormat` and `PackageType` type unions
- Add Incus/LXC entries to repository creation dropdown (Container group)
- Add setup guide steps (SimpleStreams remote, image upload, list, launch)
- Add to format categories filter and install command generator

Companion to backend PR: artifact-keeper/artifact-keeper#206

## Test plan
- [ ] Verify Incus/LXC appear in repository creation format dropdown under "Container" group
- [ ] Verify setup guide shows correct Incus CLI steps
- [ ] Verify format filter includes Incus/LXC in Container category