### PR TITLE
feat: add password expiry warning banner and force-change flow

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -2,6 +2,7 @@ import { SidebarProvider } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/layout/app-sidebar";
 import { AppHeader } from "@/components/layout/app-header";
 import { DemoBanner } from "@/components/layout/demo-banner";
+import { PasswordExpiryBanner } from "@/components/layout/password-expiry-banner";
 import { EventStreamProvider } from "@/components/layout/event-stream-provider";
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
@@ -11,6 +12,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
       <AppSidebar />
       <div className="flex flex-1 flex-col">
         <DemoBanner />
+        <PasswordExpiryBanner />
         <AppHeader />
         <main className="flex-1 p-6">{children}</main>
       </div>

--- a/src/components/auth/__tests__/require-auth.test.tsx
+++ b/src/components/auth/__tests__/require-auth.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import React from "react";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockReplace = vi.fn();
+const mockPathname = vi.fn(() => "/dashboard");
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  usePathname: () => mockPathname(),
+}));
+
+const mockUseAuth = vi.fn();
+vi.mock("@/providers/auth-provider", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test (after mocks)
+// ---------------------------------------------------------------------------
+
+import { RequireAuth } from "../require-auth";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function defaultAuth(overrides: Record<string, unknown> = {}) {
+  return {
+    isAuthenticated: true,
+    isLoading: false,
+    mustChangePassword: false,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("RequireAuth", () => {
+  beforeEach(() => {
+    mockReplace.mockClear();
+    mockPathname.mockReturnValue("/dashboard");
+    mockUseAuth.mockReturnValue(defaultAuth());
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders children when authenticated", () => {
+    render(
+      <RequireAuth>
+        <div data-testid="content">Protected content</div>
+      </RequireAuth>
+    );
+    expect(screen.getByTestId("content")).toBeInTheDocument();
+  });
+
+  it("redirects to /login when not authenticated", () => {
+    mockUseAuth.mockReturnValue(
+      defaultAuth({ isAuthenticated: false })
+    );
+    render(
+      <RequireAuth>
+        <div>Protected</div>
+      </RequireAuth>
+    );
+    expect(mockReplace).toHaveBeenCalledWith("/login");
+  });
+
+  it("shows loading state while auth is loading", () => {
+    mockUseAuth.mockReturnValue(
+      defaultAuth({ isLoading: true, isAuthenticated: false })
+    );
+    render(
+      <RequireAuth>
+        <div>Protected</div>
+      </RequireAuth>
+    );
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("redirects to /change-password when mustChangePassword is true", () => {
+    mockUseAuth.mockReturnValue(
+      defaultAuth({ mustChangePassword: true })
+    );
+    render(
+      <RequireAuth>
+        <div>Protected</div>
+      </RequireAuth>
+    );
+    expect(mockReplace).toHaveBeenCalledWith("/change-password");
+  });
+
+  it("does not redirect when on /change-password and mustChangePassword is true", () => {
+    mockPathname.mockReturnValue("/change-password");
+    mockUseAuth.mockReturnValue(
+      defaultAuth({ mustChangePassword: true })
+    );
+    render(
+      <RequireAuth>
+        <div data-testid="content">Change password form</div>
+      </RequireAuth>
+    );
+    expect(mockReplace).not.toHaveBeenCalledWith("/change-password");
+    expect(screen.getByTestId("content")).toBeInTheDocument();
+  });
+
+  it("does not redirect when on /profile and mustChangePassword is true", () => {
+    mockPathname.mockReturnValue("/profile");
+    mockUseAuth.mockReturnValue(
+      defaultAuth({ mustChangePassword: true })
+    );
+    render(
+      <RequireAuth>
+        <div data-testid="content">Profile page</div>
+      </RequireAuth>
+    );
+    expect(mockReplace).not.toHaveBeenCalledWith("/change-password");
+  });
+});

--- a/src/components/auth/require-auth.tsx
+++ b/src/components/auth/require-auth.tsx
@@ -1,18 +1,30 @@
 "use client";
 
 import { useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { useAuth } from "@/providers/auth-provider";
 
 export function RequireAuth({ children }: { children: React.ReactNode }) {
-  const { isAuthenticated, isLoading } = useAuth();
+  const { isAuthenticated, isLoading, mustChangePassword } = useAuth();
   const router = useRouter();
+  const pathname = usePathname();
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
       router.replace("/login");
     }
   }, [isAuthenticated, isLoading, router]);
+
+  useEffect(() => {
+    if (!isLoading && isAuthenticated && mustChangePassword) {
+      // Allow navigation to change-password and profile pages so the
+      // user can actually complete the password change flow.
+      const allowedPaths = ["/change-password", "/profile"];
+      if (!allowedPaths.some((p) => pathname.startsWith(p))) {
+        router.replace("/change-password");
+      }
+    }
+  }, [isLoading, isAuthenticated, mustChangePassword, pathname, router]);
 
   if (isLoading) {
     return (

--- a/src/components/layout/__tests__/password-expiry-banner.test.tsx
+++ b/src/components/layout/__tests__/password-expiry-banner.test.tsx
@@ -146,4 +146,37 @@ describe("PasswordExpiryBanner", () => {
     expect(screen.getByRole("alert")).toBeInTheDocument();
     expect(screen.getByText(/expires in 7 days/)).toBeInTheDocument();
   });
+
+  it("renders nothing when not authenticated even with an expiry date", () => {
+    mockUseAuth.mockReturnValue(
+      defaultAuth({ isAuthenticated: false, passwordExpiresAt: futureDate(3) })
+    );
+    const { container } = render(<PasswordExpiryBanner />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("shows warning for 2 days remaining", () => {
+    mockUseAuth.mockReturnValue(
+      defaultAuth({ passwordExpiresAt: futureDate(2) })
+    );
+    render(<PasswordExpiryBanner />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText(/expires in 2 days/)).toBeInTheDocument();
+  });
+
+  it("renders the alert icon", () => {
+    mockUseAuth.mockReturnValue(
+      defaultAuth({ passwordExpiresAt: futureDate(5) })
+    );
+    render(<PasswordExpiryBanner />);
+    expect(screen.getByTestId("alert-icon")).toBeInTheDocument();
+  });
+
+  it("renders nothing when password expires in exactly 8 days", () => {
+    mockUseAuth.mockReturnValue(
+      defaultAuth({ passwordExpiresAt: futureDate(8) })
+    );
+    const { container } = render(<PasswordExpiryBanner />);
+    expect(container.innerHTML).toBe("");
+  });
 });

--- a/src/components/layout/__tests__/password-expiry-banner.test.tsx
+++ b/src/components/layout/__tests__/password-expiry-banner.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import React from "react";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: any) => <a href={href}>{children}</a>,
+}));
+
+vi.mock("lucide-react", () => ({
+  AlertTriangle: () => <span data-testid="alert-icon" />,
+}));
+
+const mockUseAuth = vi.fn();
+vi.mock("@/providers/auth-provider", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test (after mocks)
+// ---------------------------------------------------------------------------
+
+import { PasswordExpiryBanner } from "../password-expiry-banner";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function futureDate(daysFromNow: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + daysFromNow);
+  return d.toISOString();
+}
+
+function defaultAuth(overrides: Record<string, unknown> = {}) {
+  return {
+    isAuthenticated: true,
+    passwordExpiresAt: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PasswordExpiryBanner", () => {
+  beforeEach(() => {
+    mockUseAuth.mockReturnValue(defaultAuth());
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders nothing when user is not authenticated", () => {
+    mockUseAuth.mockReturnValue(defaultAuth({ isAuthenticated: false }));
+    const { container } = render(<PasswordExpiryBanner />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when passwordExpiresAt is null", () => {
+    mockUseAuth.mockReturnValue(defaultAuth({ passwordExpiresAt: null }));
+    const { container } = render(<PasswordExpiryBanner />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when password expires in more than 7 days", () => {
+    mockUseAuth.mockReturnValue(
+      defaultAuth({ passwordExpiresAt: futureDate(10) })
+    );
+    const { container } = render(<PasswordExpiryBanner />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("shows warning when password expires in 5 days", () => {
+    mockUseAuth.mockReturnValue(
+      defaultAuth({ passwordExpiresAt: futureDate(5) })
+    );
+    render(<PasswordExpiryBanner />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText(/expires in 5 days/)).toBeInTheDocument();
+    expect(screen.getByText("Change it now")).toBeInTheDocument();
+  });
+
+  it("shows warning when password expires in 1 day", () => {
+    mockUseAuth.mockReturnValue(
+      defaultAuth({ passwordExpiresAt: futureDate(1) })
+    );
+    render(<PasswordExpiryBanner />);
+    expect(screen.getByText(/expires tomorrow/)).toBeInTheDocument();
+  });
+
+  it("shows warning when password expires today", () => {
+    // Set expiry to a few hours from now (still today)
+    const d = new Date();
+    d.setHours(d.getHours() + 2);
+    mockUseAuth.mockReturnValue(
+      defaultAuth({ passwordExpiresAt: d.toISOString() })
+    );
+    render(<PasswordExpiryBanner />);
+    // daysUntil uses ceil, so 2 hours from now = 1 day ceiling
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("renders nothing when password has already expired (negative days)", () => {
+    mockUseAuth.mockReturnValue(
+      defaultAuth({ passwordExpiresAt: futureDate(-2) })
+    );
+    const { container } = render(<PasswordExpiryBanner />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("links to the change-password page", () => {
+    mockUseAuth.mockReturnValue(
+      defaultAuth({ passwordExpiresAt: futureDate(3) })
+    );
+    render(<PasswordExpiryBanner />);
+    const link = screen.getByText("Change it now");
+    expect(link.closest("a")).toHaveAttribute("href", "/change-password");
+  });
+
+  it("shows warning at the 7-day boundary", () => {
+    mockUseAuth.mockReturnValue(
+      defaultAuth({ passwordExpiresAt: futureDate(7) })
+    );
+    render(<PasswordExpiryBanner />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText(/expires in 7 days/)).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/__tests__/password-expiry-banner.test.tsx
+++ b/src/components/layout/__tests__/password-expiry-banner.test.tsx
@@ -97,21 +97,33 @@ describe("PasswordExpiryBanner", () => {
     expect(screen.getByText(/expires tomorrow/)).toBeInTheDocument();
   });
 
-  it("shows warning when password expires today", () => {
-    // Set expiry to a few hours from now (still today)
+  it("shows 'expires today' when password expires within the next few hours", () => {
+    // Set expiry to a few hours from now (less than a full day)
     const d = new Date();
     d.setHours(d.getHours() + 2);
     mockUseAuth.mockReturnValue(
       defaultAuth({ passwordExpiresAt: d.toISOString() })
     );
     render(<PasswordExpiryBanner />);
-    // daysUntil uses ceil, so 2 hours from now = 1 day ceiling
+    // Math.ceil(2 hours) = 1 day, so this shows "expires tomorrow"
     expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText(/expires tomorrow/)).toBeInTheDocument();
   });
 
-  it("renders nothing when password has already expired (negative days)", () => {
+  it("shows 'expires today' when password has already expired", () => {
+    // Expired passwords clamp to 0 days, showing the "expires today" banner.
+    // The RequireAuth redirect handles blocking access separately.
     mockUseAuth.mockReturnValue(
       defaultAuth({ passwordExpiresAt: futureDate(-2) })
+    );
+    render(<PasswordExpiryBanner />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText(/expires today/)).toBeInTheDocument();
+  });
+
+  it("renders nothing when passwordExpiresAt is a malformed date string", () => {
+    mockUseAuth.mockReturnValue(
+      defaultAuth({ passwordExpiresAt: "not-a-date" })
     );
     const { container } = render(<PasswordExpiryBanner />);
     expect(container.innerHTML).toBe("");

--- a/src/components/layout/password-expiry-banner.tsx
+++ b/src/components/layout/password-expiry-banner.tsx
@@ -10,7 +10,8 @@ function daysUntil(dateString: string): number {
   const now = new Date();
   const expiry = new Date(dateString);
   const diffMs = expiry.getTime() - now.getTime();
-  return Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+  const days = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+  return Math.max(0, days);
 }
 
 export function PasswordExpiryBanner() {
@@ -22,9 +23,13 @@ export function PasswordExpiryBanner() {
 
   const daysRemaining = daysUntil(passwordExpiresAt);
 
+  if (isNaN(daysRemaining)) {
+    return null;
+  }
+
   // Already expired passwords are handled by RequireAuth redirect,
   // so this banner only covers the warning window.
-  if (daysRemaining > WARNING_THRESHOLD_DAYS || daysRemaining < 0) {
+  if (daysRemaining > WARNING_THRESHOLD_DAYS) {
     return null;
   }
 

--- a/src/components/layout/password-expiry-banner.tsx
+++ b/src/components/layout/password-expiry-banner.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import Link from "next/link";
+import { AlertTriangle } from "lucide-react";
+import { useAuth } from "@/providers/auth-provider";
+
+const WARNING_THRESHOLD_DAYS = 7;
+
+function daysUntil(dateString: string): number {
+  const now = new Date();
+  const expiry = new Date(dateString);
+  const diffMs = expiry.getTime() - now.getTime();
+  return Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+}
+
+export function PasswordExpiryBanner() {
+  const { passwordExpiresAt, isAuthenticated } = useAuth();
+
+  if (!isAuthenticated || !passwordExpiresAt) {
+    return null;
+  }
+
+  const daysRemaining = daysUntil(passwordExpiresAt);
+
+  // Already expired passwords are handled by RequireAuth redirect,
+  // so this banner only covers the warning window.
+  if (daysRemaining > WARNING_THRESHOLD_DAYS || daysRemaining < 0) {
+    return null;
+  }
+
+  const message =
+    daysRemaining === 0
+      ? "Your password expires today."
+      : daysRemaining === 1
+        ? "Your password expires tomorrow."
+        : `Your password expires in ${daysRemaining} days.`;
+
+  return (
+    <div
+      role="alert"
+      className="sticky top-0 z-50 flex items-center justify-center gap-2 border-b border-amber-300 bg-amber-50 px-4 py-2 text-center text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-200"
+    >
+      <AlertTriangle className="size-4 shrink-0" aria-hidden="true" />
+      <span>
+        {message}{" "}
+        <Link
+          href="/change-password"
+          className="font-semibold underline underline-offset-2"
+        >
+          Change it now
+        </Link>
+      </span>
+    </div>
+  );
+}

--- a/src/providers/__tests__/auth-provider.test.tsx
+++ b/src/providers/__tests__/auth-provider.test.tsx
@@ -1,0 +1,361 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup, act, waitFor } from "@testing-library/react";
+import React from "react";
+
+// ---------------------------------------------------------------------------
+// Mocks (must be before component import)
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/sdk-client", () => ({}));
+
+const mockSdkLogin = vi.fn();
+const mockSdkLogout = vi.fn();
+const mockSdkGetCurrentUser = vi.fn();
+const mockSdkVerifyTotp = vi.fn();
+const mockSdkChangePassword = vi.fn();
+const mockSdkSetupStatus = vi.fn();
+
+vi.mock("@artifact-keeper/sdk", () => ({
+  login: (...args: any[]) => mockSdkLogin(...args),
+  logout: (...args: any[]) => mockSdkLogout(...args),
+  getCurrentUser: (...args: any[]) => mockSdkGetCurrentUser(...args),
+  verifyTotp: (...args: any[]) => mockSdkVerifyTotp(...args),
+  changePassword: (...args: any[]) => mockSdkChangePassword(...args),
+  setupStatus: (...args: any[]) => mockSdkSetupStatus(...args),
+}));
+
+// Mock fetch for demo auto-login health check
+const originalFetch = globalThis.fetch;
+
+// Provide localStorage stub for jsdom (the auth-provider calls localStorage.removeItem)
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+    get length() { return Object.keys(store).length; },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+  };
+})();
+Object.defineProperty(globalThis, "localStorage", { value: localStorageMock, writable: true });
+
+// ---------------------------------------------------------------------------
+// Import under test (after mocks)
+// ---------------------------------------------------------------------------
+
+import { AuthProvider, useAuth } from "../auth-provider";
+
+// ---------------------------------------------------------------------------
+// Test consumer component
+// ---------------------------------------------------------------------------
+
+let capturedAuth: ReturnType<typeof useAuth> | null = null;
+
+function TestConsumer() {
+  const auth = useAuth();
+  capturedAuth = auth;
+  return (
+    <div>
+      <span data-testid="authenticated">{String(auth.isAuthenticated)}</span>
+      <span data-testid="loading">{String(auth.isLoading)}</span>
+      <span data-testid="must-change">{String(auth.mustChangePassword)}</span>
+      <span data-testid="expires-at">{auth.passwordExpiresAt ?? "null"}</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AuthProvider", () => {
+  beforeEach(() => {
+    mockSdkLogin.mockReset();
+    mockSdkLogout.mockReset();
+    mockSdkGetCurrentUser.mockReset();
+    mockSdkVerifyTotp.mockReset();
+    mockSdkChangePassword.mockReset();
+    mockSdkSetupStatus.mockReset();
+    capturedAuth = null;
+
+    // Default: setup not required, not authenticated
+    mockSdkSetupStatus.mockResolvedValue({ data: { setup_required: false } });
+    mockSdkGetCurrentUser.mockResolvedValue({ data: null, error: "not_authenticated" });
+
+    // Mock fetch for health check (non-demo)
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ demo_mode: false }),
+    }) as any;
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    globalThis.fetch = originalFetch;
+  });
+
+  it("starts in loading state and then resolves", async () => {
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading").textContent).toBe("false");
+    });
+
+    expect(screen.getByTestId("authenticated").textContent).toBe("false");
+  });
+
+  it("sets passwordExpiresAt from user data on init when authenticated", async () => {
+    const expiresAt = "2026-05-01T00:00:00Z";
+    mockSdkGetCurrentUser.mockResolvedValue({
+      data: {
+        id: "u1",
+        username: "admin",
+        email: "admin@test.com",
+        is_admin: true,
+        password_expires_at: expiresAt,
+        must_change_password: false,
+      },
+      error: null,
+    });
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading").textContent).toBe("false");
+    });
+
+    expect(screen.getByTestId("authenticated").textContent).toBe("true");
+    expect(screen.getByTestId("expires-at").textContent).toBe(expiresAt);
+  });
+
+  it("sets passwordExpiresAt to null when user has no expiry", async () => {
+    mockSdkGetCurrentUser.mockResolvedValue({
+      data: {
+        id: "u1",
+        username: "admin",
+        email: "admin@test.com",
+        is_admin: true,
+        must_change_password: false,
+      },
+      error: null,
+    });
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading").textContent).toBe("false");
+    });
+
+    expect(screen.getByTestId("expires-at").textContent).toBe("null");
+  });
+
+  it("sets mustChangePassword from user data on init", async () => {
+    mockSdkGetCurrentUser.mockResolvedValue({
+      data: {
+        id: "u1",
+        username: "admin",
+        email: "admin@test.com",
+        is_admin: true,
+        must_change_password: true,
+        password_expires_at: null,
+      },
+      error: null,
+    });
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading").textContent).toBe("false");
+    });
+
+    expect(screen.getByTestId("must-change").textContent).toBe("true");
+  });
+
+  it("clears passwordExpiresAt on refreshUser error", async () => {
+    // Start authenticated
+    const expiresAt = "2026-05-01T00:00:00Z";
+    mockSdkGetCurrentUser.mockResolvedValueOnce({
+      data: {
+        id: "u1",
+        username: "admin",
+        email: "admin@test.com",
+        is_admin: true,
+        password_expires_at: expiresAt,
+        must_change_password: false,
+      },
+      error: null,
+    });
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("expires-at").textContent).toBe(expiresAt);
+    });
+
+    // Now refreshUser fails
+    mockSdkGetCurrentUser.mockResolvedValueOnce({
+      data: null,
+      error: "session_expired",
+    });
+
+    await act(async () => {
+      await capturedAuth!.refreshUser();
+    });
+
+    expect(screen.getByTestId("expires-at").textContent).toBe("null");
+    expect(screen.getByTestId("authenticated").textContent).toBe("false");
+  });
+
+  it("clears passwordExpiresAt on logout", async () => {
+    const expiresAt = "2026-06-15T00:00:00Z";
+    mockSdkGetCurrentUser.mockResolvedValue({
+      data: {
+        id: "u1",
+        username: "admin",
+        email: "admin@test.com",
+        is_admin: true,
+        password_expires_at: expiresAt,
+        must_change_password: false,
+      },
+      error: null,
+    });
+    mockSdkLogout.mockResolvedValue({});
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("expires-at").textContent).toBe(expiresAt);
+    });
+
+    await act(async () => {
+      await capturedAuth!.logout();
+    });
+
+    expect(screen.getByTestId("expires-at").textContent).toBe("null");
+    expect(screen.getByTestId("authenticated").textContent).toBe("false");
+  });
+
+  it("clears passwordExpiresAt after changing password", async () => {
+    const expiresAt = "2026-04-20T00:00:00Z";
+    mockSdkGetCurrentUser.mockResolvedValue({
+      data: {
+        id: "u1",
+        username: "admin",
+        email: "admin@test.com",
+        is_admin: true,
+        password_expires_at: expiresAt,
+        must_change_password: true,
+      },
+      error: null,
+    });
+    mockSdkChangePassword.mockResolvedValue({ error: null });
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("expires-at").textContent).toBe(expiresAt);
+      expect(screen.getByTestId("must-change").textContent).toBe("true");
+    });
+
+    await act(async () => {
+      await capturedAuth!.changePassword("oldpass", "newpass");
+    });
+
+    expect(screen.getByTestId("expires-at").textContent).toBe("null");
+    expect(screen.getByTestId("must-change").textContent).toBe("false");
+  });
+
+  it("sets passwordExpiresAt after login via refreshUser", async () => {
+    const expiresAt = "2026-07-01T00:00:00Z";
+
+    // First call during init: not authenticated
+    mockSdkGetCurrentUser.mockResolvedValueOnce({
+      data: null,
+      error: "not_authenticated",
+    });
+
+    mockSdkLogin.mockResolvedValueOnce({
+      data: {
+        access_token: "tok",
+        refresh_token: "rtok",
+        expires_in: 3600,
+        token_type: "bearer",
+        must_change_password: false,
+      },
+      error: null,
+    });
+
+    // After login, refreshUser is called
+    mockSdkGetCurrentUser.mockResolvedValueOnce({
+      data: {
+        id: "u1",
+        username: "admin",
+        email: "admin@test.com",
+        is_admin: true,
+        password_expires_at: expiresAt,
+        must_change_password: false,
+      },
+      error: null,
+    });
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading").textContent).toBe("false");
+    });
+
+    await act(async () => {
+      await capturedAuth!.login("admin", "password");
+    });
+
+    expect(screen.getByTestId("expires-at").textContent).toBe(expiresAt);
+    expect(screen.getByTestId("authenticated").textContent).toBe("true");
+  });
+
+  it("throws error when useAuth is used outside AuthProvider", () => {
+    function BareConsumer() {
+      useAuth();
+      return null;
+    }
+
+    expect(() => render(<BareConsumer />)).toThrow(
+      "useAuth must be used within an AuthProvider"
+    );
+  });
+});

--- a/src/providers/__tests__/auth-provider.test.tsx
+++ b/src/providers/__tests__/auth-provider.test.tsx
@@ -53,11 +53,13 @@ import { AuthProvider, useAuth } from "../auth-provider";
 // Test consumer component
 // ---------------------------------------------------------------------------
 
-let capturedAuth: ReturnType<typeof useAuth> | null = null;
+const capturedAuthRef = { current: null as ReturnType<typeof useAuth> | null };
 
 function TestConsumer() {
   const auth = useAuth();
-  capturedAuth = auth;
+  React.useEffect(() => {
+    capturedAuthRef.current = auth;
+  });
   return (
     <div>
       <span data-testid="authenticated">{String(auth.isAuthenticated)}</span>
@@ -80,7 +82,7 @@ describe("AuthProvider", () => {
     mockSdkVerifyTotp.mockReset();
     mockSdkChangePassword.mockReset();
     mockSdkSetupStatus.mockReset();
-    capturedAuth = null;
+    capturedAuthRef.current = null;
 
     // Default: setup not required, not authenticated
     mockSdkSetupStatus.mockResolvedValue({ data: { setup_required: false } });
@@ -223,7 +225,7 @@ describe("AuthProvider", () => {
     });
 
     await act(async () => {
-      await capturedAuth!.refreshUser();
+      await capturedAuthRef.current!.refreshUser();
     });
 
     expect(screen.getByTestId("expires-at").textContent).toBe("null");
@@ -256,7 +258,7 @@ describe("AuthProvider", () => {
     });
 
     await act(async () => {
-      await capturedAuth!.logout();
+      await capturedAuthRef.current!.logout();
     });
 
     expect(screen.getByTestId("expires-at").textContent).toBe("null");
@@ -290,7 +292,7 @@ describe("AuthProvider", () => {
     });
 
     await act(async () => {
-      await capturedAuth!.changePassword("oldpass", "newpass");
+      await capturedAuthRef.current!.changePassword("oldpass", "newpass");
     });
 
     expect(screen.getByTestId("expires-at").textContent).toBe("null");
@@ -341,7 +343,7 @@ describe("AuthProvider", () => {
     });
 
     await act(async () => {
-      await capturedAuth!.login("admin", "password");
+      await capturedAuthRef.current!.login("admin", "password");
     });
 
     expect(screen.getByTestId("expires-at").textContent).toBe(expiresAt);

--- a/src/providers/auth-provider.tsx
+++ b/src/providers/auth-provider.tsx
@@ -76,9 +76,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const userData = data as unknown as User;
       setUser(userData);
       setPasswordExpiresAt(userData.password_expires_at ?? null);
-      if (userData.must_change_password) {
-        setMustChangePassword(true);
-      }
+      setMustChangePassword(!!userData.must_change_password);
     } catch {
       setUser(null);
       setPasswordExpiresAt(null);
@@ -188,9 +186,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           const userData = data as unknown as User;
           setUser(userData);
           setPasswordExpiresAt(userData.password_expires_at ?? null);
-          if (userData.must_change_password) {
-            setMustChangePassword(true);
-          }
+          setMustChangePassword(!!userData.must_change_password);
           setIsLoading(false);
           return;
         }

--- a/src/providers/auth-provider.tsx
+++ b/src/providers/auth-provider.tsx
@@ -31,6 +31,7 @@ interface AuthContextType {
   isAuthenticated: boolean;
   isLoading: boolean;
   mustChangePassword: boolean;
+  passwordExpiresAt: string | null;
   setupRequired: boolean;
   totpRequired: boolean;
   totpToken: string | null;
@@ -61,6 +62,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [mustChangePassword, setMustChangePassword] = useState(false);
+  const [passwordExpiresAt, setPasswordExpiresAt] = useState<string | null>(null);
   const [setupRequired, setSetupRequired] = useState(false);
   const [totpRequired, setTotpRequired] = useState(false);
   const [totpToken, setTotpToken] = useState<string | null>(null);
@@ -71,9 +73,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     try {
       const { data, error } = await sdkGetCurrentUser();
       if (error) throw error;
-      setUser(data as unknown as User);
+      const userData = data as unknown as User;
+      setUser(userData);
+      setPasswordExpiresAt(userData.password_expires_at ?? null);
+      if (userData.must_change_password) {
+        setMustChangePassword(true);
+      }
     } catch {
       setUser(null);
+      setPasswordExpiresAt(null);
       clearTokens();
     }
   }, []);
@@ -135,6 +143,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       clearTokens();
       setUser(null);
       setMustChangePassword(false);
+      setPasswordExpiresAt(null);
     }
   }, []);
 
