### PR TITLE
chore: use self-hosted runners for CI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            runner: ubuntu-24.04
+            runner: ak-ci-runners
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
 


### PR DESCRIPTION
## Summary

Switch the amd64 Docker build job from GitHub-hosted `ubuntu-24.04` to the self-hosted `ak-ci-runners` scale set on the K8s cluster. ARM64 builds remain on `ubuntu-24.04-arm` since the cluster is x86 only.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [x] N/A - no UI changes