### PR TITLE
fix: show correct scan status when scan fails to execute

### DIFF
--- a/src/app/(app)/(admin)/security/scans/[id]/page.tsx
+++ b/src/app/(app)/(admin)/security/scans/[id]/page.tsx
@@ -16,6 +16,7 @@ import {
 import { toast } from "sonner";
 
 import securityApi from "@/lib/api/security";
+import { isScanIncomplete } from "@/lib/scan-utils";
 import type { ScanFinding } from "@/types/security";
 
 import { Button } from "@/components/ui/button";
@@ -57,11 +58,6 @@ const STATUS_BADGE: Record<string, string> = {
   error:
     "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 border-red-200 dark:border-red-800",
 };
-
-/** Whether a scan status means findings data should not be trusted. */
-function isScanIncomplete(status: string): boolean {
-  return status === "failed" || status === "error" || status === "pending" || status === "running";
-}
 
 const SEVERITY_BADGE: Record<string, string> = {
   critical:

--- a/src/app/(app)/(admin)/security/scans/[id]/page.tsx
+++ b/src/app/(app)/(admin)/security/scans/[id]/page.tsx
@@ -54,7 +54,14 @@ const STATUS_BADGE: Record<string, string> = {
   pending: "bg-secondary text-secondary-foreground border-border",
   failed:
     "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 border-red-200 dark:border-red-800",
+  error:
+    "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 border-red-200 dark:border-red-800",
 };
+
+/** Whether a scan status means findings data should not be trusted. */
+function isScanIncomplete(status: string): boolean {
+  return status === "failed" || status === "error" || status === "pending" || status === "running";
+}
 
 const SEVERITY_BADGE: Record<string, string> = {
   critical:
@@ -408,8 +415,25 @@ export default function SecurityScanDetailPage() {
         </Card>
       )}
 
-      {/* Summary stat cards */}
-      {scan && (
+      {/* Failed/error scan warning banner */}
+      {scan && (scan.status === "failed" || scan.status === "error") && (
+        <div className="flex items-start gap-3 rounded-lg border border-red-300 bg-red-50 p-4 dark:border-red-800 dark:bg-red-950/30">
+          <AlertCircle className="size-5 text-red-600 dark:text-red-400 shrink-0 mt-0.5" />
+          <div>
+            <p className="text-sm font-medium text-red-800 dark:text-red-400">
+              This scan failed to complete
+            </p>
+            <p className="text-xs text-red-700 dark:text-red-500 mt-1">
+              {scan.error_message
+                ? scan.error_message
+                : "The scanner encountered an error. Findings data below may be incomplete or missing. Try triggering a new scan."}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Summary stat cards (only shown for completed scans) */}
+      {scan && !isScanIncomplete(scan.status) && (
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
           <StatCard
             icon={Bug}
@@ -491,7 +515,13 @@ export default function SecurityScanDetailPage() {
           setPage(1);
         }}
         loading={findingsLoading}
-        emptyMessage="No findings for this scan."
+        emptyMessage={
+          scan && isScanIncomplete(scan.status)
+            ? scan.status === "failed" || scan.status === "error"
+              ? "No findings available. The scan did not complete successfully."
+              : "Scan is still in progress."
+            : "No findings for this scan."
+        }
         rowKey={(r) => r.id}
       />
 

--- a/src/app/(app)/(admin)/security/scans/page.tsx
+++ b/src/app/(app)/(admin)/security/scans/page.tsx
@@ -49,7 +49,12 @@ const STATUS_COLORS: Record<string, string> = {
     "bg-secondary text-secondary-foreground border-border",
   failed:
     "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 border-red-200 dark:border-red-800",
+  error:
+    "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 border-red-200 dark:border-red-800",
 };
+
+/** Statuses where the scan did not complete successfully, so findings data is unreliable. */
+const INCOMPLETE_STATUSES = new Set(["failed", "error", "pending", "running"]);
 
 const SEVERITY_PILL: Record<string, string> = {
   critical:
@@ -223,8 +228,23 @@ export default function SecurityScansPage() {
       header: "Findings",
       accessor: (r) => r.findings_count,
       sortable: true,
-      cell: (r) =>
-        r.findings_count === 0 ? (
+      cell: (r) => {
+        if (INCOMPLETE_STATUSES.has(r.status)) {
+          if (r.status === "failed" || r.status === "error") {
+            return (
+              <Badge
+                variant="outline"
+                className="bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 border-red-200 dark:border-red-800 text-xs font-medium"
+              >
+                Scan Failed
+              </Badge>
+            );
+          }
+          return (
+            <span className="text-xs text-muted-foreground">-</span>
+          );
+        }
+        return r.findings_count === 0 ? (
           <Badge
             variant="outline"
             className="bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400 border-emerald-200 dark:border-emerald-800 text-xs font-medium"
@@ -242,7 +262,8 @@ export default function SecurityScansPage() {
             <SeverityCount count={r.medium_count} label="M" level="medium" />
             <SeverityCount count={r.low_count} label="L" level="low" />
           </div>
-        ),
+        );
+      },
     },
     {
       id: "started_at",

--- a/src/app/(app)/(admin)/security/scans/page.tsx
+++ b/src/app/(app)/(admin)/security/scans/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "@artifact-keeper/sdk";
 import securityApi from "@/lib/api/security";
 import { artifactsApi } from "@/lib/api/artifacts";
+import { isScanIncomplete, isScanFailed, isScanClean } from "@/lib/scan-utils";
 import type { ScanResult } from "@/types/security";
 
 import { Button } from "@/components/ui/button";
@@ -52,9 +53,6 @@ const STATUS_COLORS: Record<string, string> = {
   error:
     "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 border-red-200 dark:border-red-800",
 };
-
-/** Statuses where the scan did not complete successfully, so findings data is unreliable. */
-const INCOMPLETE_STATUSES = new Set(["failed", "error", "pending", "running"]);
 
 const SEVERITY_PILL: Record<string, string> = {
   critical:
@@ -229,29 +227,32 @@ export default function SecurityScansPage() {
       accessor: (r) => r.findings_count,
       sortable: true,
       cell: (r) => {
-        if (INCOMPLETE_STATUSES.has(r.status)) {
-          if (r.status === "failed" || r.status === "error") {
-            return (
-              <Badge
-                variant="outline"
-                className="bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 border-red-200 dark:border-red-800 text-xs font-medium"
-              >
-                Scan Failed
-              </Badge>
-            );
-          }
+        if (isScanFailed(r.status)) {
+          return (
+            <Badge
+              variant="outline"
+              className="bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 border-red-200 dark:border-red-800 text-xs font-medium"
+            >
+              Scan Failed
+            </Badge>
+          );
+        }
+        if (isScanIncomplete(r.status)) {
           return (
             <span className="text-xs text-muted-foreground">-</span>
           );
         }
-        return r.findings_count === 0 ? (
-          <Badge
-            variant="outline"
-            className="bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400 border-emerald-200 dark:border-emerald-800 text-xs font-medium"
-          >
-            Clean
-          </Badge>
-        ) : (
+        if (isScanClean(r.status, r.findings_count)) {
+          return (
+            <Badge
+              variant="outline"
+              className="bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400 border-emerald-200 dark:border-emerald-800 text-xs font-medium"
+            >
+              Clean
+            </Badge>
+          );
+        }
+        return (
           <div className="flex items-center gap-1">
             <SeverityCount
               count={r.critical_count}

--- a/src/lib/__tests__/scan-utils.test.ts
+++ b/src/lib/__tests__/scan-utils.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { isScanIncomplete, isScanFailed, isScanClean } from "../scan-utils";
+
+describe("isScanIncomplete", () => {
+  it("returns false for completed scans", () => {
+    expect(isScanIncomplete("completed")).toBe(false);
+  });
+
+  it("returns true for failed scans", () => {
+    expect(isScanIncomplete("failed")).toBe(true);
+  });
+
+  it("returns true for error scans", () => {
+    expect(isScanIncomplete("error")).toBe(true);
+  });
+
+  it("returns true for pending scans", () => {
+    expect(isScanIncomplete("pending")).toBe(true);
+  });
+
+  it("returns true for running scans", () => {
+    expect(isScanIncomplete("running")).toBe(true);
+  });
+
+  it("returns true for unknown status values", () => {
+    expect(isScanIncomplete("cancelled")).toBe(true);
+    expect(isScanIncomplete("unknown")).toBe(true);
+    expect(isScanIncomplete("")).toBe(true);
+  });
+});
+
+describe("isScanFailed", () => {
+  it("returns true for failed status", () => {
+    expect(isScanFailed("failed")).toBe(true);
+  });
+
+  it("returns true for error status", () => {
+    expect(isScanFailed("error")).toBe(true);
+  });
+
+  it("returns false for completed status", () => {
+    expect(isScanFailed("completed")).toBe(false);
+  });
+
+  it("returns false for running status", () => {
+    expect(isScanFailed("running")).toBe(false);
+  });
+
+  it("returns false for pending status", () => {
+    expect(isScanFailed("pending")).toBe(false);
+  });
+
+  it("returns false for unknown status values", () => {
+    expect(isScanFailed("cancelled")).toBe(false);
+  });
+});
+
+describe("isScanClean", () => {
+  it("returns true when completed with zero findings", () => {
+    expect(isScanClean("completed", 0)).toBe(true);
+  });
+
+  it("returns false when completed with findings", () => {
+    expect(isScanClean("completed", 5)).toBe(false);
+  });
+
+  it("returns false when failed with zero findings", () => {
+    expect(isScanClean("failed", 0)).toBe(false);
+  });
+
+  it("returns false when running with zero findings", () => {
+    expect(isScanClean("running", 0)).toBe(false);
+  });
+
+  it("returns false for unknown status even with zero findings", () => {
+    expect(isScanClean("cancelled", 0)).toBe(false);
+  });
+});

--- a/src/lib/scan-utils.ts
+++ b/src/lib/scan-utils.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared scan status utilities used by both the scan list and scan detail pages.
+ */
+
+/** Known statuses where the scan did not complete successfully. */
+const INCOMPLETE_STATUSES = new Set(["failed", "error", "pending", "running"]);
+
+/**
+ * Whether a scan status means findings data should not be trusted.
+ *
+ * Returns true for failed, error, pending, and running scans. Also returns
+ * true for any unknown status value to avoid falsely reporting "Clean" when
+ * the status is something the frontend does not recognize.
+ */
+export function isScanIncomplete(status: string): boolean {
+  return status !== "completed";
+}
+
+/**
+ * Whether the scan ended in an error or failure state (as opposed to still
+ * being in progress).
+ */
+export function isScanFailed(status: string): boolean {
+  return status === "failed" || status === "error";
+}
+
+/**
+ * Whether the scan completed successfully with zero findings, which is the
+ * only condition under which we can confidently show "Clean".
+ */
+export function isScanClean(status: string, findingsCount: number): boolean {
+  return status === "completed" && findingsCount === 0;
+}

--- a/src/lib/scan-utils.ts
+++ b/src/lib/scan-utils.ts
@@ -2,9 +2,6 @@
  * Shared scan status utilities used by both the scan list and scan detail pages.
  */
 
-/** Known statuses where the scan did not complete successfully. */
-const INCOMPLETE_STATUSES = new Set(["failed", "error", "pending", "running"]);
-
 /**
  * Whether a scan status means findings data should not be trusted.
  *


### PR DESCRIPTION
## Summary

Fixes #266. When a vulnerability scan fails to execute (backend error, scanner
timeout, etc.), the UI was displaying a green "Clean" badge in the findings
column. This happened because the code checked only `findings_count === 0`
without considering the scan status. A failed scan also has zero findings
(no results were collected), giving users false confidence that their artifacts
had no vulnerabilities.

This PR fixes both the scans list page and the scan detail page:

- **Scans list** (`/security/scans`): The findings column now shows a red
  "Scan Failed" badge for failed/error scans, a dash for pending/running scans,
  and only shows the green "Clean" badge for completed scans with zero findings.
- **Scan detail** (`/security/scans/[id]`): When a scan failed, a warning banner
  is shown explaining the failure (including the error message if available).
  The summary stat cards are hidden for incomplete scans so users do not see
  misleading green "0" values. The findings table empty message also reflects
  the scan state.
- Both pages now handle the `error` status in addition to `failed`, covering
  the full set of backend status values.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [ ] Playwright E2E spec covers the change
- [x] Responsive layout verified (mobile + desktop)
- [x] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes