### PR TITLE
fix(ci): skip SonarCloud scan when SONAR_TOKEN is unavailable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
           path: coverage/
           retention-days: 14
       - name: SonarCloud Scan
+        if: env.SONAR_TOKEN != ''
         uses: SonarSource/sonarqube-scan-action@2f77a1ec69fb1d595b06f35ab27e97605bdef703 # v5.3.2
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary
- Skip the SonarCloud scan step when `SONAR_TOKEN` is not available (e.g., on Dependabot PRs)
- Dependabot PRs don't have access to repository secrets per GitHub's security policy, which causes the scan to fail with "Project not found" and blocks the entire Unit Tests job
- The actual vitest unit tests pass fine on all Dependabot PRs; only the SonarCloud step fails

## Test plan
- [ ] Verify Unit Tests job passes on this PR (SonarCloud should run since the token is available)
- [ ] After merge, rebase a Dependabot PR and verify Unit Tests passes with SonarCloud step skipped