### PR TITLE
feat: show artifact quarantine status in list and detail views

### DIFF
--- a/src/app/(app)/repositories/_components/repo-detail-content.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.tsx
@@ -21,6 +21,7 @@ import { repositoriesApi } from "@/lib/api/repositories";
 import { artifactsApi } from "@/lib/api/artifacts";
 import securityApi from "@/lib/api/security";
 import { toUserMessage } from "@/lib/error-utils";
+import { isActivelyQuarantined } from "@/lib/quarantine";
 import type { Artifact } from "@/types";
 import type { UpsertScanConfigRequest } from "@/types/security";
 import { SbomTabContent } from "./sbom-tab-content";
@@ -28,6 +29,8 @@ import { SecurityTabContent } from "./security-tab-content";
 import { HealthTabContent } from "./health-tab-content";
 import { VirtualMembersPanel } from "./virtual-members-panel";
 import { PackagesTabContent } from "./packages-tab-content";
+import { QuarantineBadge } from "@/components/common/quarantine-badge";
+import { QuarantineBanner } from "@/components/common/quarantine-banner";
 import { formatBytes, REPO_TYPE_COLORS } from "@/lib/utils";
 import { useAuth } from "@/providers/auth-provider";
 import { toast } from "sonner";
@@ -224,16 +227,24 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
       accessor: (a) => a.name,
       sortable: true,
       cell: (a) => (
-        <button
-          className="flex items-center gap-2 text-sm font-medium text-primary hover:underline"
-          onClick={(e) => {
-            e.stopPropagation();
-            showDetail(a);
-          }}
-        >
-          <FileIcon className="size-4 text-muted-foreground" />
-          {a.name}
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            className="flex items-center gap-2 text-sm font-medium text-primary hover:underline"
+            onClick={(e) => {
+              e.stopPropagation();
+              showDetail(a);
+            }}
+          >
+            <FileIcon className="size-4 text-muted-foreground" />
+            {a.name}
+          </button>
+          {isActivelyQuarantined(a) && (
+            <QuarantineBadge
+              reason={a.quarantine_reason}
+              quarantineUntil={a.quarantine_until}
+            />
+          )}
+        </div>
       ),
     },
     {
@@ -688,6 +699,12 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
               {selectedArtifact?.name ?? "Artifact Details"}
             </DialogTitle>
           </DialogHeader>
+          {selectedArtifact && isActivelyQuarantined(selectedArtifact) && (
+            <QuarantineBanner
+              reason={selectedArtifact.quarantine_reason}
+              quarantineUntil={selectedArtifact.quarantine_until}
+            />
+          )}
           {selectedArtifact && (
             <Tabs defaultValue="details" className="flex-1 overflow-hidden flex flex-col">
               <TabsList variant="line" className="shrink-0">
@@ -728,6 +745,20 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
                     label="Downloads"
                     value={selectedArtifact.download_count.toLocaleString()}
                   />
+                  {isActivelyQuarantined(selectedArtifact) && (
+                    <>
+                      <DetailRow
+                        label="Quarantine"
+                        value={selectedArtifact.quarantine_reason || "Active"}
+                      />
+                      {selectedArtifact.quarantine_until && (
+                        <DetailRow
+                          label="Quarantine Until"
+                          value={new Date(selectedArtifact.quarantine_until).toLocaleString()}
+                        />
+                      )}
+                    </>
+                  )}
                   <DetailRow
                     label="Created"
                     value={new Date(selectedArtifact.created_at).toLocaleString()}

--- a/src/app/(app)/search/_components/search-content.tsx
+++ b/src/app/(app)/search/_components/search-content.tsx
@@ -41,6 +41,7 @@ import {
 import { searchApi, type SearchResult } from "@/lib/api/search";
 import { artifactsApi } from "@/lib/api/artifacts";
 import { repositoriesApi } from "@/lib/api/repositories";
+import { QuarantineBadge } from "@/components/common/quarantine-badge";
 import { formatBytes as formatBytesUtil, formatDate } from "@/lib/utils";
 
 // ---- Types ----
@@ -708,8 +709,16 @@ export function SearchContent() {
                         }
                       }}
                     >
-                      <TableCell className="font-medium max-w-[250px] truncate">
-                        {result.name}
+                      <TableCell className="font-medium max-w-[250px]">
+                        <span className="flex items-center gap-2">
+                          <span className="truncate">{result.name}</span>
+                          {result.is_quarantined && (
+                            <QuarantineBadge
+                              reason={result.quarantine_reason}
+                              quarantineUntil={result.quarantine_until}
+                            />
+                          )}
+                        </span>
                       </TableCell>
                       <TableCell className="text-muted-foreground">
                         {result.version || "--"}
@@ -786,7 +795,13 @@ export function SearchContent() {
                         <Download className="size-3" />
                       </Button>
                     </div>
-                    <div className="flex items-center gap-2 mt-3">
+                    <div className="flex items-center gap-2 mt-3 flex-wrap">
+                      {result.is_quarantined && (
+                        <QuarantineBadge
+                          reason={result.quarantine_reason}
+                          quarantineUntil={result.quarantine_until}
+                        />
+                      )}
                       {result.format && (
                         <Badge variant="secondary" className="text-xs">
                           {result.format}

--- a/src/components/common/__tests__/quarantine-badge.test.tsx
+++ b/src/components/common/__tests__/quarantine-badge.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { QuarantineBadge } from "../quarantine-badge";
+
+vi.mock("@/lib/quarantine", () => ({
+  formatQuarantineExpiry: (val: string | null | undefined) => {
+    if (!val) return null;
+    return "Expires in 3 hours";
+  },
+}));
+
+vi.mock("lucide-react", () => {
+  const stub = (name: string) => {
+    const Icon = (props: React.ComponentProps<"span">) => (
+      <span data-testid={`icon-${name}`} {...props} />
+    );
+    Icon.displayName = name;
+    return Icon;
+  };
+  return {
+    ShieldAlert: stub("ShieldAlert"),
+  };
+});
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({
+    children,
+    className,
+    ...props
+  }: React.ComponentProps<"span">) => (
+    <span className={className} {...props}>
+      {children}
+    </span>
+  ),
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({
+    children,
+  }: { children: React.ReactNode; asChild?: boolean } & Record<string, unknown>) => <>{children}</>,
+  TooltipContent: ({
+    children,
+    ...rest
+  }: { children: React.ReactNode } & Record<string, unknown>) => (
+    <div data-testid="tooltip-content" {...rest}>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("QuarantineBadge", () => {
+  it("renders the Quarantined text", () => {
+    render(<QuarantineBadge />);
+    expect(screen.getByText("Quarantined")).toBeInTheDocument();
+  });
+
+  it("has the correct aria-label", () => {
+    render(<QuarantineBadge />);
+    expect(screen.getByLabelText("Quarantined")).toBeInTheDocument();
+  });
+
+  it("renders the ShieldAlert icon", () => {
+    render(<QuarantineBadge />);
+    expect(screen.getByTestId("icon-ShieldAlert")).toBeInTheDocument();
+  });
+
+  it("shows tooltip with reason when provided", () => {
+    render(<QuarantineBadge reason="Security vulnerability detected" />);
+    expect(
+      screen.getByText("Security vulnerability detected")
+    ).toBeInTheDocument();
+  });
+
+  it("shows tooltip with expiry when quarantineUntil is provided", () => {
+    render(
+      <QuarantineBadge quarantineUntil="2026-04-20T00:00:00Z" />
+    );
+    expect(screen.getByText("Expires in 3 hours")).toBeInTheDocument();
+  });
+
+  it("shows both reason and expiry in tooltip", () => {
+    render(
+      <QuarantineBadge
+        reason="Malware scan pending"
+        quarantineUntil="2026-04-20T00:00:00Z"
+      />
+    );
+    expect(screen.getByText("Malware scan pending")).toBeInTheDocument();
+    expect(screen.getByText("Expires in 3 hours")).toBeInTheDocument();
+  });
+
+  it("does not render tooltip content when no reason and no expiry", () => {
+    render(<QuarantineBadge />);
+    expect(screen.queryByTestId("tooltip-content")).not.toBeInTheDocument();
+  });
+
+  it("applies custom className", () => {
+    render(<QuarantineBadge className="my-custom-class" />);
+    const badge = screen.getByLabelText("Quarantined");
+    expect(badge.className).toContain("my-custom-class");
+  });
+});

--- a/src/components/common/__tests__/quarantine-banner.test.tsx
+++ b/src/components/common/__tests__/quarantine-banner.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { QuarantineBanner } from "../quarantine-banner";
+
+vi.mock("@/lib/quarantine", () => ({
+  formatQuarantineExpiry: (val: string | null | undefined) => {
+    if (!val) return null;
+    if (val === "2026-04-10T00:00:00Z") return "Expired";
+    return "Expires in 5 days";
+  },
+}));
+
+vi.mock("lucide-react", () => {
+  const stub = (name: string) => {
+    const Icon = (props: React.ComponentProps<"span">) => (
+      <span data-testid={`icon-${name}`} {...props} />
+    );
+    Icon.displayName = name;
+    return Icon;
+  };
+  return {
+    ShieldAlert: stub("ShieldAlert"),
+  };
+});
+
+vi.mock("@/components/ui/alert", () => ({
+  Alert: ({
+    children,
+    className,
+    ...props
+  }: React.ComponentProps<"div">) => (
+    <div role="alert" className={className} {...props}>
+      {children}
+    </div>
+  ),
+  AlertTitle: ({
+    children,
+    ...props
+  }: React.ComponentProps<"div">) => (
+    <div data-testid="alert-title" {...props}>
+      {children}
+    </div>
+  ),
+  AlertDescription: ({
+    children,
+    ...props
+  }: React.ComponentProps<"div">) => (
+    <div data-testid="alert-description" {...props}>
+      {children}
+    </div>
+  ),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("QuarantineBanner", () => {
+  it("renders the quarantine title", () => {
+    render(<QuarantineBanner />);
+    expect(
+      screen.getByText("This artifact is quarantined")
+    ).toBeInTheDocument();
+  });
+
+  it("renders as an alert with role=alert", () => {
+    render(<QuarantineBanner />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("renders the ShieldAlert icon", () => {
+    render(<QuarantineBanner />);
+    expect(screen.getByTestId("icon-ShieldAlert")).toBeInTheDocument();
+  });
+
+  it("shows reason when provided", () => {
+    render(<QuarantineBanner reason="Vulnerability CVE-2026-1234 found" />);
+    expect(
+      screen.getByText("Vulnerability CVE-2026-1234 found")
+    ).toBeInTheDocument();
+  });
+
+  it("shows expiry when quarantineUntil is provided", () => {
+    render(
+      <QuarantineBanner quarantineUntil="2026-04-22T12:00:00Z" />
+    );
+    expect(screen.getByText("Expires in 5 days")).toBeInTheDocument();
+  });
+
+  it("shows both reason and expiry", () => {
+    render(
+      <QuarantineBanner
+        reason="Malware detected"
+        quarantineUntil="2026-04-22T12:00:00Z"
+      />
+    );
+    expect(screen.getByText("Malware detected")).toBeInTheDocument();
+    expect(screen.getByText("Expires in 5 days")).toBeInTheDocument();
+  });
+
+  it("shows default message when no reason and no expiry", () => {
+    render(<QuarantineBanner />);
+    expect(
+      screen.getByText(
+        "Downloads may be restricted until the quarantine is lifted by an administrator."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("does not show default message when reason is provided", () => {
+    render(<QuarantineBanner reason="Under review" />);
+    expect(
+      screen.queryByText(
+        "Downloads may be restricted until the quarantine is lifted by an administrator."
+      )
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/common/quarantine-badge.tsx
+++ b/src/components/common/quarantine-badge.tsx
@@ -1,0 +1,64 @@
+import { ShieldAlert } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { formatQuarantineExpiry } from "@/lib/quarantine";
+
+interface QuarantineBadgeProps {
+  reason?: string | null;
+  quarantineUntil?: string | null;
+  className?: string;
+}
+
+/**
+ * Compact badge indicating that an artifact is quarantined.
+ * Used in table rows and list items. Shows the reason and expiry
+ * in a tooltip on hover.
+ */
+export function QuarantineBadge({
+  reason,
+  quarantineUntil,
+  className,
+}: QuarantineBadgeProps) {
+  const expiry = formatQuarantineExpiry(quarantineUntil);
+
+  const tooltipLines: string[] = [];
+  if (reason) tooltipLines.push(reason);
+  if (expiry) tooltipLines.push(expiry);
+
+  const badge = (
+    <Badge
+      variant="outline"
+      className={cn(
+        "border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-400 gap-1",
+        className
+      )}
+      aria-label="Quarantined"
+    >
+      <ShieldAlert className="size-3" aria-hidden="true" />
+      Quarantined
+    </Badge>
+  );
+
+  if (tooltipLines.length === 0) {
+    return badge;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{badge}</TooltipTrigger>
+      <TooltipContent side="top" className="max-w-xs">
+        <div className="space-y-0.5 text-xs">
+          {reason && <p>{reason}</p>}
+          {expiry && (
+            <p className="text-muted-foreground">{expiry}</p>
+          )}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/components/common/quarantine-banner.tsx
+++ b/src/components/common/quarantine-banner.tsx
@@ -1,0 +1,46 @@
+import { ShieldAlert } from "lucide-react";
+import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
+import { formatQuarantineExpiry } from "@/lib/quarantine";
+
+interface QuarantineBannerProps {
+  reason?: string | null;
+  quarantineUntil?: string | null;
+}
+
+/**
+ * Prominent warning banner displayed at the top of artifact detail views
+ * when the artifact is currently under quarantine. Shows the reason and
+ * expiry time when available.
+ */
+export function QuarantineBanner({
+  reason,
+  quarantineUntil,
+}: QuarantineBannerProps) {
+  const expiry = formatQuarantineExpiry(quarantineUntil);
+
+  return (
+    <Alert
+      className="border-amber-300 bg-amber-50 text-amber-900 dark:border-amber-700 dark:bg-amber-950/30 dark:text-amber-200"
+    >
+      <ShieldAlert className="size-4 text-amber-600 dark:text-amber-400" aria-hidden="true" />
+      <AlertTitle className="font-semibold">
+        This artifact is quarantined
+      </AlertTitle>
+      <AlertDescription>
+        <div className="space-y-1">
+          {reason && <p>{reason}</p>}
+          {expiry && (
+            <p className="text-amber-700 dark:text-amber-400 text-xs">
+              {expiry}
+            </p>
+          )}
+          {!reason && !expiry && (
+            <p>
+              Downloads may be restricted until the quarantine is lifted by an administrator.
+            </p>
+          )}
+        </div>
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/src/lib/__tests__/quarantine.test.ts
+++ b/src/lib/__tests__/quarantine.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { isActivelyQuarantined, formatQuarantineExpiry } from "../quarantine";
+import type { Artifact } from "@/types";
+
+function makeArtifact(overrides: Partial<Artifact> = {}): Artifact {
+  return {
+    id: "art-1",
+    repository_key: "maven-releases",
+    path: "com/example/lib.jar",
+    name: "lib.jar",
+    size_bytes: 1024,
+    checksum_sha256: "abc123",
+    content_type: "application/java-archive",
+    download_count: 42,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("isActivelyQuarantined", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-17T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns false when is_quarantined is undefined", () => {
+    const artifact = makeArtifact();
+    expect(isActivelyQuarantined(artifact)).toBe(false);
+  });
+
+  it("returns false when is_quarantined is false", () => {
+    const artifact = makeArtifact({ is_quarantined: false });
+    expect(isActivelyQuarantined(artifact)).toBe(false);
+  });
+
+  it("returns true when is_quarantined is true with no expiry", () => {
+    const artifact = makeArtifact({ is_quarantined: true });
+    expect(isActivelyQuarantined(artifact)).toBe(true);
+  });
+
+  it("returns true when is_quarantined is true and quarantine_until is null", () => {
+    const artifact = makeArtifact({
+      is_quarantined: true,
+      quarantine_until: null,
+    });
+    expect(isActivelyQuarantined(artifact)).toBe(true);
+  });
+
+  it("returns true when quarantine_until is in the future", () => {
+    const artifact = makeArtifact({
+      is_quarantined: true,
+      quarantine_until: "2026-04-20T00:00:00Z",
+    });
+    expect(isActivelyQuarantined(artifact)).toBe(true);
+  });
+
+  it("returns false when quarantine_until is in the past", () => {
+    const artifact = makeArtifact({
+      is_quarantined: true,
+      quarantine_until: "2026-04-10T00:00:00Z",
+    });
+    expect(isActivelyQuarantined(artifact)).toBe(false);
+  });
+});
+
+describe("formatQuarantineExpiry", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-17T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns null for null input", () => {
+    expect(formatQuarantineExpiry(null)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(formatQuarantineExpiry(undefined)).toBeNull();
+  });
+
+  it("returns Expired for past dates", () => {
+    expect(formatQuarantineExpiry("2026-04-10T00:00:00Z")).toBe("Expired");
+  });
+
+  it("returns minutes for short durations", () => {
+    // 30 minutes in the future
+    expect(formatQuarantineExpiry("2026-04-17T12:30:00Z")).toBe(
+      "Expires in 30 minutes"
+    );
+  });
+
+  it("returns singular minute", () => {
+    expect(formatQuarantineExpiry("2026-04-17T12:01:30Z")).toBe(
+      "Expires in 1 minute"
+    );
+  });
+
+  it("returns hours for multi-hour durations", () => {
+    expect(formatQuarantineExpiry("2026-04-17T15:00:00Z")).toBe(
+      "Expires in 3 hours"
+    );
+  });
+
+  it("returns singular hour", () => {
+    expect(formatQuarantineExpiry("2026-04-17T13:30:00Z")).toBe(
+      "Expires in 1 hour"
+    );
+  });
+
+  it("returns days for multi-day durations under 14 days", () => {
+    expect(formatQuarantineExpiry("2026-04-22T12:00:00Z")).toBe(
+      "Expires in 5 days"
+    );
+  });
+
+  it("returns singular day", () => {
+    expect(formatQuarantineExpiry("2026-04-18T13:00:00Z")).toBe(
+      "Expires in 1 day"
+    );
+  });
+
+  it("returns formatted date for durations over 14 days", () => {
+    const result = formatQuarantineExpiry("2026-06-15T12:00:00Z");
+    expect(result).toMatch(/^Expires on /);
+    expect(result).toContain("2026");
+  });
+});

--- a/src/lib/api/search.ts
+++ b/src/lib/api/search.ts
@@ -11,6 +11,9 @@ export interface SearchResult {
   format?: string;
   version?: string;
   size_bytes?: number;
+  is_quarantined?: boolean;
+  quarantine_until?: string | null;
+  quarantine_reason?: string | null;
   created_at: string;
   highlights?: string[];
 }

--- a/src/lib/quarantine.ts
+++ b/src/lib/quarantine.ts
@@ -1,0 +1,49 @@
+import type { Artifact } from "@/types";
+
+/**
+ * Check whether an artifact is currently under quarantine.
+ * Returns true if `is_quarantined` is set and, when a `quarantine_until`
+ * timestamp is present, the current time has not yet passed that deadline.
+ */
+export function isActivelyQuarantined(artifact: Artifact): boolean {
+  if (!artifact.is_quarantined) return false;
+  if (!artifact.quarantine_until) return true;
+  return new Date(artifact.quarantine_until).getTime() > Date.now();
+}
+
+/**
+ * Format a quarantine expiry timestamp into a human-readable relative
+ * description (e.g. "Expires in 3 hours" or "Expires on Apr 20, 2026").
+ * Returns null if no expiry is set.
+ */
+export function formatQuarantineExpiry(quarantineUntil: string | null | undefined): string | null {
+  if (!quarantineUntil) return null;
+
+  const expiry = new Date(quarantineUntil);
+  const now = Date.now();
+  const diffMs = expiry.getTime() - now;
+
+  if (diffMs <= 0) {
+    return "Expired";
+  }
+
+  const diffMinutes = Math.floor(diffMs / 60_000);
+  const diffHours = Math.floor(diffMs / 3_600_000);
+  const diffDays = Math.floor(diffMs / 86_400_000);
+
+  if (diffMinutes < 60) {
+    return `Expires in ${diffMinutes} minute${diffMinutes !== 1 ? "s" : ""}`;
+  }
+  if (diffHours < 24) {
+    return `Expires in ${diffHours} hour${diffHours !== 1 ? "s" : ""}`;
+  }
+  if (diffDays < 14) {
+    return `Expires in ${diffDays} day${diffDays !== 1 ? "s" : ""}`;
+  }
+
+  return `Expires on ${expiry.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  })}`;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -171,6 +171,9 @@ export interface Artifact {
   checksum_sha256: string;
   content_type: string;
   download_count: number;
+  is_quarantined?: boolean;
+  quarantine_until?: string | null;
+  quarantine_reason?: string | null;
   created_at: string;
   metadata?: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary

Adds visual indicators for artifact quarantine status across the web frontend. When the backend marks an artifact as quarantined, the UI now clearly communicates this to users in three places:

- **Artifact list table**: An amber "Quarantined" badge appears next to the artifact name, with a tooltip showing the reason and expiry.
- **Artifact detail dialog**: A prominent warning banner at the top of the dialog explains the quarantine, including the reason and when it expires.
- **Search results**: Both list and grid views show the quarantine badge alongside matching results.

The implementation adds `is_quarantined`, `quarantine_until`, and `quarantine_reason` fields to the `Artifact` and `SearchResult` types. A utility module (`lib/quarantine.ts`) handles expiry checking and relative-time formatting.

Closes #253

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [ ] Playwright E2E spec covers the change
- [x] Responsive layout verified (mobile + desktop)
- [x] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes