### PR TITLE
fix: remove duplicate create buttons causing E2E strict mode failures

### DIFF
--- a/src/app/(app)/(protected)/access-tokens/page.tsx
+++ b/src/app/(app)/(protected)/access-tokens/page.tsx
@@ -286,12 +286,6 @@ export default function AccessTokensPage() {
               icon={Key}
               title="No API keys"
               description="Create an API key for programmatic access to the registry."
-              action={
-                <Button onClick={() => setCreateKeyOpen(true)}>
-                  <Plus className="size-4" />
-                  Create API Key
-                </Button>
-              }
             />
           ) : (
             <DataTable
@@ -324,12 +318,6 @@ export default function AccessTokensPage() {
               icon={Shield}
               title="No access tokens"
               description="Create a personal access token for CLI or CI/CD authentication."
-              action={
-                <Button onClick={() => setCreateTokenOpen(true)}>
-                  <Plus className="size-4" />
-                  Create Token
-                </Button>
-              }
             />
           ) : (
             <DataTable


### PR DESCRIPTION
## Summary

- Removes duplicate "Create API Key" and "Create Token" buttons from the `EmptyState` components on the access tokens page
- When the lists are empty, both a header button and an EmptyState action button rendered with the same label, causing Playwright strict mode to fail with "resolved to 2 elements"
- The header buttons are always visible above the empty state, so the EmptyState duplicates were redundant

## Test plan

- [ ] CI E2E tests pass (previously failing `access-tokens` suite)
- [ ] Verify empty state still displays icon, title, and description text
- [ ] Verify header "Create API Key" and "Create Token" buttons still work from empty state