### PR TITLE
Fix E2E seed API paths for quality gates and lifecycle

### DIFF
--- a/e2e/setup/seed-data.ts
+++ b/e2e/setup/seed-data.ts
@@ -67,7 +67,7 @@ export async function seedWebhook(request: APIRequestContext): Promise<void> {
 
 /** Create a test quality gate */
 export async function seedQualityGate(request: APIRequestContext): Promise<void> {
-  await api(request, 'POST', '/quality-gates', {
+  await api(request, 'POST', '/quality/gates', {
     name: 'e2e-test-gate',
     description: 'Quality gate for E2E tests',
     max_critical_issues: 0,
@@ -79,11 +79,11 @@ export async function seedQualityGate(request: APIRequestContext): Promise<void>
 
 /** Create a test lifecycle policy */
 export async function seedLifecyclePolicy(request: APIRequestContext): Promise<void> {
-  await api(request, 'POST', '/lifecycle/policies', {
+  await api(request, 'POST', '/admin/lifecycle', {
     name: 'e2e-test-cleanup',
     description: 'Cleanup policy for E2E tests',
     policy_type: 'max_age_days',
-    config: { max_age_days: 30 },
+    config: { days: 30 },
     priority: 10,
   });
 }


### PR DESCRIPTION
## Summary

- Fix quality gate seeding: `/quality-gates` -> `/quality/gates` (backend nests handler at `/quality`, route defined as `/gates`)
- Fix lifecycle policy seeding: `/lifecycle/policies` -> `/admin/lifecycle` (backend nests handler at `/admin/lifecycle`, route defined as `/`)

These incorrect paths caused 404 errors during E2E test setup, which then cascaded into test failures across all E2E jobs (Visual Regression, RBAC Roles, Interactions).

## Test Plan

- [ ] E2E seed logs should no longer show `failed (404)` for quality gates or lifecycle policies
- [ ] All E2E test suites should pass their setup phase cleanly