### PR TITLE
fix: resolve flaky E2E tests for security scans and access tokens

### DIFF
--- a/e2e/suites/interactions/security/security-scans.spec.ts
+++ b/e2e/suites/interactions/security/security-scans.spec.ts
@@ -13,11 +13,14 @@ test.describe('Security Scans Page', () => {
   });
 
   test('scans table or empty state is visible', async ({ page }) => {
-    const table = page.getByRole('table').first();
-    const emptyState = page.getByText(/no scan|no result/i).first();
+    // Wait for data to load (the page fetches scan results via TanStack Query)
+    await page.waitForLoadState('networkidle');
 
-    const hasTable = await table.isVisible({ timeout: 10000 }).catch(() => false);
-    const hasEmpty = await emptyState.isVisible().catch(() => false);
+    const table = page.getByRole('table').first();
+    const emptyState = page.getByText(/no scan results found/i).first();
+
+    const hasTable = await table.isVisible({ timeout: 15000 }).catch(() => false);
+    const hasEmpty = await emptyState.isVisible({ timeout: 5000 }).catch(() => false);
 
     expect(hasTable || hasEmpty).toBeTruthy();
   });


### PR DESCRIPTION
## Summary

- **Security scans test**: Added `networkidle` wait before checking for table/empty state, and updated the regex to match the actual empty message text ("No scan results found"). The page fetches data via TanStack Query and the previous test checked too early.
- **Access tokens CRUD tests**: Three fixes for test data pollution across CI runs:
  - Clean up leftover `e2e-api-key` and `e2e-access-token` entries at the start of each CRUD suite
  - Use `.first()` on row selectors to avoid Playwright strict mode violations when duplicate entries exist
  - Reload the page after revocation to verify removal instead of relying on client-side reactivity timing

## Test plan

- [ ] Security scans test passes on CI (no more false negatives from slow data loading)
- [ ] Access tokens CRUD tests pass even when leftover tokens exist from previous runs
- [ ] No strict mode violations from duplicate row matches