### PR TITLE
feat: add global-error and root error boundary pages

### DIFF
--- a/src/app/__tests__/error.test.tsx
+++ b/src/app/__tests__/error.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("lucide-react", () => {
+  const stub = (name: string) => {
+    const Icon = (props: any) => (
+      <span data-testid={`icon-${name}`} {...props} />
+    );
+    Icon.displayName = name;
+    return Icon;
+  };
+  return {
+    AlertTriangle: stub("AlertTriangle"),
+    RefreshCw: stub("RefreshCw"),
+    Home: stub("Home"),
+  };
+});
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, asChild, ...props }: any) => {
+    if (asChild) return <>{children}</>;
+    return <button {...props}>{children}</button>;
+  },
+}));
+
+import RootError from "../error";
+
+describe("RootError", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders the error heading and description", () => {
+    const error = new Error("test") as Error & { digest?: string };
+    const reset = vi.fn();
+
+    render(<RootError error={error} reset={reset} />);
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(
+      screen.getByText(/An unexpected error occurred/)
+    ).toBeInTheDocument();
+  });
+
+  it("displays the error digest when present", () => {
+    const error = Object.assign(new Error("test"), { digest: "root-abc" });
+    const reset = vi.fn();
+
+    render(<RootError error={error} reset={reset} />);
+
+    expect(screen.getByText("Error ID: root-abc")).toBeInTheDocument();
+  });
+
+  it("does not display an error ID when digest is absent", () => {
+    const error = new Error("test") as Error & { digest?: string };
+    const reset = vi.fn();
+
+    render(<RootError error={error} reset={reset} />);
+
+    expect(screen.queryByText(/Error ID:/)).not.toBeInTheDocument();
+  });
+
+  it("calls reset when the Try again button is clicked", () => {
+    const error = new Error("test") as Error & { digest?: string };
+    const reset = vi.fn();
+
+    render(<RootError error={error} reset={reset} />);
+
+    fireEvent.click(screen.getByText("Try again"));
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a link back to the dashboard", () => {
+    const error = new Error("test") as Error & { digest?: string };
+    const reset = vi.fn();
+
+    render(<RootError error={error} reset={reset} />);
+
+    const link = screen.getByText("Dashboard").closest("a");
+    expect(link).toHaveAttribute("href", "/");
+  });
+
+  it("logs the error to console.error", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new Error("root boom") as Error & { digest?: string };
+    const reset = vi.fn();
+
+    render(<RootError error={error} reset={reset} />);
+
+    expect(consoleSpy).toHaveBeenCalledWith("Root error:", error);
+  });
+
+  it("renders the AlertTriangle icon", () => {
+    const error = new Error("test") as Error & { digest?: string };
+    const reset = vi.fn();
+
+    render(<RootError error={error} reset={reset} />);
+
+    expect(screen.getByTestId("icon-AlertTriangle")).toBeInTheDocument();
+  });
+});

--- a/src/app/__tests__/global-error.test.tsx
+++ b/src/app/__tests__/global-error.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import GlobalError from "../global-error";
+
+describe("GlobalError", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders a full html document with lang attribute", () => {
+    const error = new Error("test") as Error & { digest?: string };
+    const reset = vi.fn();
+
+    render(<GlobalError error={error} reset={reset} />);
+
+    // JSDOM hoists <html> to document level rather than keeping it inside
+    // the render container, so we query the document directly.
+    const html = document.querySelector("html");
+    expect(html).toBeInTheDocument();
+    expect(html).toHaveAttribute("lang", "en");
+  });
+
+  it("renders the Artifact Keeper logo", () => {
+    const error = new Error("test") as Error & { digest?: string };
+    const reset = vi.fn();
+
+    render(<GlobalError error={error} reset={reset} />);
+
+    const img = screen.getByAltText("Artifact Keeper");
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("src", "/logo-48.png");
+    expect(img).toHaveAttribute("width", "48");
+    expect(img).toHaveAttribute("height", "48");
+  });
+
+  it("renders the error heading", () => {
+    const error = new Error("test") as Error & { digest?: string };
+    const reset = vi.fn();
+
+    render(<GlobalError error={error} reset={reset} />);
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+  });
+
+  it("renders the error description", () => {
+    const error = new Error("test") as Error & { digest?: string };
+    const reset = vi.fn();
+
+    render(<GlobalError error={error} reset={reset} />);
+
+    expect(
+      screen.getByText(/A critical error prevented this page from loading/)
+    ).toBeInTheDocument();
+  });
+
+  it("displays the error digest when present", () => {
+    const error = Object.assign(new Error("test"), { digest: "global-xyz" });
+    const reset = vi.fn();
+
+    render(<GlobalError error={error} reset={reset} />);
+
+    expect(screen.getByText("Error ID: global-xyz")).toBeInTheDocument();
+  });
+
+  it("does not display an error ID when digest is absent", () => {
+    const error = new Error("test") as Error & { digest?: string };
+    const reset = vi.fn();
+
+    render(<GlobalError error={error} reset={reset} />);
+
+    expect(screen.queryByText(/Error ID:/)).not.toBeInTheDocument();
+  });
+
+  it("calls reset when the Try again button is clicked", () => {
+    const error = new Error("test") as Error & { digest?: string };
+    const reset = vi.fn();
+
+    render(<GlobalError error={error} reset={reset} />);
+
+    fireEvent.click(screen.getByText("Try again"));
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a link to the home page", () => {
+    const error = new Error("test") as Error & { digest?: string };
+    const reset = vi.fn();
+
+    render(<GlobalError error={error} reset={reset} />);
+
+    const link = screen.getByText("Go to home page");
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/");
+  });
+
+  it("logs the error to console.error", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new Error("global boom") as Error & { digest?: string };
+    const reset = vi.fn();
+
+    render(<GlobalError error={error} reset={reset} />);
+
+    expect(consoleSpy).toHaveBeenCalledWith("Global error:", error);
+  });
+
+  it("renders a body element", () => {
+    const error = new Error("test") as Error & { digest?: string };
+    const reset = vi.fn();
+
+    render(<GlobalError error={error} reset={reset} />);
+
+    // JSDOM hoists <body> to the document level.
+    const body = document.querySelector("body");
+    expect(body).toBeInTheDocument();
+  });
+});

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw, Home } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default function RootError({
+  error,
+  reset,
+}: Readonly<{
+  error: Error & { digest?: string };
+  reset: () => void;
+}>) {
+  useEffect(() => {
+    console.error("Root error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-svh flex-col items-center justify-center px-6">
+      <div className="flex flex-col items-center text-center max-w-md">
+        <div className="flex size-16 items-center justify-center rounded-2xl bg-destructive/10 mb-6">
+          <AlertTriangle className="size-8 text-destructive" />
+        </div>
+        <h2 className="text-xl font-semibold tracking-tight">
+          Something went wrong
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground leading-relaxed">
+          An unexpected error occurred. You can try again, or go back to the
+          dashboard.
+        </p>
+        {error.digest && (
+          <p className="mt-2 text-xs text-muted-foreground font-mono">
+            Error ID: {error.digest}
+          </p>
+        )}
+        <div className="mt-6 flex items-center gap-3">
+          <Button onClick={reset} variant="default" size="sm">
+            <RefreshCw className="mr-2 size-4" />
+            Try again
+          </Button>
+          <Button asChild variant="outline" size="sm">
+            <Link href="/">
+              <Home className="mr-2 size-4" />
+              Dashboard
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function GlobalError({
+  error,
+  reset,
+}: Readonly<{
+  error: Error & { digest?: string };
+  reset: () => void;
+}>) {
+  useEffect(() => {
+    console.error("Global error:", error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          minHeight: "100svh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily:
+            "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+          backgroundColor: "#0a0a12",
+          color: "#e8e0d4",
+          padding: "1.5rem",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            textAlign: "center",
+            maxWidth: "28rem",
+          }}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src="/logo-48.png"
+            alt="Artifact Keeper"
+            width={48}
+            height={48}
+            style={{ marginBottom: "1.5rem" }}
+          />
+          <h1
+            style={{
+              fontSize: "1.25rem",
+              fontWeight: 600,
+              letterSpacing: "-0.025em",
+              margin: 0,
+            }}
+          >
+            Something went wrong
+          </h1>
+          <p
+            style={{
+              marginTop: "0.5rem",
+              fontSize: "0.875rem",
+              lineHeight: 1.6,
+              color: "#9a918a",
+            }}
+          >
+            A critical error prevented this page from loading. You can try again,
+            or go back to the home page.
+          </p>
+          {error.digest && (
+            <p
+              style={{
+                marginTop: "0.5rem",
+                fontSize: "0.75rem",
+                color: "#9a918a",
+                fontFamily: "ui-monospace, monospace",
+              }}
+            >
+              Error ID: {error.digest}
+            </p>
+          )}
+          <div
+            style={{
+              marginTop: "1.5rem",
+              display: "flex",
+              alignItems: "center",
+              gap: "0.75rem",
+            }}
+          >
+            <button
+              onClick={reset}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                borderRadius: "0.375rem",
+                backgroundColor: "#d4a853",
+                color: "#0a0a12",
+                padding: "0.625rem 1rem",
+                fontSize: "0.875rem",
+                fontWeight: 500,
+                border: "none",
+                cursor: "pointer",
+              }}
+            >
+              Try again
+            </button>
+            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+            <a
+              href="/"
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                borderRadius: "0.375rem",
+                border: "1px solid rgba(255, 255, 255, 0.12)",
+                backgroundColor: "transparent",
+                color: "#e8e0d4",
+                padding: "0.625rem 1rem",
+                fontSize: "0.875rem",
+                fontWeight: 500,
+                textDecoration: "none",
+                cursor: "pointer",
+              }}
+            >
+              Go to home page
+            </a>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Summary

Adds the missing `global-error.tsx` and root-level `error.tsx` files to
the Next.js app. Without these, unhandled errors in layouts or pages
fall through to the generic Next.js error screen instead of showing a
branded Artifact Keeper error page.

- `global-error.tsx` replaces the entire root layout on critical
  failures. It renders a full HTML document with inline styles (no
  external dependencies), the Artifact Keeper logo, a "Try again"
  button, and a link to the home page. Uses inline styles because
  Tailwind and component libraries are unavailable when the root
  layout itself has crashed.
- `error.tsx` at the app root handles route-level errors that escape
  the `(app)` and `(auth)` route group boundaries. Follows the same
  visual pattern as the existing route group error boundaries.
- Both components display the error digest when available and log
  errors to `console.error`.

Closes #210

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [ ] Playwright E2E spec covers the change
- [x] Responsive layout verified (mobile + desktop)
- [x] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes