### PR TITLE
Add /api/health endpoint for container health checks

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return NextResponse.json({
+    status: "healthy",
+    service: "artifact-keeper-web",
+    timestamp: new Date().toISOString(),
+  });
+}


### PR DESCRIPTION
## Summary

Add a lightweight `/api/health` API route that returns JSON with service status and timestamp. Docker healthchecks and Kubernetes liveness/readiness probes can hit this endpoint instead of `/`, which renders the full HTML page and is slower to respond.

The route handler returns:
```json
{
  "status": "healthy",
  "service": "artifact-keeper-web",
  "timestamp": "2026-04-17T..."
}
```

Closes #215

## Test Checklist
- [ ] Unit tests added/updated
- [x] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [x] N/A - no UI changes