### PR TITLE
Add unit test job to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,22 @@ jobs:
       - run: npm ci
       - run: npm run lint
 
+  test:
+    name: Unit Tests
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm test
+
   build:
     name: Build
-    needs: lint
+    needs: [lint, test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
- Adds a dedicated Unit Tests job that runs `npm test` (Vitest) after lint
- Build job now depends on both lint and test passing
- Ensures the 99 unit tests added in #69 run on every PR and push to main

## Test plan
- [ ] CI pipeline runs lint, then test, then build in order
- [ ] Unit test failures block the build job