### PR TITLE
feat: add storage quota field to repository create and edit dialogs

### DIFF
--- a/src/app/(app)/repositories/_components/repo-dialogs.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-dialogs.test.tsx
@@ -1094,3 +1094,268 @@ describe('quotaToBytes and bytesToQuota', () => {
     expect(bytesToQuota(0)).toEqual({ value: '', unit: 'GB' });
   });
 });
+
+describe('RepoDialogs - Virtual Member Selection', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('selects and deselects virtual member repos via checkbox', async () => {
+    const onCreateSubmit = vi.fn();
+    const user = userEvent.setup();
+    const localRepo = {
+      ...mockEditRepo,
+      key: 'local-1',
+      name: 'Local 1',
+      format: 'generic' as const,
+      repo_type: 'local' as const,
+    };
+    const remoteRepo = {
+      ...mockEditRepo,
+      key: 'remote-1',
+      name: 'Remote 1',
+      format: 'generic' as const,
+      repo_type: 'remote' as const,
+    };
+
+    render(
+      <RepoDialogs
+        {...defaultProps}
+        onCreateSubmit={onCreateSubmit}
+        availableRepos={[localRepo, remoteRepo]}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog');
+    const selects = within(dialog).getAllByTestId('mock-select');
+
+    // Set format to generic and type to virtual
+    fireEvent.change(selects[0], { target: { value: 'generic' } });
+    fireEvent.change(selects[1], { target: { value: 'virtual' } });
+
+    // Select first member
+    const checkboxes = within(dialog).getAllByRole('checkbox');
+    await user.click(checkboxes[0]);
+    expect((checkboxes[0] as HTMLInputElement).checked).toBe(true);
+
+    // Select second member
+    await user.click(checkboxes[1]);
+    expect((checkboxes[1] as HTMLInputElement).checked).toBe(true);
+
+    // Deselect first member
+    await user.click(checkboxes[0]);
+    expect((checkboxes[0] as HTMLInputElement).checked).toBe(false);
+
+    // Submit the form and verify member_repos
+    await user.type(within(dialog).getByPlaceholderText('my-repo'), 'my-virtual');
+    await user.type(within(dialog).getByPlaceholderText('My Repository'), 'My Virtual');
+    await user.click(within(dialog).getByRole('button', { name: /^create$/i }));
+
+    expect(onCreateSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repo_type: 'virtual',
+        member_repos: [{ repo_key: 'remote-1', priority: 1 }],
+      })
+    );
+  });
+});
+
+describe('RepoDialogs - Edit Dialog Additional Coverage', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('updates description in edit dialog', async () => {
+    const onEditSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <RepoDialogs
+        {...defaultProps}
+        createOpen={false}
+        editOpen={true}
+        editRepo={mockEditRepo}
+        onEditSubmit={onEditSubmit}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog');
+    const descInput = within(dialog).getByDisplayValue('A test repo');
+    await user.clear(descInput);
+    await user.type(descInput, 'Updated description');
+
+    await user.click(within(dialog).getByRole('button', { name: /save changes/i }));
+
+    expect(onEditSubmit).toHaveBeenCalledWith(
+      'test-repo',
+      expect.objectContaining({ description: 'Updated description' })
+    );
+  });
+
+  it('toggles public switch in edit dialog', async () => {
+    const onEditSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <RepoDialogs
+        {...defaultProps}
+        createOpen={false}
+        editOpen={true}
+        editRepo={mockEditRepo}
+        onEditSubmit={onEditSubmit}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog');
+    const publicSwitch = within(dialog).getByRole('switch');
+    expect(publicSwitch.getAttribute('aria-checked')).toBe('true');
+
+    await user.click(publicSwitch);
+    expect(publicSwitch.getAttribute('aria-checked')).toBe('false');
+
+    await user.click(within(dialog).getByRole('button', { name: /save changes/i }));
+
+    expect(onEditSubmit).toHaveBeenCalledWith(
+      'test-repo',
+      expect.objectContaining({ is_public: false })
+    );
+  });
+
+  it('calls onEditOpenChange(false) when edit cancel button is clicked', async () => {
+    const onEditOpenChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <RepoDialogs
+        {...defaultProps}
+        createOpen={false}
+        editOpen={true}
+        editRepo={mockEditRepo}
+        onEditOpenChange={onEditOpenChange}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: /cancel/i }));
+    expect(onEditOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('updates create description field', async () => {
+    const onCreateSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(<RepoDialogs {...defaultProps} onCreateSubmit={onCreateSubmit} />);
+
+    const dialog = screen.getByRole('dialog');
+    await user.type(within(dialog).getByPlaceholderText('my-repo'), 'desc-test');
+    await user.type(within(dialog).getByPlaceholderText('My Repository'), 'Desc Test');
+    await user.type(within(dialog).getByPlaceholderText('Optional description...'), 'My description');
+
+    await user.click(within(dialog).getByRole('button', { name: /^create$/i }));
+
+    expect(onCreateSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ description: 'My description' })
+    );
+  });
+});
+
+describe('RepoDialogs - Upstream Auth Edge Cases', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('dismisses remove auth confirmation when Keep is clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <RepoDialogs
+        {...defaultProps}
+        createOpen={false}
+        editOpen={true}
+        editRepo={mockRemoteEditRepo}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog');
+    // Click Remove to show confirmation
+    await user.click(within(dialog).getByRole('button', { name: /^remove$/i }));
+    expect(within(dialog).getByText(/removing credentials will cause/i)).toBeTruthy();
+
+    // Click Keep to dismiss
+    await user.click(within(dialog).getByRole('button', { name: /^keep$/i }));
+    expect(within(dialog).queryByText(/removing credentials will cause/i)).toBeNull();
+  });
+
+  it('submits create form with bearer token auth', async () => {
+    const onCreateSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(<RepoDialogs {...defaultProps} onCreateSubmit={onCreateSubmit} />);
+
+    const dialog = screen.getByRole('dialog');
+    await user.type(within(dialog).getByPlaceholderText('my-repo'), 'bearer-test');
+    await user.type(within(dialog).getByPlaceholderText('My Repository'), 'Bearer Test');
+
+    // Select remote type
+    const selects = within(dialog).getAllByTestId('mock-select');
+    fireEvent.change(selects[1], { target: { value: 'remote' } });
+
+    // Fill upstream URL
+    const urlInput = within(dialog).getByLabelText(/upstream url/i);
+    await user.type(urlInput, 'https://example.com');
+
+    // Select bearer auth - after remote, selects are: Format=0, Type=1, AuthType=2, QuotaUnit=3
+    const updatedSelects = within(dialog).getAllByTestId('mock-select');
+    fireEvent.change(updatedSelects[2], { target: { value: 'bearer' } });
+
+    // Fill bearer token
+    await user.type(within(dialog).getByPlaceholderText('Bearer token'), 'my-token');
+
+    await user.click(within(dialog).getByRole('button', { name: /^create$/i }));
+
+    expect(onCreateSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        upstream_auth_type: 'bearer',
+        upstream_password: 'my-token',
+      })
+    );
+    // Should not include username for bearer
+    const submitData = onCreateSubmit.mock.calls[0][0];
+    expect(submitData.upstream_username).toBeUndefined();
+  });
+
+  it('resets edit form overrides when edit dialog closes via onOpenChange', () => {
+    const onEditOpenChange = vi.fn();
+    const { rerender } = render(
+      <RepoDialogs
+        {...defaultProps}
+        createOpen={false}
+        editOpen={true}
+        editRepo={mockRemoteEditRepo}
+        onEditOpenChange={onEditOpenChange}
+      />
+    );
+
+    // Close and reopen the dialog to verify state reset
+    rerender(
+      <RepoDialogs
+        {...defaultProps}
+        createOpen={false}
+        editOpen={false}
+        editRepo={mockRemoteEditRepo}
+        onEditOpenChange={onEditOpenChange}
+      />
+    );
+
+    rerender(
+      <RepoDialogs
+        {...defaultProps}
+        createOpen={false}
+        editOpen={true}
+        editRepo={mockRemoteEditRepo}
+        onEditOpenChange={onEditOpenChange}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog');
+    // Should be in view mode, not edit mode
+    expect(within(dialog).getByRole('button', { name: /^change$/i })).toBeTruthy();
+  });
+});

--- a/src/app/(app)/repositories/_components/repo-dialogs.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-dialogs.test.tsx
@@ -725,10 +725,9 @@ describe('RepoDialogs - Upstream Auth (Edit)', () => {
     // Click Configure to enter edit mode
     await user.click(within(dialog).getByRole('button', { name: /configure/i }));
 
-    // Select basic auth
+    // Select basic auth — quota unit select is first, auth select is last
     const selects = within(dialog).getAllByTestId('mock-select');
-    // In edit dialog, the auth select is the only mock-select
-    const authSelect = selects[0];
+    const authSelect = selects[selects.length - 1];
     fireEvent.change(authSelect, { target: { value: 'basic' } });
 
     // Fill in credentials
@@ -776,9 +775,9 @@ describe('RepoDialogs - Upstream Auth (Edit)', () => {
     // Click Configure to enter edit mode
     await user.click(within(dialog).getByRole('button', { name: /configure/i }));
 
-    // Select bearer auth
+    // Select bearer auth — quota unit select is first, auth select is last
     const selects = within(dialog).getAllByTestId('mock-select');
-    const authSelect = selects[0];
+    const authSelect = selects[selects.length - 1];
     fireEvent.change(authSelect, { target: { value: 'bearer' } });
 
     // Fill in bearer token
@@ -863,5 +862,235 @@ describe('RepoDialogs - Upstream Auth (Edit)', () => {
     const reopenedDialog = screen.getByRole('dialog');
     expect(within(reopenedDialog).getByRole('button', { name: /^change$/i })).toBeTruthy();
     expect(within(reopenedDialog).queryByRole('button', { name: /save authentication/i })).toBeNull();
+  });
+});
+
+describe('RepoDialogs - Storage Quota', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('renders quota input in create dialog', () => {
+    render(<RepoDialogs {...defaultProps} />);
+
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByLabelText(/storage quota/i)).toBeTruthy();
+    expect(within(dialog).getByPlaceholderText('No limit')).toBeTruthy();
+    expect(within(dialog).getByText(/maximum storage for this repository/i)).toBeTruthy();
+  });
+
+  it('submits quota with GB unit converted to bytes', async () => {
+    const onCreateSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(<RepoDialogs {...defaultProps} onCreateSubmit={onCreateSubmit} />);
+
+    const dialog = screen.getByRole('dialog');
+    await user.type(within(dialog).getByPlaceholderText('my-repo'), 'quota-test');
+    await user.type(within(dialog).getByPlaceholderText('My Repository'), 'Quota Test');
+
+    // Enter quota value (default unit is GB)
+    const quotaInput = within(dialog).getByPlaceholderText('No limit');
+    await user.type(quotaInput, '5');
+
+    await user.click(within(dialog).getByRole('button', { name: /^create$/i }));
+
+    expect(onCreateSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        quota_bytes: 5 * 1073741824, // 5 GB in bytes
+      })
+    );
+  });
+
+  it('submits quota with MB unit converted to bytes', async () => {
+    const onCreateSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(<RepoDialogs {...defaultProps} onCreateSubmit={onCreateSubmit} />);
+
+    const dialog = screen.getByRole('dialog');
+    await user.type(within(dialog).getByPlaceholderText('my-repo'), 'mb-test');
+    await user.type(within(dialog).getByPlaceholderText('My Repository'), 'MB Test');
+
+    // Enter quota value
+    const quotaInput = within(dialog).getByPlaceholderText('No limit');
+    await user.type(quotaInput, '512');
+
+    // Switch unit to MB
+    const selects = within(dialog).getAllByTestId('mock-select');
+    // The quota unit select is the last one (after Format and Type)
+    const quotaUnitSelect = selects[selects.length - 1];
+    fireEvent.change(quotaUnitSelect, { target: { value: 'MB' } });
+
+    await user.click(within(dialog).getByRole('button', { name: /^create$/i }));
+
+    expect(onCreateSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        quota_bytes: 512 * 1048576, // 512 MB in bytes
+      })
+    );
+  });
+
+  it('sends undefined quota_bytes when quota is empty', async () => {
+    const onCreateSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(<RepoDialogs {...defaultProps} onCreateSubmit={onCreateSubmit} />);
+
+    const dialog = screen.getByRole('dialog');
+    await user.type(within(dialog).getByPlaceholderText('my-repo'), 'no-quota');
+    await user.type(within(dialog).getByPlaceholderText('My Repository'), 'No Quota');
+
+    // Leave quota empty, submit
+    await user.click(within(dialog).getByRole('button', { name: /^create$/i }));
+
+    expect(onCreateSubmit).toHaveBeenCalledTimes(1);
+    const submitData = onCreateSubmit.mock.calls[0][0];
+    expect(submitData.quota_bytes).toBeUndefined();
+  });
+
+  it('shows existing quota in edit dialog', () => {
+    const repoWith10GB = {
+      ...mockEditRepo,
+      quota_bytes: 10 * 1073741824, // 10 GB
+    };
+
+    render(
+      <RepoDialogs
+        {...defaultProps}
+        createOpen={false}
+        editOpen={true}
+        editRepo={repoWith10GB}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog');
+    const quotaInput = within(dialog).getByLabelText(/storage quota/i) as HTMLInputElement;
+    expect(quotaInput.value).toBe('10');
+  });
+
+  it('resets quota fields when create dialog closes', async () => {
+    const user = userEvent.setup();
+    const onCreateOpenChange = vi.fn();
+
+    const { unmount } = render(
+      <RepoDialogs {...defaultProps} onCreateOpenChange={onCreateOpenChange} />
+    );
+
+    const dialog = screen.getByRole('dialog');
+    // Type a quota value
+    const quotaInput = within(dialog).getByPlaceholderText('No limit');
+    await user.type(quotaInput, '100');
+
+    // Close dialog via Cancel
+    await user.click(within(dialog).getByRole('button', { name: /cancel/i }));
+    unmount();
+
+    // Reopen: quota should be empty (fresh state from mount)
+    render(<RepoDialogs {...defaultProps} />);
+    const reopenedDialog = screen.getByRole('dialog');
+    const newQuotaInput = within(reopenedDialog).getByPlaceholderText('No limit') as HTMLInputElement;
+    expect(newQuotaInput.value).toBe('');
+  });
+
+  it('includes quota_bytes in edit submit data', async () => {
+    const onEditSubmit = vi.fn();
+    const user = userEvent.setup();
+    const repoWith5GB = {
+      ...mockEditRepo,
+      quota_bytes: 5 * 1073741824,
+    };
+
+    render(
+      <RepoDialogs
+        {...defaultProps}
+        createOpen={false}
+        editOpen={true}
+        editRepo={repoWith5GB}
+        onEditSubmit={onEditSubmit}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog');
+    // Clear and set new quota
+    const quotaInput = within(dialog).getByLabelText(/storage quota/i);
+    await user.clear(quotaInput);
+    await user.type(quotaInput, '20');
+
+    await user.click(within(dialog).getByRole('button', { name: /save changes/i }));
+
+    expect(onEditSubmit).toHaveBeenCalledWith(
+      'test-repo',
+      expect.objectContaining({
+        quota_bytes: 20 * 1073741824, // 20 GB
+      })
+    );
+  });
+
+  it('sends undefined quota_bytes when edit quota is cleared', async () => {
+    const onEditSubmit = vi.fn();
+    const user = userEvent.setup();
+    const repoWith5GB = {
+      ...mockEditRepo,
+      quota_bytes: 5 * 1073741824,
+    };
+
+    render(
+      <RepoDialogs
+        {...defaultProps}
+        createOpen={false}
+        editOpen={true}
+        editRepo={repoWith5GB}
+        onEditSubmit={onEditSubmit}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog');
+    const quotaInput = within(dialog).getByLabelText(/storage quota/i);
+    await user.clear(quotaInput);
+
+    await user.click(within(dialog).getByRole('button', { name: /save changes/i }));
+
+    expect(onEditSubmit).toHaveBeenCalledTimes(1);
+    const submitData = onEditSubmit.mock.calls[0][1];
+    expect(submitData.quota_bytes).toBeUndefined();
+  });
+});
+
+describe('quotaToBytes and bytesToQuota', () => {
+  // Import the helpers directly
+  it('quotaToBytes converts GB correctly', async () => {
+    const { quotaToBytes } = await import('./repo-dialogs');
+    expect(quotaToBytes('5', 'GB')).toBe(5 * 1073741824);
+    expect(quotaToBytes('1', 'GB')).toBe(1073741824);
+  });
+
+  it('quotaToBytes converts MB correctly', async () => {
+    const { quotaToBytes } = await import('./repo-dialogs');
+    expect(quotaToBytes('512', 'MB')).toBe(512 * 1048576);
+    expect(quotaToBytes('1', 'MB')).toBe(1048576);
+  });
+
+  it('quotaToBytes returns null for empty or zero', async () => {
+    const { quotaToBytes } = await import('./repo-dialogs');
+    expect(quotaToBytes('', 'GB')).toBeNull();
+    expect(quotaToBytes('0', 'GB')).toBeNull();
+    expect(quotaToBytes('0', 'MB')).toBeNull();
+  });
+
+  it('bytesToQuota returns GB for evenly divisible values', async () => {
+    const { bytesToQuota } = await import('./repo-dialogs');
+    expect(bytesToQuota(10 * 1073741824)).toEqual({ value: '10', unit: 'GB' });
+    expect(bytesToQuota(1073741824)).toEqual({ value: '1', unit: 'GB' });
+  });
+
+  it('bytesToQuota returns MB for non-GB values', async () => {
+    const { bytesToQuota } = await import('./repo-dialogs');
+    expect(bytesToQuota(512 * 1048576)).toEqual({ value: '512', unit: 'MB' });
+  });
+
+  it('bytesToQuota returns empty for null/undefined/zero', async () => {
+    const { bytesToQuota } = await import('./repo-dialogs');
+    expect(bytesToQuota(null)).toEqual({ value: '', unit: 'GB' });
+    expect(bytesToQuota(undefined)).toEqual({ value: '', unit: 'GB' });
+    expect(bytesToQuota(0)).toEqual({ value: '', unit: 'GB' });
   });
 });

--- a/src/app/(app)/repositories/_components/repo-dialogs.tsx
+++ b/src/app/(app)/repositories/_components/repo-dialogs.tsx
@@ -33,8 +33,8 @@ const BYTES_PER_GB = 1073741824;
 
 /** Convert a quota value and unit to bytes. Returns null for empty/zero values. */
 export function quotaToBytes(value: string, unit: QuotaUnit): number | null {
-  const num = parseFloat(value);
-  if (!num || num <= 0) return null;
+  const num = Number(value);
+  if (!num || num <= 0 || !Number.isFinite(num)) return null;
   return Math.round(num * (unit === "GB" ? BYTES_PER_GB : BYTES_PER_MB));
 }
 

--- a/src/app/(app)/repositories/_components/repo-dialogs.tsx
+++ b/src/app/(app)/repositories/_components/repo-dialogs.tsx
@@ -26,6 +26,26 @@ import {
 } from "@/components/ui/dialog";
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
 
+type QuotaUnit = "MB" | "GB";
+
+const BYTES_PER_MB = 1048576;
+const BYTES_PER_GB = 1073741824;
+
+/** Convert a quota value and unit to bytes. Returns null for empty/zero values. */
+export function quotaToBytes(value: string, unit: QuotaUnit): number | null {
+  const num = parseFloat(value);
+  if (!num || num <= 0) return null;
+  return Math.round(num * (unit === "GB" ? BYTES_PER_GB : BYTES_PER_MB));
+}
+
+/** Convert bytes to a human-friendly value and unit. Prefers GB when evenly divisible. */
+export function bytesToQuota(bytes: number | undefined | null): { value: string; unit: QuotaUnit } {
+  if (!bytes || bytes <= 0) return { value: "", unit: "GB" };
+  if (bytes >= BYTES_PER_GB && bytes % BYTES_PER_GB === 0) {
+    return { value: String(bytes / BYTES_PER_GB), unit: "GB" };
+  }
+  return { value: String(Math.round(bytes / BYTES_PER_MB)), unit: "MB" };
+}
 
 interface RepoDialogsProps {
   createOpen: boolean;
@@ -35,7 +55,7 @@ interface RepoDialogsProps {
   editOpen: boolean;
   onEditOpenChange: (open: boolean) => void;
   editRepo: Repository | null;
-  onEditSubmit: (key: string, data: { key?: string; name: string; description: string; is_public: boolean }) => void;
+  onEditSubmit: (key: string, data: { key?: string; name: string; description: string; is_public: boolean; quota_bytes?: number }) => void;
   editPending: boolean;
   onUpstreamAuthUpdate?: (key: string, payload: { auth_type: string; username?: string; password?: string }) => void;
   upstreamAuthPending?: boolean;
@@ -82,6 +102,10 @@ export function RepoDialogs({
   // For virtual repos: selected member repo keys
   const [selectedMembers, setSelectedMembers] = useState<string[]>([]);
 
+  // Quota state for create dialog
+  const [createQuotaValue, setCreateQuotaValue] = useState("");
+  const [createQuotaUnit, setCreateQuotaUnit] = useState<QuotaUnit>("GB");
+
   // Upstream auth state for create dialog
   const [upstreamAuthType, setUpstreamAuthType] = useState<string>("none");
   const [upstreamUsername, setUpstreamUsername] = useState("");
@@ -93,6 +117,12 @@ export function RepoDialogs({
   const [editAuthUsername, setEditAuthUsername] = useState("");
   const [editAuthPassword, setEditAuthPassword] = useState("");
   const [removeAuthConfirm, setRemoveAuthConfirm] = useState(false);
+
+  // Quota state for edit dialog — initialized from editRepo
+  const editQuotaDefaults = useMemo(() => bytesToQuota(editRepo?.quota_bytes), [editRepo]);
+  const [editQuotaOverrides, setEditQuotaOverrides] = useState<{ value?: string; unit?: QuotaUnit }>({});
+  const editQuotaValue = editQuotaOverrides.value ?? editQuotaDefaults.value;
+  const editQuotaUnit = editQuotaOverrides.unit ?? editQuotaDefaults.unit;
 
   // Key validation - check if key is already taken
   const keyTaken = useMemo(() => {
@@ -140,6 +170,8 @@ export function RepoDialogs({
       member_repos: [],
     });
     setSelectedMembers([]);
+    setCreateQuotaValue("");
+    setCreateQuotaUnit("GB");
     setUpstreamAuthType("none");
     setUpstreamUsername("");
     setUpstreamPassword("");
@@ -177,6 +209,7 @@ export function RepoDialogs({
               e.preventDefault();
               const submitData: CreateRepositoryRequest = {
                 ...createForm,
+                quota_bytes: quotaToBytes(createQuotaValue, createQuotaUnit) ?? undefined,
                 upstream_url: createForm.repo_type === "remote" ? createForm.upstream_url : undefined,
                 member_repos: createForm.repo_type === "virtual" ? buildMemberRepos() : undefined,
               };
@@ -419,6 +452,36 @@ export function RepoDialogs({
               />
               <Label htmlFor="create-public">Public repository</Label>
             </div>
+            <div className="space-y-2">
+              <Label htmlFor="create-quota">Storage Quota</Label>
+              <div className="flex gap-2">
+                <Input
+                  id="create-quota"
+                  type="number"
+                  min="0"
+                  step="any"
+                  placeholder="No limit"
+                  value={createQuotaValue}
+                  onChange={(e) => setCreateQuotaValue(e.target.value)}
+                  className="flex-1"
+                />
+                <Select
+                  value={createQuotaUnit}
+                  onValueChange={(v) => setCreateQuotaUnit(v as QuotaUnit)}
+                >
+                  <SelectTrigger className="w-20">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="MB">MB</SelectItem>
+                    <SelectItem value="GB">GB</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Maximum storage for this repository. Leave empty for no limit.
+              </p>
+            </div>
             <DialogFooter>
               <Button
                 variant="outline"
@@ -439,6 +502,7 @@ export function RepoDialogs({
       <Dialog open={editOpen} onOpenChange={(open) => {
         if (!open) {
           setEditFormOverrides({});
+          setEditQuotaOverrides({});
           setEditAuthMode("view");
           setEditAuthType("none");
           setEditAuthUsername("");
@@ -463,6 +527,7 @@ export function RepoDialogs({
                 onEditSubmit(editRepo.key, {
                   ...rest,
                   ...(editKeyChanged ? { key: formKey } : {}),
+                  quota_bytes: quotaToBytes(editQuotaValue, editQuotaUnit) ?? undefined,
                 });
               }
             }}
@@ -514,6 +579,36 @@ export function RepoDialogs({
                 }
               />
               <Label htmlFor="edit-public">Public repository</Label>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit-quota">Storage Quota</Label>
+              <div className="flex gap-2">
+                <Input
+                  id="edit-quota"
+                  type="number"
+                  min="0"
+                  step="any"
+                  placeholder="No limit"
+                  value={editQuotaValue}
+                  onChange={(e) => setEditQuotaOverrides((o) => ({ ...o, value: e.target.value }))}
+                  className="flex-1"
+                />
+                <Select
+                  value={editQuotaUnit}
+                  onValueChange={(v) => setEditQuotaOverrides((o) => ({ ...o, unit: v as QuotaUnit }))}
+                >
+                  <SelectTrigger className="w-20">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="MB">MB</SelectItem>
+                    <SelectItem value="GB">GB</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Maximum storage for this repository. Leave empty for no limit.
+              </p>
             </div>
 
             {/* Upstream authentication for remote repos (saved separately from main form) */}


### PR DESCRIPTION
## Summary

Adds a "Storage Quota" field to the repository create and edit dialogs. The
backend already supports `quota_bytes` but the UI didn't expose it.

- Number input with MB/GB unit selector
- Converts to bytes before sending to the API
- Empty/zero means no limit
- Helper text: "Maximum storage for this repository. Leave empty for no limit."
- Edit dialog shows current quota and allows updating
- Shared conversion helpers (no duplication between create/edit)

Closes #162

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)