### PR TITLE
fix: handle empty response bodies in apiFetch to prevent stale cache

### DIFF
--- a/src/lib/api/__tests__/fetch.test.ts
+++ b/src/lib/api/__tests__/fetch.test.ts
@@ -20,9 +20,15 @@ function mockResponse(options: {
     ok = true,
     status = 200,
     json,
-    text = "",
+    text,
     textRejects = false,
   } = options;
+
+  // When `json` is provided but `text` is not, serialize the JSON value so
+  // both `.json()` and `.text()` return consistent data. The implementation
+  // reads the body via `.text()` + `JSON.parse()` to safely handle empty
+  // response bodies.
+  const resolvedText = text ?? (json !== undefined ? JSON.stringify(json) : "");
 
   return {
     ok,
@@ -30,7 +36,7 @@ function mockResponse(options: {
     json: vi.fn().mockResolvedValue(json),
     text: textRejects
       ? vi.fn().mockRejectedValue(new Error("body read failed"))
-      : vi.fn().mockResolvedValue(text),
+      : vi.fn().mockResolvedValue(resolvedText),
     headers: new Headers(),
   } as unknown as Response;
 }
@@ -68,6 +74,18 @@ describe("apiFetch", () => {
     mockFetch.mockResolvedValue(mockResponse({ ok: true, status: 204 }));
 
     const result = await apiFetch<void>("/api/v1/service-accounts/sa-1");
+
+    expect(result).toBeUndefined();
+  });
+
+  // ---- 200 with empty body (e.g. DELETE rewritten from 204 by proxy) ----
+
+  it("returns undefined for 200 response with empty body", async () => {
+    mockFetch.mockResolvedValue(mockResponse({ ok: true, status: 200, text: "" }));
+
+    const result = await apiFetch<void>("/api/v1/service-accounts/sa-1", {
+      method: "DELETE",
+    });
 
     expect(result).toBeUndefined();
   });

--- a/src/lib/api/__tests__/fetch.test.ts
+++ b/src/lib/api/__tests__/fetch.test.ts
@@ -90,6 +90,18 @@ describe("apiFetch", () => {
     expect(result).toBeUndefined();
   });
 
+  // ---- 200 with whitespace-only body ----
+
+  it("returns undefined for 200 response with whitespace-only body", async () => {
+    mockFetch.mockResolvedValue(mockResponse({ ok: true, status: 200, text: "  \n\t  " }));
+
+    const result = await apiFetch<void>("/api/v1/service-accounts/sa-1", {
+      method: "DELETE",
+    });
+
+    expect(result).toBeUndefined();
+  });
+
   // ---- Non-ok response error handling ----
 
   it("throws an error with status and body for non-ok response", async () => {

--- a/src/lib/api/fetch.ts
+++ b/src/lib/api/fetch.ts
@@ -31,6 +31,6 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
   // response.json() on an empty body throws a SyntaxError which would cause
   // mutations to appear to fail even though the server processed the request.
   const text = await response.text();
-  if (!text) return undefined as T;
+  if (!text.trim()) return undefined as T;
   return JSON.parse(text) as T;
 }

--- a/src/lib/api/fetch.ts
+++ b/src/lib/api/fetch.ts
@@ -25,5 +25,12 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
     throw new Error(`API error ${response.status}: ${body}`);
   }
   if (response.status === 204) return undefined as T;
-  return response.json() as Promise<T>;
+
+  // Guard against empty response bodies (e.g. 200 with no content, or a 204
+  // that was rewritten to 200 by the Next.js middleware proxy). Calling
+  // response.json() on an empty body throws a SyntaxError which would cause
+  // mutations to appear to fail even though the server processed the request.
+  const text = await response.text();
+  if (!text) return undefined as T;
+  return JSON.parse(text) as T;
 }


### PR DESCRIPTION
## Summary

Fixes #256. After deleting a service account, the list showed stale data until a hard refresh because the `apiFetch` wrapper threw a `SyntaxError` when parsing an empty response body on non-204 status codes.

The backend returns 204 for DELETE, but the Next.js middleware proxy can rewrite 204 responses to 200 with an empty body. The previous code called `response.json()` unconditionally for all non-204 responses, which throws on empty bodies. This caused the `useMutation` `onError` handler to fire instead of `onSuccess`, skipping the `queryClient.invalidateQueries()` call and leaving stale data in the React Query cache.

The fix reads the body as text first and skips JSON parsing when the body is empty, allowing the mutation to resolve successfully so the cache invalidation runs.

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [x] N/A - no UI changes