### PR TITLE
fix: use percentage strings for resizable panel sizes

### DIFF
--- a/src/app/(app)/repositories/page.tsx
+++ b/src/app/(app)/repositories/page.tsx
@@ -409,11 +409,11 @@ export default function RepositoriesPage() {
           className="border rounded-lg overflow-hidden"
           style={{ height: "calc(100vh - 10rem)" }}
         >
-          <ResizablePanel defaultSize={30} minSize={20} maxSize={45}>
+          <ResizablePanel defaultSize="30%" minSize="20%" maxSize="45%">
             {masterContent}
           </ResizablePanel>
           <ResizableHandle withHandle />
-          <ResizablePanel defaultSize={70} minSize={55}>
+          <ResizablePanel defaultSize="70%" minSize="55%">
             {effectiveSelectedKey ? (
               <RepoDetailPanel repoKey={effectiveSelectedKey} />
             ) : (

--- a/src/app/(app)/staging/page.tsx
+++ b/src/app/(app)/staging/page.tsx
@@ -248,11 +248,11 @@ export default function StagingPage() {
           className="border rounded-lg overflow-hidden"
           style={{ height: "calc(100vh - 10rem)" }}
         >
-          <ResizablePanel defaultSize={30} minSize={20} maxSize={45}>
+          <ResizablePanel defaultSize="30%" minSize="20%" maxSize="45%">
             {masterContent}
           </ResizablePanel>
           <ResizableHandle withHandle />
-          <ResizablePanel defaultSize={70} minSize={55}>
+          <ResizablePanel defaultSize="70%" minSize="55%">
             {effectiveSelectedKey ? (
               <StagingDetailPanel repoKey={effectiveSelectedKey} />
             ) : (


### PR DESCRIPTION
## Summary

- react-resizable-panels v4 interprets bare numeric values as pixels, not percentages. `defaultSize={30}` was treated as 30px (1.86% of group width), then clamped to `maxSize={45}` which became 2.79% (45px/1613px). This made the left panel render at ~45px instead of the intended 30%.
- Changed all `defaultSize`, `minSize`, and `maxSize` props to string percentage values (`"30%"`, `"70%"`, etc.) on both the repositories and staging pages.

Fixes #290

## Test plan

- [ ] Repositories page: left panel renders at ~30% width, drag handle works, min/max constraints respected
- [ ] Staging page: same verification
- [ ] Resize persists correctly when dragging the handle