### PR TITLE
fix: increase proxy body size limit for large artifact uploads

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -21,6 +21,14 @@ const nextConfig: NextConfig = {
   output: "standalone",
   devIndicators: false,
   transpilePackages: ["@artifact-keeper/sdk"],
+  experimental: {
+    // The default proxyClientMaxBodySize is 10 MB, which blocks artifact
+    // uploads larger than that through the middleware rewrite proxy. The
+    // backend allows up to 5 GB, so match that limit here.
+    proxyClientMaxBodySize: "5gb",
+    // Give large uploads up to 10 minutes before the proxy times out.
+    proxyTimeout: 600_000,
+  },
   async headers() {
     return [
       {

--- a/src/components/common/__tests__/file-upload.test.tsx
+++ b/src/components/common/__tests__/file-upload.test.tsx
@@ -174,4 +174,156 @@ describe("FileUpload", () => {
 
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
+
+  // ---- Drag and drop ----
+
+  it("accepts a file via drag and drop", async () => {
+    const onUpload = vi.fn().mockResolvedValue(undefined);
+    render(<FileUpload onUpload={onUpload} />);
+
+    const dropZone = screen.getByRole("button");
+    const file = createMockFile("dropped.jar", 256);
+
+    fireEvent.dragOver(dropZone, { dataTransfer: { files: [] } });
+    fireEvent.drop(dropZone, { dataTransfer: { files: [file] } });
+
+    expect(screen.getByText("dropped.jar")).toBeInTheDocument();
+  });
+
+  it("applies drag-over styling and clears on drag-leave", () => {
+    const onUpload = vi.fn();
+    render(<FileUpload onUpload={onUpload} />);
+
+    const dropZone = screen.getByRole("button");
+
+    fireEvent.dragOver(dropZone, { dataTransfer: { files: [] } });
+    expect(dropZone.className).toContain("border-primary");
+
+    fireEvent.dragLeave(dropZone, { dataTransfer: { files: [] } });
+    expect(dropZone.className).not.toContain("border-primary");
+  });
+
+  // ---- Keyboard navigation ----
+
+  it("opens file picker on Enter key when no file is selected", () => {
+    const onUpload = vi.fn();
+    render(<FileUpload onUpload={onUpload} />);
+
+    const dropZone = screen.getByRole("button");
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const clickSpy = vi.spyOn(input, "click");
+
+    fireEvent.keyDown(dropZone, { key: "Enter" });
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  it("opens file picker on Space key when no file is selected", () => {
+    const onUpload = vi.fn();
+    render(<FileUpload onUpload={onUpload} />);
+
+    const dropZone = screen.getByRole("button");
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const clickSpy = vi.spyOn(input, "click");
+
+    fireEvent.keyDown(dropZone, { key: " " });
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  // ---- Custom path input ----
+
+  it("renders custom path input when showPathInput is true", () => {
+    const onUpload = vi.fn();
+    render(<FileUpload onUpload={onUpload} showPathInput />);
+
+    const pathInput = screen.getByPlaceholderText("e.g. libs/mylib-1.0.jar");
+    expect(pathInput).toBeInTheDocument();
+  });
+
+  it("passes custom path to onUpload callback", async () => {
+    const onUpload = vi.fn().mockResolvedValue(undefined);
+    render(<FileUpload onUpload={onUpload} showPathInput />);
+
+    const pathInput = screen.getByPlaceholderText("e.g. libs/mylib-1.0.jar");
+    fireEvent.change(pathInput, { target: { value: "libs/custom-1.0.jar" } });
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, {
+      target: { files: [createMockFile("lib.jar", 512)] },
+    });
+    fireEvent.click(screen.getByText("Upload"));
+
+    await waitFor(() => {
+      expect(onUpload).toHaveBeenCalledWith(
+        expect.any(File),
+        "libs/custom-1.0.jar"
+      );
+    });
+  });
+
+  it("does not pass path when custom path input is empty", async () => {
+    const onUpload = vi.fn().mockResolvedValue(undefined);
+    render(<FileUpload onUpload={onUpload} showPathInput />);
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, {
+      target: { files: [createMockFile("lib.jar", 512)] },
+    });
+    fireEvent.click(screen.getByText("Upload"));
+
+    await waitFor(() => {
+      expect(onUpload).toHaveBeenCalledWith(expect.any(File), undefined);
+    });
+  });
+
+  // ---- File display and clear button ----
+
+  it("displays file name and size after selection", () => {
+    const onUpload = vi.fn();
+    render(<FileUpload onUpload={onUpload} />);
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, {
+      target: { files: [createMockFile("my-lib.jar", 2048)] },
+    });
+
+    expect(screen.getByText("my-lib.jar")).toBeInTheDocument();
+    expect(screen.getByText("2048 bytes")).toBeInTheDocument();
+  });
+
+  it("clears file when the X button is clicked", () => {
+    const onUpload = vi.fn();
+    render(<FileUpload onUpload={onUpload} />);
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, {
+      target: { files: [createMockFile("removeme.jar", 100)] },
+    });
+
+    expect(screen.getByText("removeme.jar")).toBeInTheDocument();
+
+    // The X button is inside the file display area
+    const clearButtons = screen.getAllByRole("button");
+    // Find the button containing the X icon (icon-xs variant)
+    const xButton = clearButtons.find(
+      (btn) => btn.querySelector('[data-testid="icon-X"]') !== null
+    );
+    expect(xButton).toBeTruthy();
+    fireEvent.click(xButton!);
+
+    expect(screen.queryByText("removeme.jar")).not.toBeInTheDocument();
+  });
+
+  // ---- Drop zone click ----
+
+  it("opens file picker when drop zone is clicked (no file selected)", () => {
+    const onUpload = vi.fn();
+    render(<FileUpload onUpload={onUpload} />);
+
+    const dropZone = screen.getByRole("button");
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const clickSpy = vi.spyOn(input, "click");
+
+    fireEvent.click(dropZone);
+    expect(clickSpy).toHaveBeenCalled();
+  });
 });

--- a/src/components/common/__tests__/file-upload.test.tsx
+++ b/src/components/common/__tests__/file-upload.test.tsx
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+
+vi.mock("lucide-react", () => {
+  const stub = (name: string) => {
+    const Icon = (props: Record<string, unknown>) => (
+      <span data-testid={`icon-${name}`} {...props} />
+    );
+    Icon.displayName = name;
+    return Icon;
+  };
+  return {
+    Upload: stub("Upload"),
+    X: stub("X"),
+    FileIcon: stub("FileIcon"),
+    AlertCircle: stub("AlertCircle"),
+  };
+});
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: any) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("@/components/ui/input", () => ({
+  Input: (props: any) => <input {...props} />,
+}));
+
+vi.mock("@/components/ui/label", () => ({
+  Label: ({ children, ...props }: any) => (
+    <label {...props}>{children}</label>
+  ),
+}));
+
+vi.mock("@/components/ui/progress", () => ({
+  Progress: (props: any) => (
+    <div data-testid="progress" data-value={props.value} />
+  ),
+}));
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: any[]) => args.filter(Boolean).join(" "),
+  formatBytes: (bytes: number) => `${bytes} bytes`,
+}));
+
+import { FileUpload } from "../file-upload";
+
+function createMockFile(
+  name: string,
+  size: number,
+  type = "application/octet-stream"
+): File {
+  const content = new Uint8Array(size);
+  return new File([content], name, { type });
+}
+
+describe("FileUpload", () => {
+  afterEach(cleanup);
+
+  // ---- Error display ----
+
+  it("displays an error message when the upload callback rejects with an Error", async () => {
+    const onUpload = vi.fn().mockRejectedValue(new Error("File exceeds the maximum upload size allowed by the server."));
+
+    render(<FileUpload onUpload={onUpload} />);
+
+    // Select a file via the hidden input
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = createMockFile("large.bin", 1024);
+    fireEvent.change(input, { target: { files: [file] } });
+
+    // Click Upload
+    const uploadButton = screen.getByText("Upload");
+    fireEvent.click(uploadButton);
+
+    await waitFor(() => {
+      const alert = screen.getByRole("alert");
+      expect(alert).toBeInTheDocument();
+      expect(alert).toHaveTextContent(
+        "File exceeds the maximum upload size allowed by the server."
+      );
+    });
+  });
+
+  it("displays a generic error when the upload callback rejects with a non-Error", async () => {
+    const onUpload = vi.fn().mockRejectedValue("unknown error");
+
+    render(<FileUpload onUpload={onUpload} />);
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, {
+      target: { files: [createMockFile("test.jar", 512)] },
+    });
+
+    fireEvent.click(screen.getByText("Upload"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Upload failed");
+    });
+  });
+
+  it("clears the error when a new file is selected", async () => {
+    const onUpload = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Something went wrong"));
+
+    render(<FileUpload onUpload={onUpload} />);
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+    // First upload: triggers error
+    fireEvent.change(input, {
+      target: { files: [createMockFile("bad.bin", 256)] },
+    });
+    fireEvent.click(screen.getByText("Upload"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    // Select a new file: should clear the error
+    fireEvent.change(input, {
+      target: { files: [createMockFile("good.bin", 128)] },
+    });
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("clears the error when the user clicks Cancel", async () => {
+    const onUpload = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Network error"));
+
+    render(<FileUpload onUpload={onUpload} />);
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, {
+      target: { files: [createMockFile("file.bin", 100)] },
+    });
+    fireEvent.click(screen.getByText("Upload"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Cancel"));
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("does not show an error when the upload succeeds", async () => {
+    const onUpload = vi.fn().mockResolvedValue(undefined);
+
+    render(<FileUpload onUpload={onUpload} />);
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, {
+      target: { files: [createMockFile("ok.jar", 64)] },
+    });
+    fireEvent.click(screen.getByText("Upload"));
+
+    await waitFor(() => {
+      expect(onUpload).toHaveBeenCalled();
+    });
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/common/file-upload.tsx
+++ b/src/components/common/file-upload.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useCallback } from "react";
-import { Upload, X, FileIcon } from "lucide-react";
+import { Upload, X, FileIcon, AlertCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -26,11 +26,13 @@ export function FileUpload({
   const [progress, setProgress] = useState(0);
   const [uploading, setUploading] = useState(false);
   const [dragOver, setDragOver] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleFile = useCallback((f: File) => {
     setFile(f);
     setProgress(0);
+    setError(null);
   }, []);
 
   const handleDrop = useCallback(
@@ -69,6 +71,7 @@ export function FileUpload({
     setFile(null);
     setProgress(0);
     setCustomPath("");
+    setError(null);
     if (inputRef.current) inputRef.current.value = "";
   }, []);
 
@@ -76,9 +79,14 @@ export function FileUpload({
     if (!file) return;
     setUploading(true);
     setProgress(0);
+    setError(null);
     try {
       await onUpload(file, customPath || undefined);
       handleClear();
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Upload failed";
+      setError(message);
     } finally {
       setUploading(false);
       setProgress(0);
@@ -175,6 +183,16 @@ export function FileUpload({
           <p className="text-xs text-muted-foreground text-center">
             Uploading... {progress}%
           </p>
+        </div>
+      )}
+
+      {error && (
+        <div
+          className="flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive"
+          role="alert"
+        >
+          <AlertCircle className="size-4 mt-0.5 shrink-0" />
+          <p>{error}</p>
         </div>
       )}
 

--- a/src/lib/api/__tests__/artifacts.test.ts
+++ b/src/lib/api/__tests__/artifacts.test.ts
@@ -102,4 +102,167 @@ describe("artifactsApi", () => {
     const { artifactsApi } = await import("../artifacts");
     await expect(artifactsApi.createDownloadTicket("repo-key", "lib.jar")).rejects.toBe("fail");
   });
+
+  // ---- upload() via XMLHttpRequest ----
+
+  describe("upload", () => {
+    let xhrInstances: Array<Record<string, any>>;
+
+    function mockXHR() {
+      xhrInstances = [];
+      function FakeXHR(this: Record<string, any>) {
+        this.open = vi.fn();
+        this.send = vi.fn();
+        this.withCredentials = false;
+        this.upload = { onprogress: null as any };
+        this.onload = null as any;
+        this.onerror = null as any;
+        this.status = 0;
+        this.responseText = "";
+        xhrInstances.push(this);
+      }
+      vi.stubGlobal("XMLHttpRequest", FakeXHR);
+    }
+
+    beforeEach(() => {
+      mockXHR();
+    });
+
+    it("resolves with parsed artifact on 2xx response", async () => {
+      const { artifactsApi } = await import("../artifacts");
+      const file = new File(["data"], "test.jar", { type: "application/java-archive" });
+
+      const promise = artifactsApi.upload("my-repo", file);
+      const xhr = xhrInstances[0];
+
+      xhr.status = 201;
+      xhr.responseText = JSON.stringify({ id: "a1", path: "test.jar" });
+      xhr.onload();
+
+      const result = await promise;
+      expect(result).toEqual({ id: "a1", path: "test.jar" });
+      expect(xhr.open).toHaveBeenCalledWith(
+        "POST",
+        "http://localhost:8080/api/v1/repositories/my-repo/artifacts"
+      );
+      expect(xhr.withCredentials).toBe(true);
+    });
+
+    it("appends path to FormData when provided", async () => {
+      const { artifactsApi } = await import("../artifacts");
+      const file = new File(["data"], "lib.jar");
+
+      const promise = artifactsApi.upload("my-repo", file, "libs/lib-1.0.jar");
+      const xhr = xhrInstances[0];
+
+      // Verify FormData was sent with the path
+      const sentFormData = xhr.send.mock.calls[0][0] as FormData;
+      expect(sentFormData.get("path")).toBe("libs/lib-1.0.jar");
+      expect(sentFormData.get("file")).toBeInstanceOf(File);
+
+      xhr.status = 200;
+      xhr.responseText = JSON.stringify({ id: "a2" });
+      xhr.onload();
+
+      await promise;
+    });
+
+    it("calls onProgress callback during upload", async () => {
+      const { artifactsApi } = await import("../artifacts");
+      const file = new File(["data"], "test.jar");
+      const onProgress = vi.fn();
+
+      const promise = artifactsApi.upload("my-repo", file, undefined, onProgress);
+      const xhr = xhrInstances[0];
+
+      // Simulate progress event
+      xhr.upload.onprogress({ lengthComputable: true, loaded: 50, total: 100 });
+      expect(onProgress).toHaveBeenCalledWith(50);
+
+      xhr.upload.onprogress({ lengthComputable: true, loaded: 100, total: 100 });
+      expect(onProgress).toHaveBeenCalledWith(100);
+
+      // Non-computable events should be ignored
+      xhr.upload.onprogress({ lengthComputable: false, loaded: 0, total: 0 });
+      expect(onProgress).toHaveBeenCalledTimes(2);
+
+      xhr.status = 200;
+      xhr.responseText = JSON.stringify({ id: "a3" });
+      xhr.onload();
+
+      await promise;
+    });
+
+    it("rejects with 413 message for payload-too-large responses", async () => {
+      const { artifactsApi } = await import("../artifacts");
+      const file = new File(["data"], "huge.bin");
+
+      const promise = artifactsApi.upload("my-repo", file);
+      const xhr = xhrInstances[0];
+
+      xhr.status = 413;
+      xhr.responseText = JSON.stringify({ error: "Payload Too Large" });
+      xhr.onload();
+
+      await expect(promise).rejects.toThrow(
+        "File exceeds the maximum upload size allowed by the server."
+      );
+    });
+
+    it("rejects with server error detail on non-2xx response", async () => {
+      const { artifactsApi } = await import("../artifacts");
+      const file = new File(["data"], "bad.jar");
+
+      const promise = artifactsApi.upload("my-repo", file);
+      const xhr = xhrInstances[0];
+
+      xhr.status = 400;
+      xhr.responseText = JSON.stringify({ error: "Invalid artifact format" });
+      xhr.onload();
+
+      await expect(promise).rejects.toThrow("Invalid artifact format");
+    });
+
+    it("rejects with message field when error field is absent", async () => {
+      const { artifactsApi } = await import("../artifacts");
+      const file = new File(["data"], "bad.jar");
+
+      const promise = artifactsApi.upload("my-repo", file);
+      const xhr = xhrInstances[0];
+
+      xhr.status = 500;
+      xhr.responseText = JSON.stringify({ message: "Internal server error" });
+      xhr.onload();
+
+      await expect(promise).rejects.toThrow("Internal server error");
+    });
+
+    it("rejects with generic status message when response is not JSON", async () => {
+      const { artifactsApi } = await import("../artifacts");
+      const file = new File(["data"], "bad.jar");
+
+      const promise = artifactsApi.upload("my-repo", file);
+      const xhr = xhrInstances[0];
+
+      xhr.status = 502;
+      xhr.responseText = "Bad Gateway";
+      xhr.onload();
+
+      await expect(promise).rejects.toThrow("Upload failed with status 502");
+    });
+
+    it("rejects with network error on onerror", async () => {
+      const { artifactsApi } = await import("../artifacts");
+      const file = new File(["data"], "test.jar");
+
+      const promise = artifactsApi.upload("my-repo", file);
+      const xhr = xhrInstances[0];
+
+      xhr.onerror();
+
+      await expect(promise).rejects.toThrow(
+        "Upload failed. Check your network connection and try again."
+      );
+    });
+  });
 });

--- a/src/lib/api/artifacts.ts
+++ b/src/lib/api/artifacts.ts
@@ -89,11 +89,22 @@ export const artifactsApi = {
         if (xhr.status >= 200 && xhr.status < 300) {
           resolve(JSON.parse(xhr.responseText) as Artifact);
         } else {
-          reject(new Error(`Upload failed: ${xhr.status}`));
+          let detail = '';
+          try {
+            const body = JSON.parse(xhr.responseText);
+            detail = body?.error || body?.message || '';
+          } catch {
+            // response is not JSON
+          }
+          if (xhr.status === 413) {
+            reject(new Error('File exceeds the maximum upload size allowed by the server.'));
+          } else {
+            reject(new Error(detail || `Upload failed with status ${xhr.status}`));
+          }
         }
       };
 
-      xhr.onerror = () => reject(new Error('Upload failed'));
+      xhr.onerror = () => reject(new Error('Upload failed. Check your network connection and try again.'));
       xhr.send(formData);
     });
   },


### PR DESCRIPTION
## Summary

Fixes #275. Users could not upload artifacts larger than 10 MB through the web UI because Next.js defaults `experimental.proxyClientMaxBodySize` to 10 MB. All uploads flow through the middleware rewrite proxy (`src/middleware.ts`), so any request body exceeding this limit was rejected before reaching the backend.

Changes:
- Set `experimental.proxyClientMaxBodySize` to `"5gb"` in `next.config.ts` to match the backend's configured maximum upload size.
- Set `experimental.proxyTimeout` to 600,000 ms (10 minutes) so large uploads on slower connections do not time out at the proxy layer.
- Add error state handling to the `FileUpload` component so users see an inline error message when an upload fails, instead of a silent failure.
- Improve error messages in the XHR upload handler (`src/lib/api/artifacts.ts`) to surface the backend's error detail and provide a specific message for HTTP 413 responses.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [x] N/A - no UI changes