### PR TITLE
Fix plugins page description to match actual capabilities

### DIFF
--- a/src/app/(app)/(protected)/plugins/page.tsx
+++ b/src/app/(app)/(protected)/plugins/page.tsx
@@ -371,7 +371,7 @@ export default function PluginsPage() {
     <div className="space-y-6">
       <PageHeader
         title="Plugins"
-        description="Manage WASM plugins for format handlers, storage backends, and more."
+        description="Manage WASM format handler plugins."
         actions={
           <div className="flex items-center gap-2">
             <Tooltip>


### PR DESCRIPTION
## Summary

- Change page description from "Manage WASM plugins for format handlers, storage backends, and more." to "Manage WASM format handler plugins."
- Only format handler plugins are currently supported; the old description oversold capabilities

## Test plan

- [x] Web build succeeds (`npm run build`)
- [ ] Visual review of the plugins page header