### PR TITLE
feat: add notification configuration tab to repository settings

### DIFF
--- a/src/app/(app)/repositories/_components/notifications-tab-content.test.tsx
+++ b/src/app/(app)/repositories/_components/notifications-tab-content.test.tsx
@@ -115,6 +115,47 @@ vi.mock("@/components/ui/dialog", () => ({
   ),
 }));
 
+// Stub ConfirmDialog
+vi.mock("@/components/common/confirm-dialog", () => ({
+  ConfirmDialog: ({
+    open,
+    onOpenChange,
+    title,
+    description,
+    confirmText,
+    loading,
+    onConfirm,
+  }: {
+    open: boolean;
+    onOpenChange: (v: boolean) => void;
+    title: string;
+    description: string;
+    confirmText?: string;
+    loading?: boolean;
+    danger?: boolean;
+    onConfirm: () => void;
+  }) =>
+    open ? (
+      <div data-testid="confirm-dialog">
+        <h2>{title}</h2>
+        <p>{description}</p>
+        <button
+          data-testid="confirm-dialog-cancel"
+          onClick={() => onOpenChange(false)}
+        >
+          Cancel
+        </button>
+        <button
+          data-testid="confirm-dialog-confirm"
+          disabled={loading}
+          onClick={onConfirm}
+        >
+          {confirmText ?? "Confirm"}
+        </button>
+      </div>
+    ) : null,
+}));
+
 // Stub Checkbox as a simple native checkbox
 vi.mock("@/components/ui/checkbox", () => ({
   Checkbox: ({
@@ -518,6 +559,110 @@ describe("NotificationsTabContent", () => {
       name: "Enable webhook",
     });
     expect(enableBtn).toBeInTheDocument();
+  });
+
+  // -----------------------------------------------------------------------
+  // Delete confirmation dialog
+  // -----------------------------------------------------------------------
+
+  it("opens confirm dialog when delete button is clicked", async () => {
+    queryResponses["webhooks"] = {
+      data: { items: [SAMPLE_WEBHOOKS[0]], total: 1 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+
+    // Confirm dialog should not be visible initially
+    expect(screen.queryByTestId("confirm-dialog")).not.toBeInTheDocument();
+
+    const card = screen.getByTestId("webhook-card-wh-1");
+    const deleteBtn = within(card).getByRole("button", {
+      name: "Delete webhook",
+    });
+    await userEvent.click(deleteBtn);
+
+    // Confirm dialog should now be visible
+    const confirmDialog = screen.getByTestId("confirm-dialog");
+    expect(confirmDialog).toBeInTheDocument();
+    expect(
+      within(confirmDialog).getByText(
+        "This will permanently remove this webhook. It will no longer receive event notifications."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("dismisses confirm dialog when cancel is clicked", async () => {
+    queryResponses["webhooks"] = {
+      data: { items: [SAMPLE_WEBHOOKS[0]], total: 1 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+
+    const card = screen.getByTestId("webhook-card-wh-1");
+    const deleteBtn = within(card).getByRole("button", {
+      name: "Delete webhook",
+    });
+    await userEvent.click(deleteBtn);
+
+    expect(screen.getByTestId("confirm-dialog")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId("confirm-dialog-cancel"));
+    expect(screen.queryByTestId("confirm-dialog")).not.toBeInTheDocument();
+  });
+
+  // -----------------------------------------------------------------------
+  // URL validation
+  // -----------------------------------------------------------------------
+
+  it("shows URL validation error for non-http URLs", async () => {
+    queryResponses["webhooks"] = {
+      data: { items: [], total: 0 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+    await userEvent.click(screen.getByTestId("add-webhook-button"));
+
+    // Fill in name and events
+    await userEvent.type(screen.getByLabelText("Name"), "Test Hook");
+    await userEvent.type(
+      screen.getByPlaceholderText("https://example.com/webhook"),
+      "ftp://example.com/hook"
+    );
+    // Check at least one event
+    const checkboxes = screen.getAllByTestId("mock-checkbox");
+    await userEvent.click(checkboxes[0]);
+
+    await userEvent.click(screen.getByTestId("create-webhook-submit"));
+
+    expect(screen.getByTestId("url-error")).toBeInTheDocument();
+    expect(
+      screen.getByText("URL must start with http:// or https://")
+    ).toBeInTheDocument();
+  });
+
+  it("clears URL validation error when URL field is edited", async () => {
+    queryResponses["webhooks"] = {
+      data: { items: [], total: 0 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+    await userEvent.click(screen.getByTestId("add-webhook-button"));
+
+    // Fill in name and events
+    await userEvent.type(screen.getByLabelText("Name"), "Test Hook");
+    const urlInput = screen.getByPlaceholderText(
+      "https://example.com/webhook"
+    );
+    await userEvent.type(urlInput, "ftp://bad");
+    const checkboxes = screen.getAllByTestId("mock-checkbox");
+    await userEvent.click(checkboxes[0]);
+
+    await userEvent.click(screen.getByTestId("create-webhook-submit"));
+    expect(screen.getByTestId("url-error")).toBeInTheDocument();
+
+    // Typing in the URL field clears the error
+    await userEvent.type(urlInput, "x");
+    expect(screen.queryByTestId("url-error")).not.toBeInTheDocument();
   });
 
   // -----------------------------------------------------------------------

--- a/src/app/(app)/repositories/_components/notifications-tab-content.test.tsx
+++ b/src/app/(app)/repositories/_components/notifications-tab-content.test.tsx
@@ -1,0 +1,645 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Track mutation and query configs for exercising callbacks
+interface MutationConfig {
+  mutationFn: (...args: unknown[]) => unknown;
+  onSuccess?: (...args: unknown[]) => void;
+  onError?: (...args: unknown[]) => void;
+}
+
+const mutationConfigs: MutationConfig[] = [];
+
+// Response map keyed by first element of queryKey
+let queryResponses: Record<string, unknown> = {};
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (opts: { queryKey: string[]; queryFn: () => unknown; enabled?: boolean }) => {
+    const keyStr = opts.queryKey[0];
+    if (queryResponses[keyStr]) {
+      // Execute queryFn so the arrow callback is covered
+      if (opts.queryFn && opts.enabled !== false) {
+        try {
+          opts.queryFn();
+        } catch {
+          /* safe */
+        }
+      }
+      return queryResponses[keyStr];
+    }
+    return { data: undefined, isLoading: false };
+  },
+  useMutation: (config: MutationConfig) => {
+    mutationConfigs.push(config);
+    return { mutate: vi.fn(), isPending: false };
+  },
+  useQueryClient: () => ({
+    invalidateQueries: vi.fn(),
+  }),
+}));
+
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+const mockList = vi.fn();
+const mockCreate = vi.fn();
+const mockDelete = vi.fn();
+const mockEnable = vi.fn();
+const mockDisable = vi.fn();
+const mockTest = vi.fn();
+
+vi.mock("@/lib/api/webhooks", () => ({
+  webhooksApi: {
+    list: (...args: unknown[]) => mockList(...args),
+    create: (...args: unknown[]) => mockCreate(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
+    enable: (...args: unknown[]) => mockEnable(...args),
+    disable: (...args: unknown[]) => mockDisable(...args),
+    test: (...args: unknown[]) => mockTest(...args),
+  },
+}));
+
+vi.mock("@/lib/error-utils", () => ({
+  toUserMessage: (_err: unknown, fallback: string) => fallback,
+}));
+
+// Stub out radix tooltip/dialog to avoid portal issues in jsdom
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: Object.assign(
+    React.forwardRef<
+      HTMLDivElement,
+      { children: React.ReactNode; asChild?: boolean }
+    >(function TooltipTrigger({ children }, _ref) {
+      return <>{children}</>;
+    }),
+    { displayName: "TooltipTrigger" }
+  ),
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <span data-testid="tooltip-content">{children}</span>
+  ),
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({
+    open,
+    children,
+  }: {
+    open: boolean;
+    onOpenChange: (v: boolean) => void;
+    children: React.ReactNode;
+  }) => (open ? <div data-testid="dialog">{children}</div> : null),
+  DialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dialog-content">{children}</div>
+  ),
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <h2>{children}</h2>
+  ),
+  DialogFooter: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dialog-footer">{children}</div>
+  ),
+}));
+
+// Stub Checkbox as a simple native checkbox
+vi.mock("@/components/ui/checkbox", () => ({
+  Checkbox: ({
+    checked,
+    onCheckedChange,
+    "aria-label": ariaLabel,
+  }: {
+    checked: boolean;
+    onCheckedChange: (v: boolean) => void;
+    "aria-label"?: string;
+  }) => (
+    <input
+      type="checkbox"
+      checked={checked}
+      onChange={(e) => onCheckedChange(e.target.checked)}
+      aria-label={ariaLabel}
+      data-testid="mock-checkbox"
+    />
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const SAMPLE_WEBHOOKS = [
+  {
+    id: "wh-1",
+    name: "CI Pipeline",
+    url: "https://ci.example.com/hook",
+    events: ["artifact_uploaded", "build_completed"] as string[],
+    is_enabled: true,
+    repository_id: "repo-123",
+    last_triggered_at: "2026-04-10T12:00:00Z",
+    created_at: "2026-03-01T00:00:00Z",
+  },
+  {
+    id: "wh-2",
+    name: "Slack Alerts",
+    url: "https://hooks.slack.com/services/abc",
+    events: ["artifact_deleted"] as string[],
+    is_enabled: false,
+    repository_id: "repo-123",
+    last_triggered_at: null,
+    created_at: "2026-03-15T00:00:00Z",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Import component under test (after mocks)
+// ---------------------------------------------------------------------------
+
+import { NotificationsTabContent, WEBHOOK_EVENTS } from "./notifications-tab-content";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("NotificationsTabContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mutationConfigs.length = 0;
+    queryResponses = {};
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // -----------------------------------------------------------------------
+  // Loading state
+  // -----------------------------------------------------------------------
+
+  it("renders loading skeleton when query is loading", () => {
+    queryResponses["webhooks"] = { data: undefined, isLoading: true };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+    expect(screen.getByTestId("notifications-loading")).toBeInTheDocument();
+  });
+
+  // -----------------------------------------------------------------------
+  // Empty state
+  // -----------------------------------------------------------------------
+
+  it("renders empty state when no webhooks are configured", () => {
+    queryResponses["webhooks"] = {
+      data: { items: [], total: 0 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+    expect(
+      screen.getByText("No webhooks configured for this repository.")
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("add-webhook-button")).toBeInTheDocument();
+  });
+
+  // -----------------------------------------------------------------------
+  // Webhook list rendering
+  // -----------------------------------------------------------------------
+
+  it("renders webhook cards with name, url, events, and status", () => {
+    queryResponses["webhooks"] = {
+      data: { items: SAMPLE_WEBHOOKS, total: 2 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+
+    // Verify both webhooks render
+    expect(screen.getByTestId("webhook-card-wh-1")).toBeInTheDocument();
+    expect(screen.getByTestId("webhook-card-wh-2")).toBeInTheDocument();
+
+    // Check name
+    expect(screen.getByText("CI Pipeline")).toBeInTheDocument();
+    expect(screen.getByText("Slack Alerts")).toBeInTheDocument();
+
+    // Check URLs
+    expect(screen.getByText("https://ci.example.com/hook")).toBeInTheDocument();
+    expect(
+      screen.getByText("https://hooks.slack.com/services/abc")
+    ).toBeInTheDocument();
+
+    // Check status badges
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("Inactive")).toBeInTheDocument();
+
+    // Check event badges
+    expect(screen.getByText("Artifact Uploaded")).toBeInTheDocument();
+    expect(screen.getByText("Build Completed")).toBeInTheDocument();
+    expect(screen.getByText("Artifact Deleted")).toBeInTheDocument();
+  });
+
+  it("displays last triggered date for triggered webhooks", () => {
+    queryResponses["webhooks"] = {
+      data: { items: [SAMPLE_WEBHOOKS[0]], total: 1 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+    expect(screen.getByText(/Last triggered/)).toBeInTheDocument();
+  });
+
+  it('displays "Never triggered" for webhooks with no last_triggered_at', () => {
+    queryResponses["webhooks"] = {
+      data: { items: [SAMPLE_WEBHOOKS[1]], total: 1 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+    expect(screen.getByText("Never triggered")).toBeInTheDocument();
+  });
+
+  it("shows webhook count badge", () => {
+    queryResponses["webhooks"] = {
+      data: { items: SAMPLE_WEBHOOKS, total: 2 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+    expect(screen.getByText("2 configured")).toBeInTheDocument();
+  });
+
+  // -----------------------------------------------------------------------
+  // Create webhook dialog
+  // -----------------------------------------------------------------------
+
+  it("opens create dialog when Add Webhook button is clicked", async () => {
+    queryResponses["webhooks"] = {
+      data: { items: [], total: 0 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+
+    // Dialog should not be open initially
+    expect(screen.queryByTestId("dialog")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId("add-webhook-button"));
+
+    // Dialog should now be open
+    const dialog = screen.getByTestId("dialog");
+    expect(dialog).toBeInTheDocument();
+    // The dialog title is rendered as an h2
+    expect(within(dialog).getByRole("heading", { name: "Add Webhook" })).toBeInTheDocument();
+  });
+
+  it("renders all event checkboxes in the create dialog", async () => {
+    queryResponses["webhooks"] = {
+      data: { items: [], total: 0 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+    await userEvent.click(screen.getByTestId("add-webhook-button"));
+
+    for (const event of WEBHOOK_EVENTS) {
+      expect(screen.getByText(event.label)).toBeInTheDocument();
+      expect(screen.getByText(event.description)).toBeInTheDocument();
+    }
+  });
+
+  it("renders form inputs for name, url, and secret", async () => {
+    queryResponses["webhooks"] = {
+      data: { items: [], total: 0 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+    await userEvent.click(screen.getByTestId("add-webhook-button"));
+
+    expect(screen.getByLabelText("Name")).toBeInTheDocument();
+    expect(screen.getByLabelText("Payload URL")).toBeInTheDocument();
+    // Secret label contains "(optional)" text
+    expect(screen.getByPlaceholderText("Used to sign payloads")).toBeInTheDocument();
+  });
+
+  // -----------------------------------------------------------------------
+  // Mutation callback coverage
+  // -----------------------------------------------------------------------
+
+  it("registers create mutation with correct onSuccess behavior", () => {
+    queryResponses["webhooks"] = {
+      data: { items: [], total: 0 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+
+    // Create mutation is the first registered
+    const createConfig = mutationConfigs[0];
+    expect(createConfig).toBeDefined();
+
+    // Exercise onSuccess
+    createConfig.onSuccess?.();
+    expect(mockToastSuccess).toHaveBeenCalledWith("Webhook created");
+  });
+
+  it("registers create mutation with correct onError behavior", () => {
+    queryResponses["webhooks"] = {
+      data: { items: [], total: 0 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+
+    const createConfig = mutationConfigs[0];
+    createConfig.onError?.(new Error("network"));
+    expect(mockToastError).toHaveBeenCalledWith("Failed to create webhook");
+  });
+
+  it("registers delete mutation with correct callbacks", () => {
+    queryResponses["webhooks"] = {
+      data: { items: SAMPLE_WEBHOOKS, total: 2 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+
+    // Delete mutation is the second registered (index 1)
+    const deleteConfig = mutationConfigs[1];
+    expect(deleteConfig).toBeDefined();
+
+    deleteConfig.onSuccess?.();
+    expect(mockToastSuccess).toHaveBeenCalledWith("Webhook deleted");
+
+    deleteConfig.onError?.(new Error("fail"));
+    expect(mockToastError).toHaveBeenCalledWith("Failed to delete webhook");
+  });
+
+  it("registers enable mutation with correct callbacks", () => {
+    queryResponses["webhooks"] = {
+      data: { items: SAMPLE_WEBHOOKS, total: 2 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+
+    // Enable is third (index 2)
+    const enableConfig = mutationConfigs[2];
+    expect(enableConfig).toBeDefined();
+
+    enableConfig.onSuccess?.();
+    expect(mockToastSuccess).toHaveBeenCalledWith("Webhook enabled");
+
+    enableConfig.onError?.(new Error("fail"));
+    expect(mockToastError).toHaveBeenCalledWith("Failed to enable webhook");
+  });
+
+  it("registers disable mutation with correct callbacks", () => {
+    queryResponses["webhooks"] = {
+      data: { items: SAMPLE_WEBHOOKS, total: 2 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+
+    // Disable is fourth (index 3)
+    const disableConfig = mutationConfigs[3];
+    expect(disableConfig).toBeDefined();
+
+    disableConfig.onSuccess?.();
+    expect(mockToastSuccess).toHaveBeenCalledWith("Webhook disabled");
+
+    disableConfig.onError?.(new Error("fail"));
+    expect(mockToastError).toHaveBeenCalledWith("Failed to disable webhook");
+  });
+
+  it("registers test mutation with correct success callback for successful test", () => {
+    queryResponses["webhooks"] = {
+      data: { items: SAMPLE_WEBHOOKS, total: 2 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+
+    // Test is fifth (index 4)
+    const testConfig = mutationConfigs[4];
+    expect(testConfig).toBeDefined();
+
+    testConfig.onSuccess?.({ success: true, status_code: 200 });
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      "Test delivery succeeded (HTTP 200)"
+    );
+  });
+
+  it("registers test mutation showing error toast on failed test delivery", () => {
+    queryResponses["webhooks"] = {
+      data: { items: SAMPLE_WEBHOOKS, total: 2 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+
+    const testConfig = mutationConfigs[4];
+    testConfig.onSuccess?.({ success: false, error: "Connection refused" });
+    expect(mockToastError).toHaveBeenCalledWith("Connection refused");
+  });
+
+  it("registers test mutation showing generic message on failed test without error", () => {
+    queryResponses["webhooks"] = {
+      data: { items: SAMPLE_WEBHOOKS, total: 2 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+
+    const testConfig = mutationConfigs[4];
+    testConfig.onSuccess?.({ success: false });
+    expect(mockToastError).toHaveBeenCalledWith("Test delivery failed");
+  });
+
+  it("registers test mutation with correct onError callback", () => {
+    queryResponses["webhooks"] = {
+      data: { items: SAMPLE_WEBHOOKS, total: 2 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+
+    const testConfig = mutationConfigs[4];
+    testConfig.onError?.(new Error("timeout"));
+    expect(mockToastError).toHaveBeenCalledWith("Failed to send test");
+  });
+
+  // -----------------------------------------------------------------------
+  // Create webhook form validation
+  // -----------------------------------------------------------------------
+
+  it("shows error toast when create is submitted with empty fields", async () => {
+    queryResponses["webhooks"] = {
+      data: { items: [], total: 0 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+    await userEvent.click(screen.getByTestId("add-webhook-button"));
+
+    // Click create without filling in fields
+    await userEvent.click(screen.getByTestId("create-webhook-submit"));
+    expect(mockToastError).toHaveBeenCalledWith(
+      "Name, URL, and at least one event are required"
+    );
+  });
+
+  // -----------------------------------------------------------------------
+  // Webhook card action buttons
+  // -----------------------------------------------------------------------
+
+  it("renders action buttons on each webhook card", () => {
+    queryResponses["webhooks"] = {
+      data: { items: [SAMPLE_WEBHOOKS[0]], total: 1 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+
+    const card = screen.getByTestId("webhook-card-wh-1");
+    const testBtn = within(card).getByRole("button", { name: "Test webhook" });
+    const toggleBtn = within(card).getByRole("button", {
+      name: "Disable webhook",
+    });
+    const deleteBtn = within(card).getByRole("button", {
+      name: "Delete webhook",
+    });
+
+    expect(testBtn).toBeInTheDocument();
+    expect(toggleBtn).toBeInTheDocument();
+    expect(deleteBtn).toBeInTheDocument();
+  });
+
+  it("renders Enable button for inactive webhooks", () => {
+    queryResponses["webhooks"] = {
+      data: { items: [SAMPLE_WEBHOOKS[1]], total: 1 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+
+    const card = screen.getByTestId("webhook-card-wh-2");
+    const enableBtn = within(card).getByRole("button", {
+      name: "Enable webhook",
+    });
+    expect(enableBtn).toBeInTheDocument();
+  });
+
+  // -----------------------------------------------------------------------
+  // WEBHOOK_EVENTS constant
+  // -----------------------------------------------------------------------
+
+  it("exports WEBHOOK_EVENTS with 9 event types", () => {
+    expect(WEBHOOK_EVENTS).toHaveLength(9);
+    expect(WEBHOOK_EVENTS.map((e) => e.value)).toContain("artifact_uploaded");
+    expect(WEBHOOK_EVENTS.map((e) => e.value)).toContain("build_completed");
+    expect(WEBHOOK_EVENTS.map((e) => e.value)).toContain("repository_deleted");
+  });
+
+  // -----------------------------------------------------------------------
+  // Query function coverage
+  // -----------------------------------------------------------------------
+
+  it("calls webhooksApi.list with repository_id", () => {
+    queryResponses["webhooks"] = {
+      data: { items: [], total: 0 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-456" />);
+    expect(mockList).toHaveBeenCalledWith({ repository_id: "repo-456" });
+  });
+
+  // -----------------------------------------------------------------------
+  // Mutation function coverage (exercise the mutationFn arrows)
+  // -----------------------------------------------------------------------
+
+  it("create mutationFn calls webhooksApi.create", async () => {
+    queryResponses["webhooks"] = {
+      data: { items: [], total: 0 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+
+    const createConfig = mutationConfigs[0];
+    const payload = {
+      name: "Test",
+      url: "https://example.com",
+      events: ["artifact_uploaded"],
+      repository_id: "repo-123",
+    };
+    mockCreate.mockResolvedValue({ id: "new-1" });
+    await createConfig.mutationFn(payload);
+    expect(mockCreate).toHaveBeenCalledWith(payload);
+  });
+
+  it("delete mutationFn calls webhooksApi.delete", async () => {
+    queryResponses["webhooks"] = {
+      data: { items: SAMPLE_WEBHOOKS, total: 2 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+
+    const deleteConfig = mutationConfigs[1];
+    mockDelete.mockResolvedValue(undefined);
+    await deleteConfig.mutationFn("wh-1");
+    expect(mockDelete).toHaveBeenCalledWith("wh-1");
+  });
+
+  it("enable mutationFn calls webhooksApi.enable", async () => {
+    queryResponses["webhooks"] = {
+      data: { items: SAMPLE_WEBHOOKS, total: 2 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+
+    const enableConfig = mutationConfigs[2];
+    mockEnable.mockResolvedValue(undefined);
+    await enableConfig.mutationFn("wh-2");
+    expect(mockEnable).toHaveBeenCalledWith("wh-2");
+  });
+
+  it("disable mutationFn calls webhooksApi.disable", async () => {
+    queryResponses["webhooks"] = {
+      data: { items: SAMPLE_WEBHOOKS, total: 2 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+
+    const disableConfig = mutationConfigs[3];
+    mockDisable.mockResolvedValue(undefined);
+    await disableConfig.mutationFn("wh-1");
+    expect(mockDisable).toHaveBeenCalledWith("wh-1");
+  });
+
+  it("test mutationFn calls webhooksApi.test", async () => {
+    queryResponses["webhooks"] = {
+      data: { items: SAMPLE_WEBHOOKS, total: 2 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+
+    const testConfig = mutationConfigs[4];
+    mockTest.mockResolvedValue({ success: true, status_code: 200 });
+    await testConfig.mutationFn("wh-1");
+    expect(mockTest).toHaveBeenCalledWith("wh-1");
+  });
+
+  // -----------------------------------------------------------------------
+  // Checkbox toggling
+  // -----------------------------------------------------------------------
+
+  it("toggles event checkboxes in the create dialog", async () => {
+    queryResponses["webhooks"] = {
+      data: { items: [], total: 0 },
+      isLoading: false,
+    };
+    render(<NotificationsTabContent repositoryId="repo-123" />);
+    await userEvent.click(screen.getByTestId("add-webhook-button"));
+
+    const checkboxes = screen.getAllByTestId("mock-checkbox");
+    expect(checkboxes.length).toBe(WEBHOOK_EVENTS.length);
+
+    // Check first checkbox
+    await userEvent.click(checkboxes[0]);
+    expect(checkboxes[0]).toBeChecked();
+
+    // Uncheck it
+    await userEvent.click(checkboxes[0]);
+    expect(checkboxes[0]).not.toBeChecked();
+  });
+});

--- a/src/app/(app)/repositories/_components/notifications-tab-content.tsx
+++ b/src/app/(app)/repositories/_components/notifications-tab-content.tsx
@@ -1,0 +1,550 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  Bell,
+  Plus,
+  Trash2,
+  TestTube,
+  Power,
+  PowerOff,
+  Clock,
+  CheckCircle2,
+  XCircle,
+  Loader2,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { webhooksApi } from "@/lib/api/webhooks";
+import type {
+  Webhook,
+  WebhookEvent,
+  CreateWebhookRequest,
+} from "@/lib/api/webhooks";
+import { toUserMessage } from "@/lib/error-utils";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const WEBHOOK_EVENTS: { value: WebhookEvent; label: string; description: string }[] = [
+  {
+    value: "artifact_uploaded",
+    label: "Artifact Uploaded",
+    description: "Triggered when an artifact is pushed to this repository",
+  },
+  {
+    value: "artifact_deleted",
+    label: "Artifact Deleted",
+    description: "Triggered when an artifact is removed from this repository",
+  },
+  {
+    value: "build_started",
+    label: "Build Started",
+    description: "Triggered when a build begins for artifacts in this repository",
+  },
+  {
+    value: "build_completed",
+    label: "Build Completed",
+    description: "Triggered when a build finishes successfully",
+  },
+  {
+    value: "build_failed",
+    label: "Build Failed",
+    description: "Triggered when a build finishes with errors",
+  },
+  {
+    value: "repository_created",
+    label: "Repository Created",
+    description: "Triggered when a new repository is created",
+  },
+  {
+    value: "repository_deleted",
+    label: "Repository Deleted",
+    description: "Triggered when a repository is deleted",
+  },
+  {
+    value: "user_created",
+    label: "User Created",
+    description: "Triggered when a new user account is created",
+  },
+  {
+    value: "user_deleted",
+    label: "User Deleted",
+    description: "Triggered when a user account is removed",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface NotificationsTabContentProps {
+  repositoryId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function NotificationsTabContent({ repositoryId }: NotificationsTabContentProps) {
+  const queryClient = useQueryClient();
+  const [createOpen, setCreateOpen] = useState(false);
+
+  // Form state
+  const [formName, setFormName] = useState("");
+  const [formUrl, setFormUrl] = useState("");
+  const [formSecret, setFormSecret] = useState("");
+  const [formEvents, setFormEvents] = useState<WebhookEvent[]>([]);
+
+  const resetForm = useCallback(() => {
+    setFormName("");
+    setFormUrl("");
+    setFormSecret("");
+    setFormEvents([]);
+  }, []);
+
+  // -------------------------------------------------------------------------
+  // Queries
+  // -------------------------------------------------------------------------
+
+  const { data: webhooksData, isLoading } = useQuery({
+    queryKey: ["webhooks", repositoryId],
+    queryFn: () => webhooksApi.list({ repository_id: repositoryId }),
+    enabled: !!repositoryId,
+  });
+
+  const webhooks = webhooksData?.items ?? [];
+
+  // -------------------------------------------------------------------------
+  // Mutations
+  // -------------------------------------------------------------------------
+
+  const createMutation = useMutation({
+    mutationFn: (data: CreateWebhookRequest) => webhooksApi.create(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["webhooks", repositoryId] });
+      setCreateOpen(false);
+      resetForm();
+      toast.success("Webhook created");
+    },
+    onError: (err: unknown) => {
+      toast.error(toUserMessage(err, "Failed to create webhook"));
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => webhooksApi.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["webhooks", repositoryId] });
+      toast.success("Webhook deleted");
+    },
+    onError: (err: unknown) => {
+      toast.error(toUserMessage(err, "Failed to delete webhook"));
+    },
+  });
+
+  const enableMutation = useMutation({
+    mutationFn: (id: string) => webhooksApi.enable(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["webhooks", repositoryId] });
+      toast.success("Webhook enabled");
+    },
+    onError: (err: unknown) => {
+      toast.error(toUserMessage(err, "Failed to enable webhook"));
+    },
+  });
+
+  const disableMutation = useMutation({
+    mutationFn: (id: string) => webhooksApi.disable(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["webhooks", repositoryId] });
+      toast.success("Webhook disabled");
+    },
+    onError: (err: unknown) => {
+      toast.error(toUserMessage(err, "Failed to disable webhook"));
+    },
+  });
+
+  const testMutation = useMutation({
+    mutationFn: (id: string) => webhooksApi.test(id),
+    onSuccess: (result) => {
+      if (result.success) {
+        toast.success(`Test delivery succeeded (HTTP ${result.status_code})`);
+      } else {
+        toast.error(result.error ?? "Test delivery failed");
+      }
+    },
+    onError: (err: unknown) => {
+      toast.error(toUserMessage(err, "Failed to send test"));
+    },
+  });
+
+  // -------------------------------------------------------------------------
+  // Handlers
+  // -------------------------------------------------------------------------
+
+  const handleToggleEvent = useCallback(
+    (event: WebhookEvent, checked: boolean) => {
+      setFormEvents((prev) =>
+        checked ? [...prev, event] : prev.filter((e) => e !== event)
+      );
+    },
+    []
+  );
+
+  const handleCreate = useCallback(() => {
+    if (!formName.trim() || !formUrl.trim() || formEvents.length === 0) {
+      toast.error("Name, URL, and at least one event are required");
+      return;
+    }
+    createMutation.mutate({
+      name: formName.trim(),
+      url: formUrl.trim(),
+      events: formEvents,
+      secret: formSecret.trim() || undefined,
+      repository_id: repositoryId,
+    });
+  }, [formName, formUrl, formSecret, formEvents, repositoryId, createMutation]);
+
+  // -------------------------------------------------------------------------
+  // Loading state
+  // -------------------------------------------------------------------------
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4" data-testid="notifications-loading">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-20 w-full" />
+        <Skeleton className="h-20 w-full" />
+      </div>
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Bell className="size-5 text-muted-foreground" />
+          <h3 className="text-sm font-medium">Webhook Notifications</h3>
+          {webhooks.length > 0 && (
+            <Badge variant="secondary" className="text-xs">
+              {webhooks.length} configured
+            </Badge>
+          )}
+        </div>
+        <Button
+          size="sm"
+          onClick={() => setCreateOpen(true)}
+          data-testid="add-webhook-button"
+        >
+          <Plus className="size-4 mr-1" />
+          Add Webhook
+        </Button>
+      </div>
+
+      {/* Webhook list */}
+      {webhooks.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <Bell className="size-12 text-muted-foreground/40 mb-4" />
+          <p className="text-sm text-muted-foreground">
+            No webhooks configured for this repository.
+          </p>
+          <p className="text-xs text-muted-foreground mt-1">
+            Add a webhook to receive notifications when events occur.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {webhooks.map((webhook) => (
+            <WebhookCard
+              key={webhook.id}
+              webhook={webhook}
+              onDelete={(id) => deleteMutation.mutate(id)}
+              onEnable={(id) => enableMutation.mutate(id)}
+              onDisable={(id) => disableMutation.mutate(id)}
+              onTest={(id) => testMutation.mutate(id)}
+              isDeleting={deleteMutation.isPending}
+              isTesting={testMutation.isPending}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Create Webhook Dialog */}
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Add Webhook</DialogTitle>
+          </DialogHeader>
+
+          <div className="space-y-4 py-2">
+            <div className="space-y-2">
+              <Label htmlFor="webhook-name">Name</Label>
+              <Input
+                id="webhook-name"
+                placeholder="e.g. CI/CD Pipeline"
+                value={formName}
+                onChange={(e) => setFormName(e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="webhook-url">Payload URL</Label>
+              <Input
+                id="webhook-url"
+                type="url"
+                placeholder="https://example.com/webhook"
+                value={formUrl}
+                onChange={(e) => setFormUrl(e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="webhook-secret">
+                Secret{" "}
+                <span className="text-muted-foreground font-normal">(optional)</span>
+              </Label>
+              <Input
+                id="webhook-secret"
+                type="password"
+                placeholder="Used to sign payloads"
+                value={formSecret}
+                onChange={(e) => setFormSecret(e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-3">
+              <Label>Events</Label>
+              <div className="grid gap-2">
+                {WEBHOOK_EVENTS.map((event) => (
+                  <label
+                    key={event.value}
+                    className="flex items-start gap-3 rounded-md border p-3 cursor-pointer hover:bg-muted/50 transition-colors"
+                  >
+                    <Checkbox
+                      checked={formEvents.includes(event.value)}
+                      onCheckedChange={(checked) =>
+                        handleToggleEvent(event.value, checked === true)
+                      }
+                      aria-label={event.label}
+                    />
+                    <div className="space-y-0.5">
+                      <span className="text-sm font-medium">{event.label}</span>
+                      <p className="text-xs text-muted-foreground">
+                        {event.description}
+                      </p>
+                    </div>
+                  </label>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setCreateOpen(false);
+                resetForm();
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleCreate}
+              disabled={createMutation.isPending}
+              data-testid="create-webhook-submit"
+            >
+              {createMutation.isPending ? (
+                <>
+                  <Loader2 className="size-4 mr-1 animate-spin" />
+                  Creating...
+                </>
+              ) : (
+                "Create Webhook"
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// WebhookCard sub-component
+// ---------------------------------------------------------------------------
+
+interface WebhookCardProps {
+  webhook: Webhook;
+  onDelete: (id: string) => void;
+  onEnable: (id: string) => void;
+  onDisable: (id: string) => void;
+  onTest: (id: string) => void;
+  isDeleting: boolean;
+  isTesting: boolean;
+}
+
+function WebhookCard({
+  webhook,
+  onDelete,
+  onEnable,
+  onDisable,
+  onTest,
+  isDeleting,
+  isTesting,
+}: WebhookCardProps) {
+  return (
+    <div
+      className="rounded-lg border bg-card p-4 space-y-3"
+      data-testid={`webhook-card-${webhook.id}`}
+    >
+      {/* Top row: name + status + actions */}
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-sm font-medium truncate">{webhook.name}</span>
+          <Badge
+            variant="outline"
+            className={`text-xs shrink-0 ${
+              webhook.is_enabled
+                ? "text-green-600 bg-green-100 dark:bg-green-950/40"
+                : "text-muted-foreground"
+            }`}
+          >
+            {webhook.is_enabled ? "Active" : "Inactive"}
+          </Badge>
+        </div>
+
+        <div className="flex items-center gap-1 shrink-0">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                onClick={() => onTest(webhook.id)}
+                disabled={isTesting}
+                aria-label="Test webhook"
+              >
+                {isTesting ? (
+                  <Loader2 className="size-3.5 animate-spin" />
+                ) : (
+                  <TestTube className="size-3.5" />
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Send test delivery</TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                onClick={() =>
+                  webhook.is_enabled
+                    ? onDisable(webhook.id)
+                    : onEnable(webhook.id)
+                }
+                aria-label={webhook.is_enabled ? "Disable webhook" : "Enable webhook"}
+              >
+                {webhook.is_enabled ? (
+                  <PowerOff className="size-3.5" />
+                ) : (
+                  <Power className="size-3.5" />
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {webhook.is_enabled ? "Disable" : "Enable"}
+            </TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                className="text-destructive hover:text-destructive"
+                onClick={() => onDelete(webhook.id)}
+                disabled={isDeleting}
+                aria-label="Delete webhook"
+              >
+                <Trash2 className="size-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Delete</TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+
+      {/* URL */}
+      <p className="text-xs text-muted-foreground font-mono truncate" title={webhook.url}>
+        {webhook.url}
+      </p>
+
+      {/* Events + last triggered */}
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <div className="flex flex-wrap gap-1">
+          {webhook.events.map((event) => (
+            <Badge key={event} variant="secondary" className="text-xs font-normal">
+              {formatEventLabel(event)}
+            </Badge>
+          ))}
+        </div>
+
+        <div className="flex items-center gap-1 text-xs text-muted-foreground shrink-0">
+          {webhook.last_triggered_at ? (
+            <>
+              <CheckCircle2 className="size-3 text-green-500" />
+              <Clock className="size-3" />
+              <span>
+                Last triggered{" "}
+                {new Date(webhook.last_triggered_at).toLocaleDateString()}
+              </span>
+            </>
+          ) : (
+            <>
+              <XCircle className="size-3" />
+              <span>Never triggered</span>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatEventLabel(event: WebhookEvent): string {
+  const found = WEBHOOK_EVENTS.find((e) => e.value === event);
+  return found?.label ?? event;
+}

--- a/src/app/(app)/repositories/_components/notifications-tab-content.tsx
+++ b/src/app/(app)/repositories/_components/notifications-tab-content.tsx
@@ -42,6 +42,7 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from "@/components/ui/tooltip";
+import { ConfirmDialog } from "@/components/common/confirm-dialog";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -110,18 +111,22 @@ interface NotificationsTabContentProps {
 export function NotificationsTabContent({ repositoryId }: NotificationsTabContentProps) {
   const queryClient = useQueryClient();
   const [createOpen, setCreateOpen] = useState(false);
+  const [webhookToDelete, setWebhookToDelete] = useState<string | null>(null);
+  const [actingWebhookId, setActingWebhookId] = useState<string | null>(null);
 
   // Form state
   const [formName, setFormName] = useState("");
   const [formUrl, setFormUrl] = useState("");
   const [formSecret, setFormSecret] = useState("");
   const [formEvents, setFormEvents] = useState<WebhookEvent[]>([]);
+  const [urlError, setUrlError] = useState<string | null>(null);
 
   const resetForm = useCallback(() => {
     setFormName("");
     setFormUrl("");
     setFormSecret("");
     setFormEvents([]);
+    setUrlError(null);
   }, []);
 
   // -------------------------------------------------------------------------
@@ -157,9 +162,12 @@ export function NotificationsTabContent({ repositoryId }: NotificationsTabConten
     mutationFn: (id: string) => webhooksApi.delete(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["webhooks", repositoryId] });
+      setWebhookToDelete(null);
+      setActingWebhookId(null);
       toast.success("Webhook deleted");
     },
     onError: (err: unknown) => {
+      setActingWebhookId(null);
       toast.error(toUserMessage(err, "Failed to delete webhook"));
     },
   });
@@ -168,9 +176,11 @@ export function NotificationsTabContent({ repositoryId }: NotificationsTabConten
     mutationFn: (id: string) => webhooksApi.enable(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["webhooks", repositoryId] });
+      setActingWebhookId(null);
       toast.success("Webhook enabled");
     },
     onError: (err: unknown) => {
+      setActingWebhookId(null);
       toast.error(toUserMessage(err, "Failed to enable webhook"));
     },
   });
@@ -179,9 +189,11 @@ export function NotificationsTabContent({ repositoryId }: NotificationsTabConten
     mutationFn: (id: string) => webhooksApi.disable(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["webhooks", repositoryId] });
+      setActingWebhookId(null);
       toast.success("Webhook disabled");
     },
     onError: (err: unknown) => {
+      setActingWebhookId(null);
       toast.error(toUserMessage(err, "Failed to disable webhook"));
     },
   });
@@ -189,6 +201,7 @@ export function NotificationsTabContent({ repositoryId }: NotificationsTabConten
   const testMutation = useMutation({
     mutationFn: (id: string) => webhooksApi.test(id),
     onSuccess: (result) => {
+      setActingWebhookId(null);
       if (result.success) {
         toast.success(`Test delivery succeeded (HTTP ${result.status_code})`);
       } else {
@@ -196,6 +209,7 @@ export function NotificationsTabContent({ repositoryId }: NotificationsTabConten
       }
     },
     onError: (err: unknown) => {
+      setActingWebhookId(null);
       toast.error(toUserMessage(err, "Failed to send test"));
     },
   });
@@ -218,9 +232,15 @@ export function NotificationsTabContent({ repositoryId }: NotificationsTabConten
       toast.error("Name, URL, and at least one event are required");
       return;
     }
+    const trimmedUrl = formUrl.trim();
+    if (!trimmedUrl.startsWith("http://") && !trimmedUrl.startsWith("https://")) {
+      setUrlError("URL must start with http:// or https://");
+      return;
+    }
+    setUrlError(null);
     createMutation.mutate({
       name: formName.trim(),
-      url: formUrl.trim(),
+      url: trimmedUrl,
       events: formEvents,
       secret: formSecret.trim() || undefined,
       repository_id: repositoryId,
@@ -281,18 +301,30 @@ export function NotificationsTabContent({ repositoryId }: NotificationsTabConten
         </div>
       ) : (
         <div className="space-y-3">
-          {webhooks.map((webhook) => (
-            <WebhookCard
-              key={webhook.id}
-              webhook={webhook}
-              onDelete={(id) => deleteMutation.mutate(id)}
-              onEnable={(id) => enableMutation.mutate(id)}
-              onDisable={(id) => disableMutation.mutate(id)}
-              onTest={(id) => testMutation.mutate(id)}
-              isDeleting={deleteMutation.isPending}
-              isTesting={testMutation.isPending}
-            />
-          ))}
+          {webhooks.map((webhook) => {
+            const isActing = actingWebhookId === webhook.id;
+            return (
+              <WebhookCard
+                key={webhook.id}
+                webhook={webhook}
+                onDelete={(id) => setWebhookToDelete(id)}
+                onEnable={(id) => {
+                  setActingWebhookId(id);
+                  enableMutation.mutate(id);
+                }}
+                onDisable={(id) => {
+                  setActingWebhookId(id);
+                  disableMutation.mutate(id);
+                }}
+                onTest={(id) => {
+                  setActingWebhookId(id);
+                  testMutation.mutate(id);
+                }}
+                isDeleting={isActing && deleteMutation.isPending}
+                isTesting={isActing && testMutation.isPending}
+              />
+            );
+          })}
         </div>
       )}
 
@@ -321,8 +353,16 @@ export function NotificationsTabContent({ repositoryId }: NotificationsTabConten
                 type="url"
                 placeholder="https://example.com/webhook"
                 value={formUrl}
-                onChange={(e) => setFormUrl(e.target.value)}
+                onChange={(e) => {
+                  setFormUrl(e.target.value);
+                  setUrlError(null);
+                }}
               />
+              {urlError && (
+                <p className="text-xs text-destructive" data-testid="url-error">
+                  {urlError}
+                </p>
+              )}
             </div>
 
             <div className="space-y-2">
@@ -393,6 +433,25 @@ export function NotificationsTabContent({ repositoryId }: NotificationsTabConten
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* Delete Webhook Confirm */}
+      <ConfirmDialog
+        open={!!webhookToDelete}
+        onOpenChange={(open) => {
+          if (!open) setWebhookToDelete(null);
+        }}
+        title="Delete Webhook"
+        description="This will permanently remove this webhook. It will no longer receive event notifications."
+        confirmText="Delete Webhook"
+        danger
+        loading={deleteMutation.isPending}
+        onConfirm={() => {
+          if (webhookToDelete) {
+            setActingWebhookId(webhookToDelete);
+            deleteMutation.mutate(webhookToDelete);
+          }
+        }}
+      />
     </div>
   );
 }

--- a/src/app/(app)/repositories/_components/repo-detail-content.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   ArrowLeft,
+  Bell,
   Download,
   Trash2,
   Search,
@@ -26,6 +27,7 @@ import type { UpsertScanConfigRequest } from "@/types/security";
 import { SbomTabContent } from "./sbom-tab-content";
 import { SecurityTabContent } from "./security-tab-content";
 import { HealthTabContent } from "./health-tab-content";
+import { NotificationsTabContent } from "./notifications-tab-content";
 import { VirtualMembersPanel } from "./virtual-members-panel";
 import { PackagesTabContent } from "./packages-tab-content";
 import { formatBytes, REPO_TYPE_COLORS } from "@/lib/utils";
@@ -511,6 +513,12 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
               Security
             </TabsTrigger>
           )}
+          {user?.is_admin && (
+            <TabsTrigger value="notifications">
+              <Bell className="size-3.5 mr-1" />
+              Notifications
+            </TabsTrigger>
+          )}
         </TabsList>
 
         {/* --- Artifacts Tab --- */}
@@ -675,6 +683,13 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
                 </Button>
               </form>
             )}
+          </TabsContent>
+        )}
+
+        {/* --- Notifications Tab --- */}
+        {user?.is_admin && (
+          <TabsContent value="notifications" className="mt-4">
+            <NotificationsTabContent repositoryId={repository.id} />
           </TabsContent>
         )}
       </Tabs>


### PR DESCRIPTION
## Summary

Adds a Notifications tab to the repository detail view (visible to admins) for configuring webhook notifications on repository events. Closes #267.

The tab uses the existing webhooks API (`src/lib/api/webhooks.ts`) and follows the same component patterns as the Security and Health tabs. It provides:

- A list of configured webhooks showing name, URL, subscribed events, active/inactive status, and last triggered timestamp
- An "Add Webhook" dialog with event selection checkboxes covering all 9 webhook event types (artifact upload/delete, build start/complete/fail, repo create/delete, user create/delete)
- Per-webhook action buttons for testing delivery, toggling enabled state, and deletion
- Loading skeleton and empty state consistent with other tab content components

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [ ] Playwright E2E spec covers the change
- [x] Responsive layout verified (mobile + desktop)
- [x] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes