### PR TITLE
fix: remove SSO callback rewrite workaround

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -63,18 +63,6 @@ const nextConfig: NextConfig = {
       },
     ];
   },
-  async rewrites() {
-    return [
-      // The backend redirects to /auth/callback after SSO code exchange,
-      // but the Next.js page lives in the (auth) route group which does
-      // not produce a URL segment. Rewrite so the page is reachable at
-      // both /callback and /auth/callback.
-      {
-        source: "/auth/callback",
-        destination: "/callback",
-      },
-    ];
-  },
   // API proxy is handled by src/middleware.ts at runtime (reads BACKEND_URL
   // env var on each request) so that Docker containers can be configured
   // without rebuilding.  See: https://github.com/artifact-keeper/artifact-keeper-web/issues/56


### PR DESCRIPTION
## Summary

- Removed the `rewrites()` block from `next.config.ts` that mapped `/auth/callback` to `/callback`
- This was a workaround for the backend redirecting to `/auth/callback` instead of `/callback`
- The backend fix (artifact-keeper/artifact-keeper#583) now redirects to `/callback` directly, making this rewrite unnecessary

## Changes

Removed ~12 lines from `next.config.ts` (the `async rewrites()` method).

## Test plan

- [x] `npm run build` succeeds
- [ ] Manual SSO login flow: verify redirect lands on `/callback` and token exchange completes

Related: artifact-keeper/artifact-keeper#583