### PR TITLE
fix: add /v2 to middleware matcher for Docker login

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -58,6 +58,7 @@ export const config = {
     "/proto/:path*",
     "/incus/:path*",
     "/ext/:path*",
+    "/v2",
     "/v2/:path*",
   ],
 };


### PR DESCRIPTION
## Summary

- `docker login` hits `GET /v2/` (bare, no path segments after `/v2/`) for the OCI version check
- The middleware matcher only had `"/v2/:path*"` which requires at least one segment after `/v2/`, so the request fell through to the Next.js page router and returned 404
- Added `"/v2"` as a separate matcher entry so the bare path is proxied to the backend, which returns the expected `401` with `WWW-Authenticate: Bearer` challenge

## Test plan

- [ ] `curl -v https://host/v2/` returns `401` with `WWW-Authenticate: Bearer realm="..."` (or `308` redirect to `/v2` which then returns `401`)
- [ ] `docker login host` completes the auth handshake
- [ ] Existing `/v2/:path*` OCI operations (push, pull, manifests) still work
- [ ] `npm run lint` passes