### PR TITLE
ci: replace SonarCloud with native 80% coverage and 3% duplication gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,134 @@ jobs:
           name: coverage-report
           path: coverage/
           retention-days: 14
-      - name: SonarCloud Scan
-        if: env.SONAR_TOKEN != ''
-        uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7.1.0
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      - name: Coverage summary and gate
+        run: |
+          # Parse coverage summary from vitest output
+          if [ -f coverage/coverage-summary.json ]; then
+            RESULT=$(python3 -c "
+          import json
+          data = json.load(open('coverage/coverage-summary.json'))
+          total = data.get('total', {})
+          lines = total.get('lines', {})
+          pct = lines.get('pct', 0)
+          covered = lines.get('covered', 0)
+          total_lines = lines.get('total', 0)
+          print(f'{pct} {covered} {total_lines}')
+          ")
+            PCT=$(echo "$RESULT" | awk '{print $1}')
+            echo "### Coverage: ${PCT}% lines" >> $GITHUB_STEP_SUMMARY
+            echo "Total coverage: ${PCT}%"
+          else
+            echo "No coverage summary found"
+            PCT="0"
+          fi
+
+      - name: New code coverage gate
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags --depth=1 origin ${{ github.base_ref }}
+          CHANGED_FILES=$(git diff --name-only FETCH_HEAD -- 'src/**/*.ts' 'src/**/*.tsx' 2>/dev/null | grep -v '\.test\.\|\.spec\.\|__tests__' || true)
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No source files changed, skipping new code coverage check"
+            echo "### New Code Coverage: N/A (no source changes)" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+
+          if [ ! -f coverage/lcov.info ]; then
+            echo "No lcov.info found, skipping"
+            exit 0
+          fi
+
+          RESULT=$(python3 -c "
+          import sys
+          changed = set('''$CHANGED_FILES'''.split())
+          hit = miss = 0
+          in_changed = False
+          for line in open('coverage/lcov.info'):
+              line = line.strip()
+              if line.startswith('SF:'):
+                  path = line[3:]
+                  in_changed = any(path.endswith(f) for f in changed)
+              elif line.startswith('DA:') and in_changed:
+                  parts = line[3:].split(',')
+                  count = int(parts[1])
+                  if count > 0:
+                      hit += 1
+                  else:
+                      miss += 1
+          total = hit + miss
+          if total == 0:
+              print('none')
+          else:
+              pct = (hit * 100) // total
+              print(f'{pct} {hit} {total}')
+          ")
+
+          if [ "$RESULT" = "none" ]; then
+            echo "### New Code Coverage: N/A (no instrumented lines)" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+
+          PCT=$(echo "$RESULT" | awk '{print $1}')
+          HIT=$(echo "$RESULT" | awk '{print $2}')
+          TOTAL=$(echo "$RESULT" | awk '{print $3}')
+
+          echo "### New Code Coverage: ${PCT}% (${HIT}/${TOTAL} lines)" >> $GITHUB_STEP_SUMMARY
+          echo "New code coverage: ${PCT}% (${HIT}/${TOTAL} lines)"
+
+          if [ "$PCT" -lt 80 ]; then
+            echo "::error::New code coverage is ${PCT}%, below 80% threshold"
+            exit 1
+          fi
+
+      - name: Code duplication gate
+        if: always() && github.event_name == 'pull_request'
+        run: |
+          npm install -g jscpd@4 --silent 2>/dev/null
+          git fetch --no-tags --depth=1 origin ${{ github.base_ref }} 2>/dev/null || true
+          CHANGED_SRC=$(git diff --name-only FETCH_HEAD -- 'src/**/*.ts' 'src/**/*.tsx' 2>/dev/null | grep -v '\.test\.\|\.spec\.\|__tests__' || true)
+
+          if [ -z "$CHANGED_SRC" ]; then
+            echo "### Code Duplication: N/A (no source changes)" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+
+          RESULT=$(jscpd --min-lines 10 --threshold 3 --reporters json \
+            --format typescript,tsx --output /tmp/jscpd-report \
+            $(echo "$CHANGED_SRC" | tr '\n' ' ') 2>&1) || true
+
+          if [ -f /tmp/jscpd-report/jscpd-report.json ]; then
+            DUP_PCT=$(python3 -c "
+          import json
+          data = json.load(open('/tmp/jscpd-report/jscpd-report.json'))
+          stats = data.get('statistics', {})
+          total = stats.get('total', {})
+          pct = total.get('percentage', 0)
+          dups = total.get('duplicatedLines', 0)
+          lines = total.get('lines', 0)
+          clones = len(data.get('duplicates', []))
+          print(f'{pct:.1f} {dups} {lines} {clones}')
+          " 2>/dev/null) || DUP_PCT="0.0 0 0 0"
+
+            PCT=$(echo "$DUP_PCT" | awk '{print $1}')
+            echo "### Code Duplication: ${PCT}%" >> $GITHUB_STEP_SUMMARY
+
+            OVER=$(python3 -c "print('yes' if float('${PCT}') > 3.0 else 'no')")
+            if [ "$OVER" = "yes" ]; then
+              echo "::error::Code duplication is ${PCT}%, exceeding 3% threshold"
+              python3 -c "
+          import json
+          data = json.load(open('/tmp/jscpd-report/jscpd-report.json'))
+          for d in data.get('duplicates', []):
+              fa, sa = d['firstFile'], d['secondFile']
+              print(f\"  {fa['name']}:{fa['startLoc']['line']}-{fa['endLoc']['line']} <-> {sa['name']}:{sa['startLoc']['line']}-{sa['endLoc']['line']}\")
+          " 2>/dev/null || true
+              exit 1
+            fi
+          else
+            echo "### Code Duplication: 0%" >> $GITHUB_STEP_SUMMARY
+          fi
 
   build:
     name: Build

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,9 +1,0 @@
-sonar.projectKey=artifact-keeper_artifact-keeper-web
-sonar.organization=artifact-keeper
-sonar.sources=src
-sonar.tests=src
-sonar.test.inclusions=**/__tests__/**,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
-sonar.exclusions=node_modules/**,.next/**,out/**,coverage/**
-sonar.coverage.exclusions=**/__tests__/**,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
-sonar.javascript.lcov.reportPaths=coverage/lcov.info
-sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary

Replace SonarCloud with native quality gates, same approach as the backend repo:

- **80% new code coverage**: checks changed .ts/.tsx files against lcov.info, fails PR if below 80%
- **3% duplication**: runs jscpd on changed source files, fails PR if above 3%
- **Coverage summary**: printed to GitHub Actions step summary
- Removed `sonar-project.properties`
- SonarCloud scan step removed from CI

## Test Checklist
- [x] No regressions in existing tests

## API Changes
- [x] N/A