### PR TITLE
fix: add supply chain attestations to Docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,6 +304,8 @@ jobs:
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=build-${{ matrix.platform }}
           cache-to: type=gha,scope=build-${{ matrix.platform }},mode=max
+          sbom: true
+          provenance: mode=max
 
       - name: Export digest
         run: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,6 +63,8 @@ jobs:
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=web-${{ matrix.platform }}
           cache-to: type=gha,scope=web-${{ matrix.platform }},mode=max
+          sbom: true
+          provenance: mode=max
 
       - name: Export digest
         run: |


### PR DESCRIPTION
## Summary
- Add `sbom: true` and `provenance: mode=max` to `docker/build-push-action` in both `ci.yml` and `docker-publish.yml`
- Resolves the "Missing supply chain attestation(s)" Docker Scout policy violation

## Test plan
- [ ] CI Docker build completes with attestations attached
- [ ] Docker-publish workflow generates SBOM and provenance manifests