### PR TITLE
feat: display password policy requirements on password fields

### DIFF
--- a/src/app/(app)/(admin)/settings/page.tsx
+++ b/src/app/(app)/(admin)/settings/page.tsx
@@ -3,6 +3,7 @@
 import { useAuth } from "@/providers/auth-provider";
 import { useQuery } from "@tanstack/react-query";
 import { adminApi } from "@/lib/api/admin";
+import { settingsApi } from "@/lib/api/settings";
 import { Server, HardDrive, Lock, Info } from "lucide-react";
 
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
@@ -14,6 +15,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Separator } from "@/components/ui/separator";
 
 import { PageHeader } from "@/components/common/page-header";
+import type { PasswordPolicy } from "@/lib/api/settings";
 
 // -- helpers --
 
@@ -37,6 +39,23 @@ function SettingRow({
   );
 }
 
+function formatPasswordPolicy(policy: PasswordPolicy | undefined): string {
+  if (!policy) return "Loading...";
+  const parts = [`Minimum ${policy.min_length} characters`];
+  const complexity: string[] = [];
+  if (policy.require_uppercase) complexity.push("uppercase");
+  if (policy.require_lowercase) complexity.push("lowercase");
+  if (policy.require_digit) complexity.push("number");
+  if (policy.require_special) complexity.push("special character");
+  if (complexity.length > 0) {
+    parts.push(`requires ${complexity.join(", ")}`);
+  }
+  if (policy.history_count > 0) {
+    parts.push(`${policy.history_count} password history`);
+  }
+  return parts.join("; ");
+}
+
 // -- page --
 
 export default function SettingsPage() {
@@ -44,6 +63,13 @@ export default function SettingsPage() {
   const { data: health } = useQuery({
     queryKey: ["health"],
     queryFn: () => adminApi.getHealth(),
+  });
+
+  const { data: passwordPolicy } = useQuery({
+    queryKey: ["password-policy"],
+    queryFn: () => settingsApi.getPasswordPolicy(),
+    staleTime: 5 * 60 * 1000,
+    retry: false,
   });
 
   if (!user?.is_admin) {
@@ -210,7 +236,7 @@ export default function SettingsPage() {
               <Separator />
               <SettingRow
                 label="Password Policy"
-                value="Minimum 8 characters"
+                value={formatPasswordPolicy(passwordPolicy)}
                 description="Minimum password requirements for user accounts."
               />
             </CardContent>

--- a/src/app/(app)/(admin)/users/__tests__/page.test.tsx
+++ b/src/app/(app)/(admin)/users/__tests__/page.test.tsx
@@ -32,6 +32,8 @@ vi.mock("lucide-react", () => {
     Copy: stub("Copy"),
     Users: stub("Users"),
     ShieldCheck: stub("ShieldCheck"),
+    Check: stub("Check"),
+    X: stub("X"),
   };
 });
 
@@ -97,6 +99,26 @@ vi.mock("@/lib/api/admin", () => ({
 }));
 
 vi.mock("@/lib/api/profile", () => ({}));
+vi.mock("@/lib/api/settings", () => ({
+  settingsApi: {
+    getPasswordPolicy: vi.fn().mockResolvedValue({
+      min_length: 8,
+      require_uppercase: true,
+      require_lowercase: true,
+      require_digit: true,
+      require_special: false,
+      history_count: 5,
+    }),
+    DEFAULT_PASSWORD_POLICY: {
+      min_length: 8,
+      require_uppercase: true,
+      require_lowercase: true,
+      require_digit: true,
+      require_special: false,
+      history_count: 5,
+    },
+  },
+}));
 vi.mock("@/lib/query-keys", () => ({
   invalidateGroup: vi.fn(),
 }));

--- a/src/app/(app)/(admin)/users/page.tsx
+++ b/src/app/(app)/(admin)/users/page.tsx
@@ -55,6 +55,7 @@ import { DataTable, type DataTableColumn } from "@/components/common/data-table"
 import { StatusBadge } from "@/components/common/status-badge";
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
 import { EmptyState } from "@/components/common/empty-state";
+import { PasswordPolicyHint } from "@/components/common/password-policy-hint";
 
 // -- helpers --
 
@@ -590,31 +591,34 @@ export default function UsersPage() {
                 </div>
               </div>
               {!createForm.auto_generate && (
-                <div className="flex gap-2">
-                  <Input
-                    id="create-password"
-                    type="text"
-                    placeholder="Enter password"
-                    value={createForm.password}
-                    onChange={(e) =>
-                      setCreateForm((f) => ({ ...f, password: e.target.value }))
-                    }
-                    required
-                  />
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() =>
-                      setCreateForm((f) => ({
-                        ...f,
-                        password: generateRandomPassword(),
-                      }))
-                    }
-                  >
-                    Generate
-                  </Button>
-                </div>
+                <>
+                  <div className="flex gap-2">
+                    <Input
+                      id="create-password"
+                      type="text"
+                      placeholder="Enter password"
+                      value={createForm.password}
+                      onChange={(e) =>
+                        setCreateForm((f) => ({ ...f, password: e.target.value }))
+                      }
+                      required
+                    />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() =>
+                        setCreateForm((f) => ({
+                          ...f,
+                          password: generateRandomPassword(),
+                        }))
+                      }
+                    >
+                      Generate
+                    </Button>
+                  </div>
+                  <PasswordPolicyHint password={createForm.password} />
+                </>
               )}
             </div>
             <div className="flex items-center gap-3">

--- a/src/app/(app)/(protected)/profile/page.tsx
+++ b/src/app/(app)/(protected)/profile/page.tsx
@@ -46,6 +46,7 @@ import {
 
 import { PageHeader } from "@/components/common/page-header";
 import { CopyButton } from "@/components/common/copy-button";
+import { PasswordPolicyHint } from "@/components/common/password-policy-hint";
 
 // -- Profile Page --
 
@@ -237,15 +238,6 @@ export default function ProfilePage() {
               </CardDescription>
             </CardHeader>
             <CardContent>
-              <Alert className="mb-6">
-                <Info className="size-4" />
-                <AlertTitle>Password requirements</AlertTitle>
-                <AlertDescription>
-                  Your password must be at least 8 characters long. We recommend
-                  using a combination of letters, numbers, and special
-                  characters.
-                </AlertDescription>
-              </Alert>
               <form
                 className="space-y-4 max-w-md"
                 onSubmit={(e) => {
@@ -283,6 +275,7 @@ export default function ProfilePage() {
                     required
                     minLength={8}
                   />
+                  <PasswordPolicyHint password={newPassword} />
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="confirm-password">Confirm New Password</Label>

--- a/src/app/(auth)/change-password/page.tsx
+++ b/src/app/(auth)/change-password/page.tsx
@@ -26,6 +26,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
+import { PasswordPolicyHint } from "@/components/common/password-policy-hint";
 
 const changePasswordSchema = z
   .object({
@@ -132,6 +133,7 @@ export default function ChangePasswordPage() {
                       {...field}
                     />
                   </FormControl>
+                  <PasswordPolicyHint password={field.value} className="mt-1" />
                   <FormMessage />
                 </FormItem>
               )}

--- a/src/components/common/__tests__/password-policy-hint.test.tsx
+++ b/src/components/common/__tests__/password-policy-hint.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+vi.mock("lucide-react", () => ({
+  Check: (props: any) => <span data-testid="icon-check" {...props} />,
+  X: (props: any) => <span data-testid="icon-x" {...props} />,
+}));
+
+const mockGetPasswordPolicy = vi.fn();
+
+vi.mock("@/lib/api/settings", () => ({
+  settingsApi: {
+    getPasswordPolicy: (...args: unknown[]) => mockGetPasswordPolicy(...args),
+    DEFAULT_PASSWORD_POLICY: {
+      min_length: 8,
+      require_uppercase: true,
+      require_lowercase: true,
+      require_digit: true,
+      require_special: false,
+      history_count: 5,
+    },
+  },
+}));
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+// Mock TanStack Query to return data synchronously
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: undefined, isLoading: false, error: null }),
+}));
+
+import { PasswordPolicyHint } from "@/components/common/password-policy-hint";
+
+describe("PasswordPolicyHint", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("renders the requirements heading", () => {
+    render(<PasswordPolicyHint />);
+    expect(screen.getByText("Password requirements")).toBeInTheDocument();
+  });
+
+  it("renders the minimum length requirement", () => {
+    render(<PasswordPolicyHint />);
+    expect(screen.getByText("Minimum 8 characters")).toBeInTheDocument();
+  });
+
+  it("renders uppercase requirement when required", () => {
+    render(<PasswordPolicyHint />);
+    expect(
+      screen.getByText("At least one uppercase letter")
+    ).toBeInTheDocument();
+  });
+
+  it("renders lowercase requirement when required", () => {
+    render(<PasswordPolicyHint />);
+    expect(
+      screen.getByText("At least one lowercase letter")
+    ).toBeInTheDocument();
+  });
+
+  it("renders digit requirement when required", () => {
+    render(<PasswordPolicyHint />);
+    expect(screen.getByText("At least one number")).toBeInTheDocument();
+  });
+
+  it("renders password history notice", () => {
+    render(<PasswordPolicyHint />);
+    expect(
+      screen.getByText("Cannot reuse your last 5 passwords")
+    ).toBeInTheDocument();
+  });
+
+  it("does not render special character requirement when not required", () => {
+    render(<PasswordPolicyHint />);
+    expect(
+      screen.queryByText("At least one special character")
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows neutral indicators when no password is provided", () => {
+    render(<PasswordPolicyHint />);
+    // No check or X icons should appear when password is empty
+    expect(screen.queryAllByTestId("icon-check")).toHaveLength(0);
+    expect(screen.queryAllByTestId("icon-x")).toHaveLength(0);
+  });
+
+  it("shows check icons for met rules when password is provided", () => {
+    render(<PasswordPolicyHint password="Abcdefgh1" />);
+    // Length (9 >= 8), uppercase (A), lowercase (bcdefgh), digit (1) should all pass
+    const checks = screen.getAllByTestId("icon-check");
+    expect(checks.length).toBe(4);
+  });
+
+  it("shows X icons for unmet rules when password is provided", () => {
+    render(<PasswordPolicyHint password="abc" />);
+    // Length not met, no uppercase, lowercase met, no digit
+    const xs = screen.getAllByTestId("icon-x");
+    expect(xs.length).toBeGreaterThan(0);
+  });
+
+  it("has correct aria-label on container", () => {
+    render(<PasswordPolicyHint />);
+    const list = screen.getByRole("list", { name: "Password requirements" });
+    expect(list).toBeInTheDocument();
+  });
+
+  it("renders list items with role", () => {
+    render(<PasswordPolicyHint />);
+    const items = screen.getAllByRole("listitem");
+    // min length + uppercase + lowercase + digit + history = 5 items
+    expect(items.length).toBe(5);
+  });
+
+  it("applies additional className", () => {
+    render(<PasswordPolicyHint className="mt-4" />);
+    const list = screen.getByRole("list");
+    expect(list.className).toContain("mt-4");
+  });
+});

--- a/src/components/common/password-policy-hint.tsx
+++ b/src/components/common/password-policy-hint.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { Check, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { settingsApi, type PasswordPolicy } from "@/lib/api/settings";
+
+interface PasswordPolicyHintProps {
+  /** The current password value to validate against policy rules */
+  password?: string;
+  /** Additional CSS classes for the container */
+  className?: string;
+}
+
+interface PolicyRule {
+  label: string;
+  met: boolean;
+}
+
+function buildRules(password: string, policy: PasswordPolicy): PolicyRule[] {
+  const rules: PolicyRule[] = [
+    {
+      label: `Minimum ${policy.min_length} characters`,
+      met: password.length >= policy.min_length,
+    },
+  ];
+
+  if (policy.require_uppercase) {
+    rules.push({
+      label: "At least one uppercase letter",
+      met: /[A-Z]/.test(password),
+    });
+  }
+
+  if (policy.require_lowercase) {
+    rules.push({
+      label: "At least one lowercase letter",
+      met: /[a-z]/.test(password),
+    });
+  }
+
+  if (policy.require_digit) {
+    rules.push({
+      label: "At least one number",
+      met: /\d/.test(password),
+    });
+  }
+
+  if (policy.require_special) {
+    rules.push({
+      label: "At least one special character",
+      met: /[^A-Za-z0-9]/.test(password),
+    });
+  }
+
+  if (policy.history_count > 0) {
+    rules.push({
+      label: `Cannot reuse your last ${policy.history_count} ${policy.history_count === 1 ? "password" : "passwords"}`,
+      // History check is server-side only; always show as neutral
+      met: false,
+    });
+  }
+
+  return rules;
+}
+
+/**
+ * Displays the active password policy requirements with live validation
+ * feedback. Fetches policy from the server settings endpoint and falls
+ * back to sensible defaults when the endpoint is unavailable.
+ */
+export function PasswordPolicyHint({
+  password = "",
+  className,
+}: PasswordPolicyHintProps) {
+  const { data: policy } = useQuery({
+    queryKey: ["password-policy"],
+    queryFn: () => settingsApi.getPasswordPolicy(),
+    staleTime: 5 * 60 * 1000, // cache for 5 minutes
+    retry: false,
+  });
+
+  const effectivePolicy = policy ?? settingsApi.DEFAULT_PASSWORD_POLICY;
+  const rules = buildRules(password, effectivePolicy);
+  const hasInput = password.length > 0;
+
+  return (
+    <div
+      className={cn("space-y-1.5", className)}
+      role="list"
+      aria-label="Password requirements"
+    >
+      <p className="text-xs font-medium text-muted-foreground">
+        Password requirements
+      </p>
+      {rules.map((rule) => {
+        // For history rules, never show a check since we can't validate client-side
+        const isHistoryRule = rule.label.startsWith("Cannot reuse");
+        const showStatus = hasInput && !isHistoryRule;
+
+        return (
+          <div
+            key={rule.label}
+            className="flex items-center gap-1.5"
+            role="listitem"
+          >
+            {showStatus ? (
+              rule.met ? (
+                <Check
+                  className="size-3.5 shrink-0 text-green-600 dark:text-green-400"
+                  aria-hidden="true"
+                />
+              ) : (
+                <X
+                  className="size-3.5 shrink-0 text-destructive"
+                  aria-hidden="true"
+                />
+              )
+            ) : (
+              <span className="size-3.5 shrink-0 flex items-center justify-center">
+                <span className="size-1 rounded-full bg-muted-foreground/40" />
+              </span>
+            )}
+            <span
+              className={cn(
+                "text-xs",
+                showStatus && rule.met
+                  ? "text-green-600 dark:text-green-400"
+                  : showStatus && !rule.met
+                    ? "text-destructive"
+                    : "text-muted-foreground"
+              )}
+            >
+              {rule.label}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/api/__tests__/settings.test.ts
+++ b/src/lib/api/__tests__/settings.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/sdk-client", () => ({}));
+
+const mockGetSettings = vi.fn();
+
+vi.mock("@artifact-keeper/sdk", () => ({
+  getSettings: (...args: unknown[]) => mockGetSettings(...args),
+}));
+
+describe("settingsApi", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("getPasswordPolicy returns defaults when server has no policy fields", async () => {
+    mockGetSettings.mockResolvedValue({
+      data: { storage_backend: "fs", storage_path: "/data" },
+      error: undefined,
+    });
+    const mod = await import("../settings");
+    const policy = await mod.settingsApi.getPasswordPolicy();
+    expect(policy).toEqual(mod.settingsApi.DEFAULT_PASSWORD_POLICY);
+  });
+
+  it("getPasswordPolicy extracts nested password_policy object", async () => {
+    mockGetSettings.mockResolvedValue({
+      data: {
+        password_policy: {
+          min_length: 12,
+          require_uppercase: false,
+          require_lowercase: true,
+          require_digit: true,
+          require_special: true,
+          history_count: 10,
+        },
+      },
+      error: undefined,
+    });
+    const mod = await import("../settings");
+    const policy = await mod.settingsApi.getPasswordPolicy();
+    expect(policy.min_length).toBe(12);
+    expect(policy.require_uppercase).toBe(false);
+    expect(policy.require_special).toBe(true);
+    expect(policy.history_count).toBe(10);
+  });
+
+  it("getPasswordPolicy reads flat password_min_length field", async () => {
+    mockGetSettings.mockResolvedValue({
+      data: { password_min_length: 16 },
+      error: undefined,
+    });
+    const mod = await import("../settings");
+    const policy = await mod.settingsApi.getPasswordPolicy();
+    expect(policy.min_length).toBe(16);
+  });
+
+  it("getPasswordPolicy reads flat password_history_count field", async () => {
+    mockGetSettings.mockResolvedValue({
+      data: { password_history_count: 3 },
+      error: undefined,
+    });
+    const mod = await import("../settings");
+    const policy = await mod.settingsApi.getPasswordPolicy();
+    expect(policy.history_count).toBe(3);
+  });
+
+  it("getPasswordPolicy returns defaults on SDK error", async () => {
+    mockGetSettings.mockResolvedValue({
+      data: undefined,
+      error: "unauthorized",
+    });
+    const mod = await import("../settings");
+    const policy = await mod.settingsApi.getPasswordPolicy();
+    expect(policy).toEqual(mod.settingsApi.DEFAULT_PASSWORD_POLICY);
+  });
+
+  it("getPasswordPolicy returns defaults when SDK throws", async () => {
+    mockGetSettings.mockRejectedValue(new Error("network error"));
+    const mod = await import("../settings");
+    const policy = await mod.settingsApi.getPasswordPolicy();
+    expect(policy).toEqual(mod.settingsApi.DEFAULT_PASSWORD_POLICY);
+  });
+
+  it("nested password_policy takes precedence over flat fields", async () => {
+    mockGetSettings.mockResolvedValue({
+      data: {
+        password_min_length: 6,
+        password_policy: { min_length: 20 },
+      },
+      error: undefined,
+    });
+    const mod = await import("../settings");
+    const policy = await mod.settingsApi.getPasswordPolicy();
+    expect(policy.min_length).toBe(20);
+  });
+});

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -1,0 +1,89 @@
+import "@/lib/sdk-client";
+import { getSettings } from "@artifact-keeper/sdk";
+
+export interface PasswordPolicy {
+  min_length: number;
+  require_uppercase: boolean;
+  require_lowercase: boolean;
+  require_digit: boolean;
+  require_special: boolean;
+  history_count: number;
+}
+
+/**
+ * Default password policy used when the server doesn't expose policy
+ * fields or the settings endpoint is unavailable. These match the
+ * backend defaults defined in the Rust configuration.
+ */
+const DEFAULT_PASSWORD_POLICY: PasswordPolicy = {
+  min_length: 8,
+  require_uppercase: true,
+  require_lowercase: true,
+  require_digit: true,
+  require_special: false,
+  history_count: 5,
+};
+
+export const settingsApi = {
+  DEFAULT_PASSWORD_POLICY,
+
+  /**
+   * Fetch the password policy from system settings.
+   *
+   * The /api/v1/admin/settings endpoint returns a SystemSettings object.
+   * The backend may include password_policy fields in the response even
+   * though the current SDK type definition doesn't declare them. We
+   * extract those fields if present and merge with defaults.
+   *
+   * TODO: Once the backend exposes password_policy as a typed field in
+   * the OpenAPI spec and the SDK regenerates, replace the `as unknown`
+   * cast with proper typed access.
+   */
+  getPasswordPolicy: async (): Promise<PasswordPolicy> => {
+    try {
+      const { data, error } = await getSettings();
+      if (error) return DEFAULT_PASSWORD_POLICY;
+
+      // The backend may return password policy fields that aren't yet
+      // typed in the SDK. Safely extract them from the raw response.
+      const raw = data as unknown as Record<string, unknown>;
+      const serverPolicy =
+        (raw?.password_policy as Partial<PasswordPolicy>) ?? {};
+
+      return {
+        min_length:
+          typeof serverPolicy.min_length === "number"
+            ? serverPolicy.min_length
+            : (typeof raw?.password_min_length === "number"
+                ? raw.password_min_length
+                : DEFAULT_PASSWORD_POLICY.min_length),
+        require_uppercase:
+          typeof serverPolicy.require_uppercase === "boolean"
+            ? serverPolicy.require_uppercase
+            : DEFAULT_PASSWORD_POLICY.require_uppercase,
+        require_lowercase:
+          typeof serverPolicy.require_lowercase === "boolean"
+            ? serverPolicy.require_lowercase
+            : DEFAULT_PASSWORD_POLICY.require_lowercase,
+        require_digit:
+          typeof serverPolicy.require_digit === "boolean"
+            ? serverPolicy.require_digit
+            : DEFAULT_PASSWORD_POLICY.require_digit,
+        require_special:
+          typeof serverPolicy.require_special === "boolean"
+            ? serverPolicy.require_special
+            : DEFAULT_PASSWORD_POLICY.require_special,
+        history_count:
+          typeof serverPolicy.history_count === "number"
+            ? serverPolicy.history_count
+            : (typeof raw?.password_history_count === "number"
+                ? raw.password_history_count
+                : DEFAULT_PASSWORD_POLICY.history_count),
+      };
+    } catch {
+      return DEFAULT_PASSWORD_POLICY;
+    }
+  },
+};
+
+export default settingsApi;


### PR DESCRIPTION
## Summary

Adds a `PasswordPolicyHint` component that shows live password policy requirements below password input fields. The component fetches the active policy from the admin settings API (`/api/v1/admin/settings`) and falls back to sensible defaults when the endpoint is unavailable or doesn't include password policy fields.

Password policy hints are now displayed in three locations:
- The forced change-password page (`/change-password`)
- The profile security tab (self-service password change)
- The admin create-user dialog (when manual password entry is selected)

The admin settings page also shows a dynamic password policy summary instead of a hardcoded "Minimum 8 characters" string.

Closes #252

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [ ] Playwright E2E spec covers the change
- [x] Responsive layout verified (mobile + desktop)
- [x] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes