### PR TITLE
Fix CVE findings showing GHSA instead of CVE identifier

### DIFF
--- a/src/app/(app)/(admin)/security/dt-projects/[uuid]/page.tsx
+++ b/src/app/(app)/(admin)/security/dt-projects/[uuid]/page.tsx
@@ -15,7 +15,6 @@ import {
   Package,
   Scale,
   BarChart3,
-  ExternalLink,
   Filter,
   CheckSquare,
   Loader2,
@@ -57,6 +56,7 @@ import {
 
 import { StatCard } from "@/components/common/stat-card";
 import { DataTable, type DataTableColumn } from "@/components/common/data-table";
+import { VulnIdLink } from "@/components/common/vuln-id-link";
 
 // -- constants --
 
@@ -145,7 +145,6 @@ function FindingTriageRow({
   };
 
   const vulnId = finding.vulnerability.vulnId;
-  const isCve = vulnId.startsWith("CVE-");
 
   return (
     <>
@@ -182,20 +181,11 @@ function FindingTriageRow({
         </td>
         {/* Vulnerability */}
         <td className="px-3 py-2.5">
-          {isCve ? (
-            <a
-              href={`https://nvd.nist.gov/vuln/detail/${vulnId}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-sm text-primary hover:underline inline-flex items-center gap-1"
-              onClick={(e) => e.stopPropagation()}
-            >
-              {vulnId}
-              <ExternalLink className="size-3" />
-            </a>
-          ) : (
-            <span className="text-sm font-medium">{vulnId}</span>
-          )}
+          <VulnIdLink
+            id={vulnId}
+            source={finding.vulnerability.source}
+            showIcon
+          />
         </td>
         {/* CVSS */}
         <td className="px-3 py-2.5">

--- a/src/app/(app)/(admin)/security/scans/[id]/page.tsx
+++ b/src/app/(app)/(admin)/security/scans/[id]/page.tsx
@@ -43,6 +43,7 @@ import {
 import { StatCard } from "@/components/common/stat-card";
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
 import { DataTable, type DataTableColumn } from "@/components/common/data-table";
+import { VulnIdLink } from "@/components/common/vuln-id-link";
 
 // -- constants --
 
@@ -234,19 +235,11 @@ export default function SecurityScanDetailPage() {
     },
     {
       id: "cve_id",
-      header: "CVE",
+      header: "Advisory",
       accessor: (r) => r.cve_id ?? "",
       cell: (r) =>
         r.cve_id ? (
-          <a
-            href={`https://nvd.nist.gov/vuln/detail/${r.cve_id}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-sm text-primary hover:underline"
-            onClick={(e) => e.stopPropagation()}
-          >
-            {r.cve_id}
-          </a>
+          <VulnIdLink id={r.cve_id} />
         ) : (
           <span className="text-sm text-muted-foreground">-</span>
         ),

--- a/src/app/(app)/repositories/_components/sbom-tab-content.tsx
+++ b/src/app/(app)/repositories/_components/sbom-tab-content.tsx
@@ -22,6 +22,7 @@ import { toUserMessage } from "@/lib/error-utils";
 import type { SbomComponent, SbomFormat, CveHistoryEntry } from "@/types/sbom";
 import type { Artifact } from "@/types";
 
+import { VulnIdLink } from "@/components/common/vuln-id-link";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -414,7 +415,7 @@ function CveHistoryRow({ cve }: { cve: CveHistoryEntry }) {
       />
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
-          <span className="font-medium text-sm">{cve.cve_id}</span>
+          <VulnIdLink id={cve.cve_id} />
           {cve.severity && (
             <Badge
               variant="outline"

--- a/src/app/(app)/repositories/_components/security-tab-content.tsx
+++ b/src/app/(app)/repositories/_components/security-tab-content.tsx
@@ -39,6 +39,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { DataTable, type DataTableColumn } from "@/components/common/data-table";
+import { VulnIdLink } from "@/components/common/vuln-id-link";
 
 // ---------------------------------------------------------------------------
 // Props
@@ -249,10 +250,10 @@ export function SecurityTabContent({ artifact }: SecurityTabContentProps) {
   const columns: DataTableColumn<CveHistoryEntry>[] = [
     {
       id: "cve_id",
-      header: "CVE ID",
+      header: "Advisory",
       accessor: (c) => c.cve_id,
       sortable: true,
-      cell: (c) => <span className="font-medium text-sm font-mono">{c.cve_id}</span>,
+      cell: (c) => <VulnIdLink id={c.cve_id} />,
     },
     {
       id: "severity",
@@ -370,14 +371,14 @@ export function SecurityTabContent({ artifact }: SecurityTabContentProps) {
   const dtFindingsColumns: DataTableColumn<DtFinding>[] = [
     {
       id: "vulnId",
-      header: "Vuln ID",
+      header: "Advisory",
       accessor: (f) => f.vulnerability.vulnId,
       sortable: true,
       cell: (f) => (
-        <div>
-          <span className="font-medium text-sm font-mono">{f.vulnerability.vulnId}</span>
-          <span className="ml-1.5 text-xs text-muted-foreground">{f.vulnerability.source}</span>
-        </div>
+        <VulnIdLink
+          id={f.vulnerability.vulnId}
+          source={f.vulnerability.source}
+        />
       ),
     },
     {

--- a/src/components/common/__tests__/vuln-id-link.test.tsx
+++ b/src/components/common/__tests__/vuln-id-link.test.tsx
@@ -133,4 +133,78 @@ describe("VulnIdLink", () => {
 
     expect(container.firstChild).toHaveClass("my-custom-class");
   });
+
+  it("applies custom className to the outer element for unlinked identifiers", () => {
+    const { container } = render(
+      <VulnIdLink id="PYSEC-2024-42" className="custom-plain" />
+    );
+
+    expect(container.firstChild).toHaveClass("custom-plain");
+  });
+
+  // ---- showIcon with GHSA ----
+
+  it("shows the external link icon for GHSA IDs when showIcon is true", () => {
+    render(<VulnIdLink id="GHSA-abcd-efgh-ijkl" showIcon />);
+
+    expect(screen.getByTestId("icon-external-link")).toBeInTheDocument();
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "href",
+      "https://github.com/advisories/GHSA-abcd-efgh-ijkl"
+    );
+  });
+
+  it("does not render an icon for unlinked identifiers regardless of showIcon", () => {
+    render(<VulnIdLink id="PYSEC-2024-42" showIcon />);
+
+    // showIcon only applies within the anchor tag, so unlinked IDs never show it
+    expect(screen.queryByTestId("icon-external-link")).not.toBeInTheDocument();
+  });
+
+  // ---- source prop with showIcon ----
+
+  it("renders GHSA link with source override and icon", () => {
+    render(
+      <VulnIdLink id="GHSA-abcd-efgh-ijkl" source="GitHub" showIcon />
+    );
+
+    expect(screen.getByRole("link")).toBeInTheDocument();
+    expect(screen.getByText("GitHub")).toBeInTheDocument();
+    expect(screen.queryByText("GHSA")).not.toBeInTheDocument();
+    expect(screen.getByTestId("icon-external-link")).toBeInTheDocument();
+  });
+
+  it("renders source label alongside plain text for unknown IDs with source", () => {
+    render(<VulnIdLink id="RUSTSEC-2024-1" source="RustSec" />);
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.getByText("RUSTSEC-2024-1")).toBeInTheDocument();
+    expect(screen.getByText("RustSec")).toBeInTheDocument();
+  });
+
+  // ---- empty string source ----
+
+  it("treats empty string source the same as an explicit value", () => {
+    render(<VulnIdLink id="CVE-2024-5678" source="" />);
+
+    // Empty string is truthy for the ?? operator, so it becomes the sourceLabel
+    // The component uses source ?? ..., and "" is not nullish, so it uses ""
+    // which results in no visible label text (empty span)
+    expect(screen.queryByText("CVE")).not.toBeInTheDocument();
+  });
+
+  // ---- click behavior on plain text ----
+
+  it("does not call stopPropagation for unlinked identifiers (no link to click)", () => {
+    const parentClick = vi.fn();
+
+    render(
+      <div onClick={parentClick}>
+        <VulnIdLink id="PYSEC-2024-42" />
+      </div>
+    );
+
+    fireEvent.click(screen.getByText("PYSEC-2024-42"));
+    expect(parentClick).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/components/common/__tests__/vuln-id-link.test.tsx
+++ b/src/components/common/__tests__/vuln-id-link.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+
+vi.mock("lucide-react", () => ({
+  ExternalLink: (props: Record<string, unknown>) => (
+    <span data-testid="icon-external-link" {...props} />
+  ),
+}));
+
+import { VulnIdLink } from "../vuln-id-link";
+
+describe("VulnIdLink", () => {
+  afterEach(cleanup);
+
+  // ---- CVE identifiers ----
+
+  it("renders a link to NVD for CVE IDs", () => {
+    render(<VulnIdLink id="CVE-2024-1234" />);
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute(
+      "href",
+      "https://nvd.nist.gov/vuln/detail/CVE-2024-1234"
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    expect(link).toHaveTextContent("CVE-2024-1234");
+  });
+
+  it("shows auto-detected CVE source label", () => {
+    render(<VulnIdLink id="CVE-2024-1234" />);
+
+    expect(screen.getByText("CVE")).toBeInTheDocument();
+  });
+
+  // ---- GHSA identifiers ----
+
+  it("renders a link to GitHub advisories for GHSA IDs", () => {
+    render(<VulnIdLink id="GHSA-abcd-efgh-ijkl" />);
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute(
+      "href",
+      "https://github.com/advisories/GHSA-abcd-efgh-ijkl"
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveTextContent("GHSA-abcd-efgh-ijkl");
+  });
+
+  it("shows auto-detected GHSA source label", () => {
+    render(<VulnIdLink id="GHSA-abcd-efgh-ijkl" />);
+
+    expect(screen.getByText("GHSA")).toBeInTheDocument();
+  });
+
+  // ---- Unknown identifiers ----
+
+  it("renders plain text for unknown ID formats", () => {
+    render(<VulnIdLink id="PYSEC-2024-42" />);
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.getByText("PYSEC-2024-42")).toBeInTheDocument();
+  });
+
+  it("does not show a source label for unknown ID formats", () => {
+    render(<VulnIdLink id="PYSEC-2024-42" />);
+
+    // vulnIdType returns "Advisory" for unknown, and the component
+    // suppresses the label when type is "Advisory" and no source is given
+    expect(screen.queryByText("Advisory")).not.toBeInTheDocument();
+  });
+
+  // ---- source prop override ----
+
+  it("source prop overrides auto-detected source label", () => {
+    render(<VulnIdLink id="CVE-2024-1234" source="Trivy" />);
+
+    expect(screen.getByText("Trivy")).toBeInTheDocument();
+    expect(screen.queryByText("CVE")).not.toBeInTheDocument();
+  });
+
+  it("source prop adds a label even for unknown identifier types", () => {
+    render(<VulnIdLink id="PYSEC-2024-42" source="OSV" />);
+
+    expect(screen.getByText("OSV")).toBeInTheDocument();
+  });
+
+  it("null source falls back to auto-detected label", () => {
+    render(<VulnIdLink id="GHSA-abcd-efgh-ijkl" source={null} />);
+
+    expect(screen.getByText("GHSA")).toBeInTheDocument();
+  });
+
+  // ---- click handler ----
+
+  it("click handler calls stopPropagation on linked identifiers", () => {
+    const parentClick = vi.fn();
+
+    render(
+      <div onClick={parentClick}>
+        <VulnIdLink id="CVE-2024-1234" />
+      </div>
+    );
+
+    const link = screen.getByRole("link");
+    fireEvent.click(link);
+
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+
+  // ---- showIcon prop ----
+
+  it("shows the external link icon when showIcon is true", () => {
+    render(<VulnIdLink id="CVE-2024-1234" showIcon />);
+
+    expect(screen.getByTestId("icon-external-link")).toBeInTheDocument();
+  });
+
+  it("hides the external link icon by default", () => {
+    render(<VulnIdLink id="CVE-2024-1234" />);
+
+    expect(screen.queryByTestId("icon-external-link")).not.toBeInTheDocument();
+  });
+
+  // ---- className prop ----
+
+  it("applies custom className to the outer element", () => {
+    const { container } = render(
+      <VulnIdLink id="CVE-2024-1234" className="my-custom-class" />
+    );
+
+    expect(container.firstChild).toHaveClass("my-custom-class");
+  });
+});

--- a/src/components/common/vuln-id-link.tsx
+++ b/src/components/common/vuln-id-link.tsx
@@ -1,0 +1,64 @@
+import { ExternalLink } from "lucide-react";
+import { advisoryUrl, vulnIdType } from "@/lib/vuln-utils";
+
+interface VulnIdLinkProps {
+  /** The vulnerability identifier (CVE-xxxx, GHSA-xxxx, or other). */
+  id: string;
+  /** Optional source label displayed after the identifier (e.g. "NVD", "GHSA"). */
+  source?: string | null;
+  /** Additional CSS classes applied to the outer element. */
+  className?: string;
+  /** Whether to show an external link icon next to linked identifiers. */
+  showIcon?: boolean;
+}
+
+/**
+ * Renders a vulnerability identifier as a link when possible.
+ *
+ * CVE identifiers link to NVD. GHSA identifiers link to GitHub Advisories.
+ * Unknown identifier formats render as plain text.
+ */
+export function VulnIdLink({
+  id,
+  source,
+  className,
+  showIcon = false,
+}: VulnIdLinkProps) {
+  const url = advisoryUrl(id);
+  const type = vulnIdType(id);
+
+  const sourceLabel = source ?? (type !== "Advisory" ? type : null);
+
+  if (url) {
+    return (
+      <div className={className}>
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm text-primary hover:underline inline-flex items-center gap-1 font-mono font-medium"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {id}
+          {showIcon && <ExternalLink className="size-3" />}
+        </a>
+        {sourceLabel && (
+          <span className="ml-1.5 text-xs text-muted-foreground">
+            {sourceLabel}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className={className}>
+      <span className="font-medium text-sm font-mono">{id}</span>
+      {sourceLabel && (
+        <span className="ml-1.5 text-xs text-muted-foreground">
+          {sourceLabel}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/lib/__tests__/vuln-utils.test.ts
+++ b/src/lib/__tests__/vuln-utils.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import {
+  isCveId,
+  isGhsaId,
+  advisoryUrl,
+  vulnIdType,
+} from "../vuln-utils";
+
+describe("isCveId", () => {
+  it("returns true for standard CVE identifiers", () => {
+    expect(isCveId("CVE-2024-1234")).toBe(true);
+    expect(isCveId("CVE-2023-45678")).toBe(true);
+    expect(isCveId("CVE-2020-0001")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isCveId("cve-2024-1234")).toBe(true);
+  });
+
+  it("returns false for non-CVE identifiers", () => {
+    expect(isCveId("GHSA-abcd-efgh-ijkl")).toBe(false);
+    expect(isCveId("")).toBe(false);
+    expect(isCveId("CVE-")).toBe(false);
+    expect(isCveId("CVE-2024")).toBe(false);
+    expect(isCveId("some-random-string")).toBe(false);
+  });
+});
+
+describe("isGhsaId", () => {
+  it("returns true for standard GHSA identifiers", () => {
+    expect(isGhsaId("GHSA-abcd-efgh-ijkl")).toBe(true);
+    expect(isGhsaId("GHSA-1234-5678-9abc")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isGhsaId("ghsa-abcd-efgh-ijkl")).toBe(true);
+  });
+
+  it("returns false for non-GHSA identifiers", () => {
+    expect(isGhsaId("CVE-2024-1234")).toBe(false);
+    expect(isGhsaId("")).toBe(false);
+    expect(isGhsaId("GHSA-")).toBe(false);
+    expect(isGhsaId("GHSA-abc-efgh-ijkl")).toBe(false);
+    expect(isGhsaId("some-random-string")).toBe(false);
+  });
+});
+
+describe("advisoryUrl", () => {
+  it("returns NVD URL for CVE identifiers", () => {
+    expect(advisoryUrl("CVE-2024-1234")).toBe(
+      "https://nvd.nist.gov/vuln/detail/CVE-2024-1234"
+    );
+  });
+
+  it("returns GitHub advisory URL for GHSA identifiers", () => {
+    expect(advisoryUrl("GHSA-abcd-efgh-ijkl")).toBe(
+      "https://github.com/advisories/GHSA-abcd-efgh-ijkl"
+    );
+  });
+
+  it("returns null for unknown identifier formats", () => {
+    expect(advisoryUrl("some-random-string")).toBeNull();
+    expect(advisoryUrl("")).toBeNull();
+  });
+});
+
+describe("vulnIdType", () => {
+  it("classifies CVE identifiers", () => {
+    expect(vulnIdType("CVE-2024-1234")).toBe("CVE");
+  });
+
+  it("classifies GHSA identifiers", () => {
+    expect(vulnIdType("GHSA-abcd-efgh-ijkl")).toBe("GHSA");
+  });
+
+  it("classifies unknown identifiers as Advisory", () => {
+    expect(vulnIdType("PYSEC-2024-1")).toBe("Advisory");
+    expect(vulnIdType("")).toBe("Advisory");
+  });
+});

--- a/src/lib/vuln-utils.ts
+++ b/src/lib/vuln-utils.ts
@@ -1,0 +1,44 @@
+/**
+ * Utility functions for vulnerability identifier handling.
+ *
+ * Vulnerability findings can carry different identifier types (CVE, GHSA, etc.).
+ * These helpers determine the correct display label and advisory URL for each type.
+ */
+
+/** Check whether an identifier looks like a CVE (e.g. CVE-2024-1234). */
+export function isCveId(id: string): boolean {
+  return /^CVE-\d{4}-\d+$/i.test(id);
+}
+
+/** Check whether an identifier looks like a GitHub Security Advisory (e.g. GHSA-xxxx-xxxx-xxxx). */
+export function isGhsaId(id: string): boolean {
+  return /^GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}$/i.test(id);
+}
+
+/**
+ * Return the appropriate advisory URL for a vulnerability identifier.
+ *
+ * - CVE identifiers link to NVD: https://nvd.nist.gov/vuln/detail/CVE-XXXX-XXXXX
+ * - GHSA identifiers link to GitHub: https://github.com/advisories/GHSA-xxxx-xxxx-xxxx
+ * - Unknown formats return null (no link).
+ */
+export function advisoryUrl(id: string): string | null {
+  if (isCveId(id)) {
+    return `https://nvd.nist.gov/vuln/detail/${id}`;
+  }
+  if (isGhsaId(id)) {
+    return `https://github.com/advisories/${id}`;
+  }
+  return null;
+}
+
+/**
+ * Classify a vulnerability identifier string for display purposes.
+ *
+ * Returns the identifier type as a short label ("CVE", "GHSA", or "Advisory").
+ */
+export function vulnIdType(id: string): "CVE" | "GHSA" | "Advisory" {
+  if (isCveId(id)) return "CVE";
+  if (isGhsaId(id)) return "GHSA";
+  return "Advisory";
+}


### PR DESCRIPTION
## Summary

Vulnerability scan findings were displaying GHSA identifiers (e.g., GHSA-xxxx-xxxx-xxxx) in the CVE column and generating broken NVD links using those GHSA IDs. This fix introduces a shared `VulnIdLink` component and `vuln-utils` helper module that detect the identifier type and link to the correct advisory source: CVEs to NVD, GHSAs to GitHub Advisories, and unknown formats as plain text.

The fix applies across all locations where vulnerability identifiers are displayed:
- Scan detail page (`/security/scans/[id]`)
- Security tab on repository artifact pages (CVE history table)
- Security tab DT findings table
- SBOM tab CVE history rows
- DT project detail page (`/security/dt-projects/[uuid]`)

Fixes #257

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [ ] Playwright E2E spec covers the change
- [x] Responsive layout verified (mobile + desktop)
- [x] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes