### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,120 @@
+name: Bug Report
+description: Report a bug or unexpected behavior in the Artifact Keeper web interface
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to report a bug. This helps us improve the Artifact Keeper web interface.
+
+        If your issue is related to the backend API or server, please file it in the [artifact-keeper](https://github.com/artifact-keeper/artifact-keeper/issues/new) repository instead.
+
+        For security vulnerabilities, please use [private security reporting](https://github.com/artifact-keeper/artifact-keeper-web/security/advisories/new) rather than opening a public issue.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment Information
+      description: Provide details about your environment.
+      value: |
+        - Browser: (e.g., Chrome, Firefox, Safari, Edge)
+        - Browser Version:
+        - Operating System:
+        - Screen Resolution:
+        - Connection type: (direct, behind proxy)
+    validations:
+      required: true
+
+  - type: input
+    id: web-version
+    attributes:
+      label: Web UI Version
+      description: The version of the Artifact Keeper web interface you are using.
+      placeholder: "e.g., 1.1.0, latest, dev"
+    validations:
+      required: true
+
+  - type: input
+    id: backend-version
+    attributes:
+      label: Backend Version
+      description: The version of the Artifact Keeper backend, if known.
+      placeholder: "e.g., 1.1.0, latest, N/A"
+    validations:
+      required: false
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed-behavior
+    attributes:
+      label: Observed Behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Step-by-step instructions to reproduce the issue.
+      placeholder: |
+        1. Navigate to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. Observe the error
+    validations:
+      required: true
+
+  - type: textarea
+    id: console-logs
+    attributes:
+      label: Browser Console Logs
+      description: |
+        If applicable, paste any errors or warnings from the browser developer console.
+        You can open DevTools with F12 (Windows/Linux) or Cmd+Option+I (macOS).
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain the issue.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other context about the problem.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I have searched existing issues to make sure this is not a duplicate.
+          required: true
+        - label: I have redacted any sensitive information (tokens, passwords, internal URLs).
+          required: true
+        - label: I have tested this on the latest version of the web interface.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Backend / API Issues
+    url: https://github.com/artifact-keeper/artifact-keeper/issues/new
+    about: Report bugs or request features for the backend API and server
+  - name: Security Vulnerability
+    url: https://github.com/artifact-keeper/artifact-keeper-web/security/advisories/new
+    about: Please report security vulnerabilities privately through GitHub Security Advisories
+  - name: GitHub Discussions
+    url: https://github.com/orgs/artifact-keeper/discussions
+    about: Ask questions and discuss ideas with the community
+  - name: Documentation
+    url: https://artifactkeeper.com/docs
+    about: Browse the official documentation

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,59 @@
+name: Documentation Issue
+description: Report an issue with documentation or suggest improvements
+labels: ["documentation", "needs-triage"]
+body:
+  - type: dropdown
+    id: documentation-type
+    attributes:
+      label: Documentation Type
+      description: What kind of documentation issue is this?
+      options:
+        - Missing documentation
+        - Incorrect or outdated information
+        - Unclear or confusing content
+        - Typo or formatting issue
+        - Missing examples
+        - API documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: location
+    attributes:
+      label: Location
+      description: Where is the documentation issue? Provide a URL, file path, or page name.
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the issue with the current documentation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggested-improvement
+    attributes:
+      label: Suggested Improvement
+      description: How would you improve this documentation?
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other context or references.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I have searched existing issues to make sure this is not a duplicate.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,81 @@
+name: Feature Request
+description: Suggest a new feature or enhancement for the Artifact Keeper web interface
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for suggesting a feature. Your feedback helps shape the direction of Artifact Keeper.
+
+        If your request is related to the backend API or server functionality, please file it in the [artifact-keeper](https://github.com/artifact-keeper/artifact-keeper/issues/new) repository instead. If you are not sure where it belongs, go ahead and file it here and we will move it if needed.
+
+  - type: textarea
+    id: problem-statement
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve? Describe the pain point or gap.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed Solution
+      description: How would you like this to work? Be as specific as you can.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Have you considered any alternative approaches or workarounds?
+    validations:
+      required: false
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: Describe a concrete scenario where this feature would be useful.
+      placeholder: "As a [type of user], I want [goal] so that [reason]."
+    validations:
+      required: false
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the web interface does this relate to?
+      options:
+        - Dashboard
+        - Repository Browser
+        - Search
+        - Package Details
+        - Admin Panel
+        - Security / Scanning
+        - User Management
+        - Settings
+        - Navigation / Layout
+        - Accessibility
+        - Other
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other context, mockups, or references that might help.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I have searched existing issues to make sure this is not a duplicate.
+          required: true
+        - label: I have reviewed the documentation to confirm this feature does not already exist.
+          required: true


### PR DESCRIPTION
## Summary

- Add structured GitHub issue templates using YAML forms for bug reports, feature requests, and documentation issues
- Add config.yml with contact links directing users to the correct repo for backend issues, security advisories, community discussions, and documentation
- Bug report template includes fields for environment details, browser console logs, reproduction steps, and a pre-submission checklist
- Feature request template includes a component dropdown covering all major sections of the web UI
- Documentation template covers common doc issue types with a required location field

## Test plan

- [ ] Navigate to https://github.com/artifact-keeper/artifact-keeper-web/issues/new/choose and verify the template chooser renders all three templates plus the four contact links
- [ ] Open each template form and confirm all fields render correctly with the expected labels, placeholders, and required/optional markers
- [ ] Verify the contact links point to the correct URLs (backend repo, security advisories, discussions, docs site)
- [ ] Confirm blank issues are still allowed via the "Open a blank issue" link