### PR TITLE
feat: show auth source badge on admin users list and edit dialog

### DIFF
--- a/src/app/(app)/(admin)/users/__tests__/page.test.tsx
+++ b/src/app/(app)/(admin)/users/__tests__/page.test.tsx
@@ -236,6 +236,18 @@ vi.mock("@/components/common/status-badge", () => ({
   ),
 }));
 
+vi.mock("@/components/common/auth-source-badge", () => ({
+  AuthSourceBadge: ({ provider }: any) => (
+    <span data-testid="auth-source-badge">{provider ?? "local"}</span>
+  ),
+  getAuthProviderLabel: (provider?: string) => {
+    if (!provider) return "Local";
+    const map: Record<string, string> = { local: "Local", ldap: "LDAP", oidc: "OIDC", saml: "SAML" };
+    const normalized = provider.toLowerCase();
+    return map[normalized] ?? provider.charAt(0).toUpperCase() + provider.slice(1);
+  },
+}));
+
 vi.mock("@/components/common/confirm-dialog", () => ({
   ConfirmDialog: ({ open, title, onConfirm, onOpenChange }: any) =>
     open ? (
@@ -274,6 +286,7 @@ const adminUser = {
   email: "admin@test.com",
   is_admin: true,
   is_active: true,
+  auth_provider: "local",
 };
 
 const regularUser = {
@@ -283,6 +296,7 @@ const regularUser = {
   display_name: "John Doe",
   is_admin: false,
   is_active: true,
+  auth_provider: "ldap",
 };
 
 const mockUsers = [adminUser, regularUser];
@@ -626,6 +640,87 @@ describe("UsersPage", () => {
     setupMocks({ users: [adminUser, inactiveUser] });
     render(<UsersPage />);
     expect(screen.getAllByTestId("icon-ToggleLeft").length).toBeGreaterThanOrEqual(1);
+  });
+
+  // -- Auth Source column --
+
+  it("renders Auth Source column header in the data table", () => {
+    setupMocks();
+    render(<UsersPage />);
+    expect(screen.getByText("Auth Source")).toBeInTheDocument();
+  });
+
+  it("renders auth source badge for each user in the table", () => {
+    setupMocks();
+    render(<UsersPage />);
+    const authBadges = screen.getAllByTestId("auth-source-badge");
+    expect(authBadges.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("displays correct auth provider value for local user", () => {
+    setupMocks();
+    render(<UsersPage />);
+    const authBadges = screen.getAllByTestId("auth-source-badge");
+    expect(authBadges[0]).toHaveTextContent("local");
+  });
+
+  it("displays correct auth provider value for LDAP user", () => {
+    setupMocks();
+    render(<UsersPage />);
+    const authBadges = screen.getAllByTestId("auth-source-badge");
+    expect(authBadges[1]).toHaveTextContent("ldap");
+  });
+
+  it("renders auth source badges for different provider types", () => {
+    const oidcUser = { ...regularUser, id: "user-3", username: "oidcuser", auth_provider: "oidc" };
+    const samlUser = { ...regularUser, id: "user-4", username: "samluser", auth_provider: "saml" };
+    setupMocks({ users: [adminUser, oidcUser, samlUser] });
+    render(<UsersPage />);
+    const authBadges = screen.getAllByTestId("auth-source-badge");
+    expect(authBadges).toHaveLength(3);
+    expect(authBadges[1]).toHaveTextContent("oidc");
+    expect(authBadges[2]).toHaveTextContent("saml");
+  });
+
+  it("renders auth source badge for user with no auth_provider field", () => {
+    const noProviderUser = { ...regularUser, auth_provider: undefined };
+    setupMocks({ users: [noProviderUser] });
+    render(<UsersPage />);
+    const authBadges = screen.getAllByTestId("auth-source-badge");
+    expect(authBadges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // -- Auth Source in edit dialog --
+
+  it("shows auth source in edit dialog", () => {
+    setupMocks();
+    render(<UsersPage />);
+    const editIcons = screen.getAllByTestId("icon-Pencil");
+    fireEvent.click(editIcons[1]); // jdoe
+    expect(screen.getByTestId("edit-auth-source")).toBeInTheDocument();
+  });
+
+  it("shows correct auth provider in edit dialog for LDAP user", () => {
+    setupMocks();
+    render(<UsersPage />);
+    const editIcons = screen.getAllByTestId("icon-Pencil");
+    fireEvent.click(editIcons[1]); // jdoe (ldap)
+    const editAuthSource = screen.getByTestId("edit-auth-source");
+    const badge = editAuthSource.querySelector('[data-testid="auth-source-badge"]');
+    expect(badge).toHaveTextContent("ldap");
+  });
+
+  it("shows Auth Source label in edit dialog", () => {
+    setupMocks();
+    render(<UsersPage />);
+    const editIcons = screen.getAllByTestId("icon-Pencil");
+    fireEvent.click(editIcons[1]);
+    // "Auth Source" appears both in the table header and the edit dialog label
+    const authSourceTexts = screen.getAllByText("Auth Source");
+    expect(authSourceTexts.length).toBeGreaterThanOrEqual(2);
+    // The edit dialog container should include the auth source label
+    const editAuthSource = screen.getByTestId("edit-auth-source");
+    expect(editAuthSource.closest("form")).toBeInTheDocument();
   });
 
   // -- User without display name --

--- a/src/app/(app)/(admin)/users/page.tsx
+++ b/src/app/(app)/(admin)/users/page.tsx
@@ -53,6 +53,7 @@ import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
 import { PageHeader } from "@/components/common/page-header";
 import { DataTable, type DataTableColumn } from "@/components/common/data-table";
 import { StatusBadge } from "@/components/common/status-badge";
+import { AuthSourceBadge, getAuthProviderLabel } from "@/components/common/auth-source-badge";
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
 import { EmptyState } from "@/components/common/empty-state";
 import { PasswordPolicyHint } from "@/components/common/password-policy-hint";
@@ -381,6 +382,13 @@ export default function UsersPage() {
       ),
     },
     {
+      id: "auth_source",
+      header: "Auth Source",
+      accessor: (u) => getAuthProviderLabel(u.auth_provider),
+      sortable: true,
+      cell: (u) => <AuthSourceBadge provider={u.auth_provider} />,
+    },
+    {
       id: "actions",
       header: "",
       cell: (u) => (
@@ -674,6 +682,12 @@ export default function UsersPage() {
               }
             }}
           >
+            <div className="space-y-2">
+              <Label>Auth Source</Label>
+              <div data-testid="edit-auth-source">
+                <AuthSourceBadge provider={selectedUser?.auth_provider} />
+              </div>
+            </div>
             <div className="space-y-2">
               <Label htmlFor="edit-email">Email</Label>
               <Input

--- a/src/components/common/__tests__/auth-source-badge.test.tsx
+++ b/src/components/common/__tests__/auth-source-badge.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children, className, ...props }: any) => (
+    <span className={className} {...props}>
+      {children}
+    </span>
+  ),
+}));
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: any[]) => args.filter(Boolean).join(" "),
+}));
+
+import {
+  AuthSourceBadge,
+  getAuthProviderLabel,
+} from "../auth-source-badge";
+
+describe("AuthSourceBadge", () => {
+  afterEach(() => cleanup());
+  it("renders 'Local' when no provider is given", () => {
+    render(<AuthSourceBadge />);
+    const badge = screen.getByTestId("auth-source-badge");
+    expect(badge).toHaveTextContent("Local");
+  });
+
+  it("renders 'Local' for provider='local'", () => {
+    render(<AuthSourceBadge provider="local" />);
+    expect(screen.getByTestId("auth-source-badge")).toHaveTextContent("Local");
+  });
+
+  it("renders 'LDAP' for provider='ldap'", () => {
+    render(<AuthSourceBadge provider="ldap" />);
+    expect(screen.getByTestId("auth-source-badge")).toHaveTextContent("LDAP");
+  });
+
+  it("renders 'OIDC' for provider='oidc'", () => {
+    render(<AuthSourceBadge provider="oidc" />);
+    expect(screen.getByTestId("auth-source-badge")).toHaveTextContent("OIDC");
+  });
+
+  it("renders 'SAML' for provider='saml'", () => {
+    render(<AuthSourceBadge provider="saml" />);
+    expect(screen.getByTestId("auth-source-badge")).toHaveTextContent("SAML");
+  });
+
+  it("handles uppercase provider values", () => {
+    render(<AuthSourceBadge provider="LDAP" />);
+    expect(screen.getByTestId("auth-source-badge")).toHaveTextContent("LDAP");
+  });
+
+  it("handles mixed-case provider values", () => {
+    render(<AuthSourceBadge provider="Oidc" />);
+    expect(screen.getByTestId("auth-source-badge")).toHaveTextContent("OIDC");
+  });
+
+  it("capitalizes unknown provider values", () => {
+    render(<AuthSourceBadge provider="github" />);
+    expect(screen.getByTestId("auth-source-badge")).toHaveTextContent("Github");
+  });
+
+  it("applies slate color class for local provider", () => {
+    render(<AuthSourceBadge provider="local" />);
+    const badge = screen.getByTestId("auth-source-badge");
+    expect(badge.className).toContain("slate");
+  });
+
+  it("applies sky color class for ldap provider", () => {
+    render(<AuthSourceBadge provider="ldap" />);
+    const badge = screen.getByTestId("auth-source-badge");
+    expect(badge.className).toContain("sky");
+  });
+
+  it("applies violet color class for oidc provider", () => {
+    render(<AuthSourceBadge provider="oidc" />);
+    const badge = screen.getByTestId("auth-source-badge");
+    expect(badge.className).toContain("violet");
+  });
+
+  it("applies amber color class for saml provider", () => {
+    render(<AuthSourceBadge provider="saml" />);
+    const badge = screen.getByTestId("auth-source-badge");
+    expect(badge.className).toContain("amber");
+  });
+
+  it("applies secondary style for unknown provider", () => {
+    render(<AuthSourceBadge provider="unknown_provider" />);
+    const badge = screen.getByTestId("auth-source-badge");
+    expect(badge.className).toContain("secondary");
+  });
+
+  it("applies custom className", () => {
+    render(<AuthSourceBadge provider="local" className="my-custom-class" />);
+    const badge = screen.getByTestId("auth-source-badge");
+    expect(badge.className).toContain("my-custom-class");
+  });
+
+  it("renders with data-testid attribute", () => {
+    render(<AuthSourceBadge provider="local" />);
+    expect(screen.getByTestId("auth-source-badge")).toBeInTheDocument();
+  });
+});
+
+describe("getAuthProviderLabel", () => {
+  it("returns 'Local' when provider is undefined", () => {
+    expect(getAuthProviderLabel(undefined)).toBe("Local");
+  });
+
+  it("returns 'Local' for 'local'", () => {
+    expect(getAuthProviderLabel("local")).toBe("Local");
+  });
+
+  it("returns 'LDAP' for 'ldap'", () => {
+    expect(getAuthProviderLabel("ldap")).toBe("LDAP");
+  });
+
+  it("returns 'OIDC' for 'oidc'", () => {
+    expect(getAuthProviderLabel("oidc")).toBe("OIDC");
+  });
+
+  it("returns 'SAML' for 'saml'", () => {
+    expect(getAuthProviderLabel("saml")).toBe("SAML");
+  });
+
+  it("returns 'LDAP' for uppercase 'LDAP'", () => {
+    expect(getAuthProviderLabel("LDAP")).toBe("LDAP");
+  });
+
+  it("capitalizes unknown provider strings", () => {
+    expect(getAuthProviderLabel("keycloak")).toBe("Keycloak");
+  });
+
+  it("returns 'Local' for empty string", () => {
+    expect(getAuthProviderLabel("")).toBe("Local");
+  });
+});

--- a/src/components/common/auth-source-badge.tsx
+++ b/src/components/common/auth-source-badge.tsx
@@ -1,0 +1,82 @@
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+export type AuthProvider = "local" | "ldap" | "oidc" | "saml";
+
+interface AuthSourceBadgeProps {
+  provider?: string;
+  className?: string;
+}
+
+const providerConfig: Record<
+  AuthProvider,
+  { label: string; colorClass: string }
+> = {
+  local: {
+    label: "Local",
+    colorClass:
+      "bg-slate-100 text-slate-700 dark:bg-slate-800/40 dark:text-slate-300 border-slate-200 dark:border-slate-700",
+  },
+  ldap: {
+    label: "LDAP",
+    colorClass:
+      "bg-sky-100 text-sky-700 dark:bg-sky-950/40 dark:text-sky-400 border-sky-200 dark:border-sky-800",
+  },
+  oidc: {
+    label: "OIDC",
+    colorClass:
+      "bg-violet-100 text-violet-700 dark:bg-violet-950/40 dark:text-violet-400 border-violet-200 dark:border-violet-800",
+  },
+  saml: {
+    label: "SAML",
+    colorClass:
+      "bg-amber-100 text-amber-700 dark:bg-amber-950/40 dark:text-amber-400 border-amber-200 dark:border-amber-800",
+  },
+};
+
+function isKnownProvider(value: string): value is AuthProvider {
+  return value in providerConfig;
+}
+
+/**
+ * Returns the display label for an auth provider value.
+ * Known providers get their canonical label; unknown values are
+ * capitalized as-is.
+ */
+export function getAuthProviderLabel(provider?: string): string {
+  if (!provider) return "Local";
+  const normalized = provider.toLowerCase();
+  if (isKnownProvider(normalized)) {
+    return providerConfig[normalized].label;
+  }
+  return provider.charAt(0).toUpperCase() + provider.slice(1);
+}
+
+/**
+ * Renders a colored badge indicating the authentication source for a user account.
+ * Supports local, LDAP, OIDC, and SAML providers with distinct colors.
+ * Unknown providers are displayed with a neutral style.
+ */
+export function AuthSourceBadge({ provider, className }: AuthSourceBadgeProps) {
+  const normalized = (provider ?? "local").toLowerCase();
+  const config = isKnownProvider(normalized)
+    ? providerConfig[normalized]
+    : {
+        label:
+          provider
+            ? provider.charAt(0).toUpperCase() + provider.slice(1)
+            : "Local",
+        colorClass:
+          "bg-secondary text-secondary-foreground border-border",
+      };
+
+  return (
+    <Badge
+      variant="outline"
+      className={cn("border font-medium", config.colorClass, className)}
+      data-testid="auth-source-badge"
+    >
+      {config.label}
+    </Badge>
+  );
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,6 +33,7 @@ export interface User {
   must_change_password?: boolean;
   password_expires_at?: string | null;
   totp_enabled?: boolean;
+  auth_provider?: string;
 }
 
 export interface LoginResponse {


### PR DESCRIPTION
## Summary

Adds visibility into the authentication source (Local, LDAP, OIDC, SAML) for user accounts in the admin interface. Closes #273.

- New `AuthSourceBadge` component with distinct color coding per provider type (slate for Local, sky for LDAP, violet for OIDC, amber for SAML). Unknown providers render with a neutral style.
- New "Auth Source" column in the admin users table, sortable by provider label.
- Read-only auth source display in the edit user dialog so admins can see the provider at a glance.
- `User` type extended with the optional `auth_provider` field to match the backend `AdminUserResponse`.

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [ ] Playwright E2E spec covers the change
- [x] Responsive layout verified (mobile + desktop)
- [x] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes