### PR TITLE
fix: refresh auth context after SSO callback token exchange

### DIFF
--- a/src/app/(auth)/callback/page.tsx
+++ b/src/app/(auth)/callback/page.tsx
@@ -6,6 +6,7 @@ import { Loader2 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import { useAuth } from "@/providers/auth-provider";
 
 function getSsoErrorMessage(errorCode: string | null): string {
   const messages: Record<string, string> = {
@@ -23,6 +24,7 @@ function getSsoErrorMessage(errorCode: string | null): string {
 function CallbackHandler() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { refreshUser } = useAuth();
 
   const code = searchParams.get("code");
   const urlError = searchParams.get("error");
@@ -67,6 +69,7 @@ function CallbackHandler() {
 
         // Tokens are now set as httpOnly cookies by the backend.
         // No need to store them in localStorage.
+        await refreshUser();
         router.replace("/");
       } catch {
         setError("Failed to complete sign-in. Please try again.");
@@ -74,7 +77,7 @@ function CallbackHandler() {
     };
 
     exchangeCode();
-  }, [code, immediateError, router]);
+  }, [code, immediateError, refreshUser, router]);
 
   if (error) {
     return (


### PR DESCRIPTION
## Summary

After OIDC/SSO login, the sidebar and navigation stay in the anonymous state until a manual page reload. The `login()` function in `auth-provider.tsx` correctly calls `refreshUser()` after authentication, but the SSO callback page only calls `router.replace("/")` without updating the auth context first.

This adds a `refreshUser()` call after the token exchange so the `AuthProvider` picks up the new session cookies and the UI renders the authenticated menu immediately.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [ ] No regressions in existing tests

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [x] N/A - no UI changes