### PR TITLE
fix: remove /simple/ suffix from PyPI setup page URLs

### DIFF
--- a/src/app/(app)/setup/page.tsx
+++ b/src/app/(app)/setup/page.tsx
@@ -98,12 +98,12 @@ npm config set //${REGISTRY_HOST}/npm/${repoKey}/:_authToken YOUR_TOKEN`,
           title: "Configure pip",
           description: "Add to ~/.pip/pip.conf or ~/.config/pip/pip.conf:",
           code: `[global]
-index-url = ${REGISTRY_URL}/pypi/${repoKey}/simple/
+index-url = ${REGISTRY_URL}/pypi/${repoKey}/
 trusted-host = ${REGISTRY_HOST}`,
         },
         {
           title: "Install a package",
-          code: `pip install --index-url ${REGISTRY_URL}/pypi/${repoKey}/simple/ <package-name>`,
+          code: `pip install --index-url ${REGISTRY_URL}/pypi/${repoKey}/ <package-name>`,
         },
         {
           title: "Upload with twine",


### PR DESCRIPTION
## Summary

Removes the `/simple/` suffix from the pip index URLs generated on the Setup page. When a PyPI remote repository uses the default upstream URL (`https://pypi.org/simple`), the backend appends the request path to it. With the old `/simple/` suffix in the client URL, pip requests would hit `/simple/simple/<package>/` on the upstream, which fails. The correct client-facing URL is `/pypi/{repo_key}/` without the suffix, since the backend handles the simple API path routing internally.

Fixes #219

## Test Checklist
- [ ] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [x] N/A - no UI changes