### PR TITLE
Add SonarCloud scanning to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,10 @@ jobs:
           name: coverage-report
           path: coverage/
           retention-days: 14
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   build:
     name: Build

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.projectKey=artifact-keeper_artifact-keeper-web
+sonar.organization=artifact-keeper
+sonar.sources=src
+sonar.exclusions=node_modules/**,.next/**,out/**,coverage/**
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary

- Adds `sonar-project.properties` with project key, organization, source directory, and exclusions for generated/dependency directories.
- Adds a SonarCloud scan step to the `test` job in CI, running after coverage generation so the lcov report is available for analysis.

## Test plan

- [ ] Verify the `SONAR_TOKEN` secret is configured in the repository settings.
- [ ] Confirm the SonarCloud scan step runs successfully after `test:coverage` completes.
- [ ] Check that coverage data appears in the SonarCloud dashboard.