### PR TITLE
chore(deps): upgrade react-resizable-panels to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "react-dom": "19.2.4",
         "react-hook-form": "^7.71.2",
         "react-qr-code": "^2.0.18",
-        "react-resizable-panels": "^3.0.6",
+        "react-resizable-panels": "^4.6.5",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "zod": "^4.3.6"
@@ -8269,6 +8269,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -10632,13 +10633,13 @@
       }
     },
     "node_modules/react-resizable-panels": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-3.0.6.tgz",
-      "integrity": "sha512-b3qKHQ3MLqOgSS+FRYKapNkJZf5EQzuf6+RLiq1/IlTHw99YrZ2NJZLk4hQIzTnnIkRg2LUqyVinu6YWWpUYew==",
+      "version": "4.6.5",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.6.5.tgz",
+      "integrity": "sha512-pmQP6qv9KmsesNMvWVNvVfVJAwYSOWWbAOAtrPR8Cre20+j1NWIlyft0btjtDQE+OepXmI6g3VPrCXQY0oD7+Q==",
       "license": "MIT",
       "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc",
-        "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-style-singleton": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "react-dom": "19.2.4",
     "react-hook-form": "^7.71.2",
     "react-qr-code": "^2.0.18",
-    "react-resizable-panels": "^3.0.6",
+    "react-resizable-panels": "^4.6.5",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"

--- a/src/app/(app)/repositories/page.tsx
+++ b/src/app/(app)/repositories/page.tsx
@@ -405,8 +405,7 @@ export default function RepositoriesPage() {
         <div className="border rounded-lg overflow-hidden">{masterContent}</div>
       ) : (
         <ResizablePanelGroup
-          direction="horizontal"
-          autoSaveId="repo-browser"
+          orientation="horizontal"
           className="border rounded-lg overflow-hidden"
           style={{ height: "calc(100vh - 10rem)" }}
         >

--- a/src/app/(app)/staging/page.tsx
+++ b/src/app/(app)/staging/page.tsx
@@ -244,8 +244,7 @@ export default function StagingPage() {
         <div className="border rounded-lg overflow-hidden">{masterContent}</div>
       ) : (
         <ResizablePanelGroup
-          direction="horizontal"
-          autoSaveId="staging-browser"
+          orientation="horizontal"
           className="border rounded-lg overflow-hidden"
           style={{ height: "calc(100vh - 10rem)" }}
         >

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -2,12 +2,12 @@
 
 import { GripVerticalIcon } from "lucide-react"
 import {
+  Group,
   Panel,
-  PanelGroup,
-  PanelResizeHandle,
-  type PanelGroupProps,
+  Separator,
+  type GroupProps,
   type PanelProps,
-  type PanelResizeHandleProps,
+  type SeparatorProps,
 } from "react-resizable-panels"
 
 import { cn } from "@/lib/utils"
@@ -15,9 +15,9 @@ import { cn } from "@/lib/utils"
 function ResizablePanelGroup({
   className,
   ...props
-}: PanelGroupProps) {
+}: GroupProps) {
   return (
-    <PanelGroup
+    <Group
       data-slot="resizable-panel-group"
       className={cn(
         "flex h-full w-full aria-[orientation=vertical]:flex-col",
@@ -36,11 +36,11 @@ function ResizableHandle({
   withHandle,
   className,
   ...props
-}: PanelResizeHandleProps & {
+}: SeparatorProps & {
   withHandle?: boolean
 }) {
   return (
-    <PanelResizeHandle
+    <Separator
       data-slot="resizable-handle"
       className={cn(
         "bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-1 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:translate-x-0 aria-[orientation=horizontal]:after:-translate-y-1/2 [&[aria-orientation=horizontal]>div]:rotate-90",
@@ -53,7 +53,7 @@ function ResizableHandle({
           <GripVerticalIcon className="size-2.5" />
         </div>
       )}
-    </PanelResizeHandle>
+    </Separator>
   )
 }
 


### PR DESCRIPTION
## Summary
- Upgrades react-resizable-panels from 3.0.6 to 4.6.5 (major version)
- Updates wrapper component to v4 API: `Group`/`Separator` components, `orientation` prop
- Removes deprecated `autoSaveId` prop from consumer pages
- Replaces Dependabot PR #85

## Test plan
- [x] `npm run build` passes with no type errors
- [x] All 178 unit tests pass
- [x] `npm run lint` has no errors
- [ ] Manual verification of resizable panels on repositories and staging pages