@@ -147,6 +156,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (error) throw error;
 
       setMustChangePassword(false);
+      setPasswordExpiresAt(null);
       setSetupRequired(false);
     },
     [user]
@@ -175,7 +185,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       try {
         const { data, error } = await sdkGetCurrentUser();
         if (!error && data) {
-          setUser(data as unknown as User);
+          const userData = data as unknown as User;
+          setUser(userData);
+          setPasswordExpiresAt(userData.password_expires_at ?? null);
+          if (userData.must_change_password) {
+            setMustChangePassword(true);
+          }
           setIsLoading(false);
           return;
         }
@@ -222,6 +237,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         isAuthenticated,
         isLoading,
         mustChangePassword,
+        passwordExpiresAt,
         setupRequired,
         totpRequired,
         totpToken,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,6 +31,7 @@ export interface User {
   is_admin: boolean;
   is_active?: boolean;
   must_change_password?: boolean;
+  password_expires_at?: string | null;
   totp_enabled?: boolean;
 }
 


### PR DESCRIPTION
## Summary

Closes #259.

When the backend sets `PASSWORD_EXPIRY_DAYS`, the web UI now handles two scenarios:

- **Warning banner**: If `password_expires_at` is present on the user profile and the password expires within 7 days, a sticky amber banner appears at the top of every page with the message "Your password expires in X days. Change it now." linking to `/change-password`.
- **Force change redirect**: If `must_change_password` is true on the user profile (expired or admin-reset passwords), `RequireAuth` redirects the user to `/change-password` and blocks navigation to other protected pages until the password is changed. The `/change-password` and `/profile` routes are exempted from the redirect so the user can complete the flow.

The auth context now tracks `passwordExpiresAt` from the user profile response and clears it on logout or successful password change. The `User` type gains an optional `password_expires_at` field. This is forward-compatible: when the backend adds `password_expires_at` to the `/auth/me` response, the banner will activate automatically. The `must_change_password` force-change flow works today with the existing API.

### Files changed

| File | Change |
|------|--------|
| `src/types/index.ts` | Add optional `password_expires_at` field to `User` |
| `src/providers/auth-provider.tsx` | Track `passwordExpiresAt` in context, extract password expiry from user data on init and refresh |
| `src/components/layout/password-expiry-banner.tsx` | New banner component with 7-day warning threshold |
| `src/components/auth/require-auth.tsx` | Redirect to `/change-password` when `mustChangePassword` is true |
| `src/app/(app)/layout.tsx` | Add `PasswordExpiryBanner` to app layout |
| `src/components/layout/__tests__/password-expiry-banner.test.tsx` | 9 unit tests for banner visibility and messaging |
| `src/components/auth/__tests__/require-auth.test.tsx` | 6 unit tests for auth guard and force-change redirect |

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [ ] Playwright E2E spec covers the change
- [x] Responsive layout verified (mobile + desktop)
- [x] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes