### PR TITLE
fix: add rewrite so /auth/callback reaches the SSO callback page

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -58,6 +58,18 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  async rewrites() {
+    return [
+      // The backend redirects to /auth/callback after SSO code exchange,
+      // but the Next.js page lives in the (auth) route group which does
+      // not produce a URL segment. Rewrite so the page is reachable at
+      // both /callback and /auth/callback.
+      {
+        source: "/auth/callback",
+        destination: "/callback",
+      },
+    ];
+  },
   // API proxy is handled by src/middleware.ts at runtime (reads BACKEND_URL
   // env var on each request) so that Docker containers can be configured
   // without rebuilding.  See: https://github.com/artifact-keeper/artifact-keeper-web/issues/56


### PR DESCRIPTION
## Summary

The backend redirects to `/auth/callback` after SSO code exchange, but the callback page lives in the Next.js `(auth)` route group at `src/app/(auth)/callback/page.tsx`. Route groups don't create URL segments, so the page is only reachable at `/callback`, not `/auth/callback`. This causes a 404 after SSO login.

Adds a `rewrites()` entry in `next.config.ts` to internally rewrite `/auth/callback` to `/callback`, so the page is reachable at both paths without duplicating the component or adding a redirect hop.

Fixes artifact-keeper/artifact-keeper#530

## Test Checklist
- [ ] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [x] N/A - no UI changes