### PR TITLE
fix(devops): exclude pre-release tags from Docker Hub :latest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -140,7 +140,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Extract metadata (Docker Hub)
@@ -155,7 +155,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Create manifest list and push (ghcr.io)


### PR DESCRIPTION
## Summary
- Add `!contains(github.ref, '-')` guard to prevent pre-release tags (e.g. v1.1.0-rc.2) from being tagged as `:latest` on Docker Hub
- Matches the existing correct pattern already in ci.yml

## Test plan
- [ ] Tag push `v1.0.0` sets `:latest` on Docker Hub
- [ ] Tag push `v1.1.0-rc.1` does NOT set `:latest` on Docker Hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)