### PR TITLE
fix: hide system health from anonymous dashboard users

### DIFF
--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -240,7 +240,7 @@ function SeverityBreakdown({ trends }: { trends: CveTrends }) {
 // ---------------------------------------------------------------------------
 
 export default function DashboardPage() {
-  const { user } = useAuth();
+  const { user, isAuthenticated } = useAuth();
   const queryClient = useQueryClient();
 
   const {
@@ -250,6 +250,7 @@ export default function DashboardPage() {
   } = useQuery({
     queryKey: ["health"],
     queryFn: () => adminApi.getHealth(),
+    enabled: isAuthenticated,
   });
 
   const {
@@ -299,53 +300,57 @@ export default function DashboardPage() {
         title={greeting ? `Welcome back, ${greeting}` : "Dashboard"}
         description="Overview of your Artifact Keeper instance."
         actions={
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleRefresh}
-            disabled={isRefreshing}
-          >
-            <RefreshCw
-              className={`size-4 ${isRefreshing ? "animate-spin" : ""}`}
-            />
-            Refresh
-          </Button>
+          isAuthenticated ? (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleRefresh}
+              disabled={isRefreshing}
+            >
+              <RefreshCw
+                className={`size-4 ${isRefreshing ? "animate-spin" : ""}`}
+              />
+              Refresh
+            </Button>
+          ) : undefined
         }
       />
 
-      {/* System Health */}
-      <section>
-        <h2 className="mb-3 text-sm font-medium text-muted-foreground uppercase tracking-wider">
-          System Health
-        </h2>
-        {healthLoading ? (
-          <HealthSkeleton />
-        ) : (
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
-            <HealthCard label="Overall" status={health?.status} />
-            <HealthCard
-              label="Database"
-              status={health?.checks?.database?.status}
-            />
-            <HealthCard
-              label="Storage"
-              status={health?.checks?.storage?.status}
-            />
-            {health?.checks?.security_scanner && (
+      {/* System Health (authenticated users only) */}
+      {isAuthenticated && (
+        <section>
+          <h2 className="mb-3 text-sm font-medium text-muted-foreground uppercase tracking-wider">
+            System Health
+          </h2>
+          {healthLoading ? (
+            <HealthSkeleton />
+          ) : (
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+              <HealthCard label="Overall" status={health?.status} />
               <HealthCard
-                label="Security Scanner"
-                status={health.checks.security_scanner.status}
+                label="Database"
+                status={health?.checks?.database?.status}
               />
-            )}
-            {health?.checks?.meilisearch && (
               <HealthCard
-                label="Search Engine"
-                status={health.checks.meilisearch.status}
+                label="Storage"
+                status={health?.checks?.storage?.status}
               />
-            )}
-          </div>
-        )}
-      </section>
+              {health?.checks?.security_scanner && (
+                <HealthCard
+                  label="Security Scanner"
+                  status={health.checks.security_scanner.status}
+                />
+              )}
+              {health?.checks?.meilisearch && (
+                <HealthCard
+                  label="Search Engine"
+                  status={health.checks.meilisearch.status}
+                />
+              )}
+            </div>
+          )}
+        </section>
+      )}
 
       {/* Admin Stats */}
       {user?.is_admin && (


### PR DESCRIPTION
## Summary

- Gate the System Health section, health API query, and refresh button behind `isAuthenticated` so anonymous visitors don't see system internals (DB status, storage health, scanner availability, pool stats).
- Anonymous users now see only the "Dashboard" header and the Recent Repositories card, which the backend already filters to `is_public=true` repos.
- Admin Stats and Security Overview sections were already gated behind `user.is_admin`, no changes needed there.

Closes #98

## Test plan

- [ ] Visit `/` as anonymous user: should see only "Dashboard" title and Recent Repositories (public repos only, no refresh button)
- [ ] Visit `/` as authenticated non-admin: should see "Welcome back" greeting, System Health, refresh button, and Recent Repositories
- [ ] Visit `/` as admin: should see all of the above plus Statistics and Security Overview sections
- [ ] Network tab: verify no `/health` request fires for anonymous users