### PR TITLE
feat: add repository-scoped access token management

### DIFF
--- a/src/app/(app)/(protected)/access-tokens/__tests__/page.test.tsx
+++ b/src/app/(app)/(protected)/access-tokens/__tests__/page.test.tsx
@@ -59,6 +59,12 @@ vi.mock("@/lib/api/profile", () => ({
   },
 }));
 
+vi.mock("@/lib/api/service-accounts", () => ({
+  serviceAccountsApi: {
+    previewRepoSelector: vi.fn(),
+  },
+}));
+
 vi.mock("@/lib/constants/token", () => ({
   SCOPES: [
     { value: "read", label: "Read" },
@@ -209,6 +215,9 @@ vi.mock("@/components/common/token-create-form", () => ({
     onSubmit,
     onCancel,
     availableScopes,
+    showRepoSelector,
+    repoSelector,
+    onRepoSelectorChange,
   }: any) => (
     <div data-testid="token-create-form">
       <span>{title}</span>
@@ -227,8 +236,27 @@ vi.mock("@/components/common/token-create-form", () => ({
           ))}
         </div>
       )}
+      {showRepoSelector && (
+        <div data-testid="repo-selector-section">
+          <span data-testid="repo-selector-data">
+            {JSON.stringify(repoSelector)}
+          </span>
+          <button
+            data-testid="repo-selector-change-btn"
+            onClick={() =>
+              onRepoSelectorChange?.({ match_formats: ["docker"] })
+            }
+          >
+            Change Selector
+          </button>
+        </div>
+      )}
     </div>
   ),
+}));
+
+vi.mock("@/components/common/repo-selector-form", () => ({
+  RepoSelectorForm: () => <div data-testid="repo-selector-form" />,
 }));
 
 // ---------------------------------------------------------------------------
@@ -265,6 +293,42 @@ const mockAccessTokens = [
     expires_at: "2026-12-31T00:00:00Z",
     last_used_at: "2026-02-25T08:30:00Z",
     created_at: "2026-02-01T00:00:00Z",
+  },
+];
+
+const mockScopedAccessTokens = [
+  {
+    id: "token-scoped-1",
+    name: "Scoped Docker Token",
+    token_prefix: "at_dck1",
+    scopes: ["read", "write"],
+    expires_at: "2026-12-31T00:00:00Z",
+    last_used_at: null,
+    created_at: "2026-03-01T00:00:00Z",
+    repo_selector: {
+      match_formats: ["docker", "helm"],
+      match_pattern: "prod-*",
+      match_labels: { env: "production" },
+    },
+  },
+  {
+    id: "token-scoped-2",
+    name: "Repo ID Token",
+    token_prefix: "at_rid1",
+    scopes: ["read"],
+    expires_at: null,
+    last_used_at: "2026-03-10T12:00:00Z",
+    created_at: "2026-03-05T00:00:00Z",
+    repository_ids: ["repo-1", "repo-2", "repo-3"],
+  },
+  {
+    id: "token-unscoped",
+    name: "All Repos Token",
+    token_prefix: "at_all1",
+    scopes: ["read"],
+    expires_at: null,
+    last_used_at: null,
+    created_at: "2026-03-10T00:00:00Z",
   },
 ];
 
@@ -324,7 +388,7 @@ function setupDefaultMocks(
 // Import the component under test (vi.mock calls above are hoisted)
 // ---------------------------------------------------------------------------
 
-import AccessTokensPage from "../page";
+import AccessTokensPage, { renderRepoAccess } from "../page";
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -942,7 +1006,7 @@ describe("AccessTokensPage", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Personal access tokens for CLI and CI/CD authentication."
+        "Personal access tokens for CLI and CI/CD authentication. Tokens can be scoped to specific repositories."
       )
     ).toBeInTheDocument();
   });
@@ -1223,7 +1287,6 @@ describe("AccessTokensPage", () => {
     fireEvent.click(screen.getByTestId("confirm-btn"));
 
     // The revokeKeyMutation's mutate should have been called
-    // We verify the mutation config's mutationFn was set up correctly
     expect(mutationConfigs[1]).toBeDefined();
   });
 
@@ -1325,9 +1388,9 @@ describe("AccessTokensPage", () => {
   });
 
   // -------------------------------------------------------------------------
-  // 50. DataTable column headers are passed correctly for access tokens
+  // 51. DataTable column headers for access tokens include Repo Access
   // -------------------------------------------------------------------------
-  it("passes correct column headers to the access tokens DataTable", () => {
+  it("passes correct column headers to the access tokens DataTable including Repo Access", () => {
     setupDefaultMocks({ accessTokens: mockAccessTokens });
 
     render(<AccessTokensPage />);
@@ -1336,13 +1399,14 @@ describe("AccessTokensPage", () => {
     expect(tokenTab.textContent).toContain("Name");
     expect(tokenTab.textContent).toContain("Token Prefix");
     expect(tokenTab.textContent).toContain("Scopes");
+    expect(tokenTab.textContent).toContain("Repo Access");
     expect(tokenTab.textContent).toContain("Expires");
     expect(tokenTab.textContent).toContain("Last Used");
     expect(tokenTab.textContent).toContain("Created");
   });
 
   // -------------------------------------------------------------------------
-  // 51. DateCell renders formatted dates for non-null values
+  // 52. DateCell renders formatted dates for non-null values
   // -------------------------------------------------------------------------
   it("renders formatted dates for non-null date fields", () => {
     setupDefaultMocks({ apiKeys: mockApiKeys });
@@ -1355,5 +1419,308 @@ describe("AccessTokensPage", () => {
     expect(tables[0].textContent).toContain("CI Pipeline Key");
     // The second key has null dates showing "Never"
     expect(tables[0].textContent).toContain("Never");
+  });
+
+  // =========================================================================
+  // Repository scoping tests
+  // =========================================================================
+
+  // -------------------------------------------------------------------------
+  // 53. Access token create dialog shows repo selector
+  // -------------------------------------------------------------------------
+  it("shows repo selector section in create access token dialog", () => {
+    setupDefaultMocks();
+
+    render(<AccessTokensPage />);
+
+    // Open create token dialog
+    const tokenTab = screen.getByTestId("tab-content-access-tokens");
+    const createBtn = tokenTab.querySelector("button")!;
+    fireEvent.click(createBtn);
+
+    expect(screen.getByTestId("repo-selector-section")).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // 54. API key create dialog does NOT show repo selector
+  // -------------------------------------------------------------------------
+  it("does not show repo selector in create API key dialog", () => {
+    setupDefaultMocks();
+
+    render(<AccessTokensPage />);
+
+    // Open create API key dialog
+    const apiKeysTab = screen.getByTestId("tab-content-api-keys");
+    const createBtn = apiKeysTab.querySelector("button")!;
+    fireEvent.click(createBtn);
+
+    expect(screen.queryByTestId("repo-selector-section")).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // 55. Repo selector initializes with empty object
+  // -------------------------------------------------------------------------
+  it("initializes repo selector with empty object", () => {
+    setupDefaultMocks();
+
+    render(<AccessTokensPage />);
+
+    const tokenTab = screen.getByTestId("tab-content-access-tokens");
+    fireEvent.click(tokenTab.querySelector("button")!);
+
+    const selectorData = screen.getByTestId("repo-selector-data");
+    expect(selectorData.textContent).toBe("{}");
+  });
+
+  // -------------------------------------------------------------------------
+  // 56. Repo selector resets on dialog close
+  // -------------------------------------------------------------------------
+  it("resets repo selector when access token dialog is closed", () => {
+    setupDefaultMocks();
+
+    render(<AccessTokensPage />);
+
+    // Open dialog
+    const tokenTab = screen.getByTestId("tab-content-access-tokens");
+    fireEvent.click(tokenTab.querySelector("button")!);
+
+    // Change the selector
+    fireEvent.click(screen.getByTestId("repo-selector-change-btn"));
+
+    // Close dialog
+    fireEvent.click(screen.getByTestId("dialog-close-trigger"));
+
+    // Re-open dialog
+    fireEvent.click(tokenTab.querySelector("button")!);
+
+    // Selector should be reset to empty
+    const selectorData = screen.getByTestId("repo-selector-data");
+    expect(selectorData.textContent).toBe("{}");
+  });
+
+  // -------------------------------------------------------------------------
+  // 57. createTokenMutation onSuccess resets repo selector
+  // -------------------------------------------------------------------------
+  it("resets repo selector after successful token creation", async () => {
+    const { toast } = await import("sonner");
+    setupDefaultMocks();
+
+    render(<AccessTokensPage />);
+
+    const createTokenConfig = mutationConfigs[2];
+    act(() => {
+      createTokenConfig.onSuccess({ token: "new-scoped-token" });
+    });
+
+    expect(toast.success).toHaveBeenCalledWith("Access token created");
+    // The repo selector should be reset (tested implicitly by re-opening dialog)
+  });
+
+  // -------------------------------------------------------------------------
+  // 58. Tokens with repo_selector show scope summary in table
+  // -------------------------------------------------------------------------
+  it("renders repo access column showing selector summary for scoped tokens", () => {
+    setupDefaultMocks({ accessTokens: mockScopedAccessTokens });
+
+    render(<AccessTokensPage />);
+
+    // The scoped token with formats, pattern, and labels
+    expect(screen.getByText(/2 format\(s\)/)).toBeInTheDocument();
+    expect(screen.getByText(/prod-\*/)).toBeInTheDocument();
+    expect(screen.getByText(/1 label\(s\)/)).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // 59. Tokens with repository_ids show repo count
+  // -------------------------------------------------------------------------
+  it("renders repo access column showing repo count for repository_ids tokens", () => {
+    setupDefaultMocks({ accessTokens: mockScopedAccessTokens });
+
+    render(<AccessTokensPage />);
+
+    expect(screen.getByText("3 repo(s)")).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // 60. Tokens without scope show 'All repos'
+  // -------------------------------------------------------------------------
+  it("renders 'All repos' for tokens without repo_selector or repository_ids", () => {
+    setupDefaultMocks({ accessTokens: mockScopedAccessTokens });
+
+    render(<AccessTokensPage />);
+
+    expect(screen.getByText("All repos")).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // 61. Updated access tokens description mentions scoping
+  // -------------------------------------------------------------------------
+  it("shows updated description mentioning repository scoping", () => {
+    setupDefaultMocks();
+
+    render(<AccessTokensPage />);
+
+    expect(
+      screen.getByText(
+        "Personal access tokens for CLI and CI/CD authentication. Tokens can be scoped to specific repositories."
+      )
+    ).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // 62. Token table has Repo Access column header
+  // -------------------------------------------------------------------------
+  it("includes Repo Access in the access tokens column headers", () => {
+    setupDefaultMocks({ accessTokens: mockAccessTokens });
+
+    render(<AccessTokensPage />);
+
+    const tokenTab = screen.getByTestId("tab-content-access-tokens");
+    expect(tokenTab.textContent).toContain("Repo Access");
+  });
+
+  // -------------------------------------------------------------------------
+  // 63. API keys table does NOT have Repo Access column
+  // -------------------------------------------------------------------------
+  it("does not include Repo Access in the API keys column headers", () => {
+    setupDefaultMocks({ apiKeys: mockApiKeys });
+
+    render(<AccessTokensPage />);
+
+    const apiKeysTab = screen.getByTestId("tab-content-api-keys");
+    // Check no "Repo Access" in the API keys section
+    // Both tabs are visible in DOM. Check the table headers within the API keys tab
+    const apiTable = apiKeysTab.querySelector("[data-testid='data-table']");
+    if (apiTable) {
+      const headers = apiTable.querySelectorAll("th");
+      const headerTexts = Array.from(headers).map((h) => h.textContent);
+      expect(headerTexts).not.toContain("Repo Access");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderRepoAccess unit tests
+// ---------------------------------------------------------------------------
+
+describe("renderRepoAccess", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders 'Selector' fallback when repo_selector has no useful fields", () => {
+    const token = {
+      id: "t1",
+      name: "test",
+      token_prefix: "at_x",
+      created_at: "2026-01-01",
+      repo_selector: {},
+    };
+    const { container } = render(<>{renderRepoAccess(token)}</>);
+    expect(container.textContent).toBe("Selector");
+  });
+
+  it("renders format count from repo_selector", () => {
+    const token = {
+      id: "t2",
+      name: "test",
+      token_prefix: "at_x",
+      created_at: "2026-01-01",
+      repo_selector: { match_formats: ["docker", "npm", "maven"] },
+    };
+    const { container } = render(<>{renderRepoAccess(token)}</>);
+    expect(container.textContent).toContain("3 format(s)");
+  });
+
+  it("renders pattern from repo_selector", () => {
+    const token = {
+      id: "t3",
+      name: "test",
+      token_prefix: "at_x",
+      created_at: "2026-01-01",
+      repo_selector: { match_pattern: "staging-*" },
+    };
+    const { container } = render(<>{renderRepoAccess(token)}</>);
+    expect(container.textContent).toContain("staging-*");
+  });
+
+  it("renders label count from repo_selector", () => {
+    const token = {
+      id: "t4",
+      name: "test",
+      token_prefix: "at_x",
+      created_at: "2026-01-01",
+      repo_selector: { match_labels: { env: "prod", tier: "backend" } },
+    };
+    const { container } = render(<>{renderRepoAccess(token)}</>);
+    expect(container.textContent).toContain("2 label(s)");
+  });
+
+  it("renders combined summary for selector with all fields", () => {
+    const token = {
+      id: "t5",
+      name: "test",
+      token_prefix: "at_x",
+      created_at: "2026-01-01",
+      repo_selector: {
+        match_formats: ["docker"],
+        match_pattern: "prod-*",
+        match_labels: { env: "production" },
+      },
+    };
+    const { container } = render(<>{renderRepoAccess(token)}</>);
+    expect(container.textContent).toContain("1 format(s)");
+    expect(container.textContent).toContain("prod-*");
+    expect(container.textContent).toContain("1 label(s)");
+  });
+
+  it("renders repository_ids count when no repo_selector", () => {
+    const token = {
+      id: "t6",
+      name: "test",
+      token_prefix: "at_x",
+      created_at: "2026-01-01",
+      repository_ids: ["r1", "r2"],
+    };
+    const { container } = render(<>{renderRepoAccess(token)}</>);
+    expect(container.textContent).toBe("2 repo(s)");
+  });
+
+  it("renders 'All repos' when neither repo_selector nor repository_ids", () => {
+    const token = {
+      id: "t7",
+      name: "test",
+      token_prefix: "at_x",
+      created_at: "2026-01-01",
+    };
+    const { container } = render(<>{renderRepoAccess(token)}</>);
+    expect(container.textContent).toBe("All repos");
+  });
+
+  it("renders 'All repos' when repository_ids is empty", () => {
+    const token = {
+      id: "t8",
+      name: "test",
+      token_prefix: "at_x",
+      created_at: "2026-01-01",
+      repository_ids: [],
+    };
+    const { container } = render(<>{renderRepoAccess(token)}</>);
+    expect(container.textContent).toBe("All repos");
+  });
+
+  it("prefers repo_selector over repository_ids when both are present", () => {
+    const token = {
+      id: "t9",
+      name: "test",
+      token_prefix: "at_x",
+      created_at: "2026-01-01",
+      repo_selector: { match_formats: ["npm"] },
+      repository_ids: ["r1", "r2"],
+    };
+    const { container } = render(<>{renderRepoAccess(token)}</>);
+    // Should show selector, not repo count
+    expect(container.textContent).toContain("1 format(s)");
+    expect(container.textContent).not.toContain("repo(s)");
   });
 });

--- a/src/app/(app)/(protected)/access-tokens/page.tsx
+++ b/src/app/(app)/(protected)/access-tokens/page.tsx
@@ -19,6 +19,7 @@ import type {
   CreateApiKeyResponse,
   CreateAccessTokenResponse,
 } from "@/lib/api/profile";
+import type { RepoSelector } from "@/lib/api/service-accounts";
 import { useAuth } from "@/providers/auth-provider";
 import { SCOPES } from "@/lib/constants/token";
 
@@ -76,6 +77,37 @@ function TokenPrefix({ prefix }: { prefix: string }) {
   );
 }
 
+export function renderRepoAccess(token: AccessToken) {
+  if (token.repo_selector) {
+    const parts: string[] = [];
+    if (token.repo_selector.match_formats?.length) {
+      parts.push(`${token.repo_selector.match_formats.length} format(s)`);
+    }
+    if (token.repo_selector.match_pattern) {
+      parts.push(token.repo_selector.match_pattern);
+    }
+    const labelCount = Object.keys(token.repo_selector.match_labels ?? {}).length;
+    if (labelCount > 0) {
+      parts.push(`${labelCount} label(s)`);
+    }
+    return (
+      <Badge variant="secondary" className="text-xs">
+        {parts.join(", ") || "Selector"}
+      </Badge>
+    );
+  }
+  if (token.repository_ids && token.repository_ids.length > 0) {
+    return (
+      <Badge variant="secondary" className="text-xs">
+        {token.repository_ids.length} repo(s)
+      </Badge>
+    );
+  }
+  return (
+    <span className="text-xs text-muted-foreground">All repos</span>
+  );
+}
+
 export default function AccessTokensPage() {
   const { user } = useAuth();
   const queryClient = useQueryClient();
@@ -96,6 +128,7 @@ export default function AccessTokensPage() {
   const [tokenName, setTokenName] = useState("");
   const [tokenExpiry, setTokenExpiry] = useState("90");
   const [tokenScopes, setTokenScopes] = useState<string[]>(["read"]);
+  const [tokenRepoSelector, setTokenRepoSelector] = useState<RepoSelector>({});
   const [newlyCreatedToken, setNewlyCreatedToken] = useState<string | null>(
     null
   );
@@ -147,6 +180,7 @@ export default function AccessTokensPage() {
       setTokenName("");
       setTokenScopes(["read"]);
       setTokenExpiry("90");
+      setTokenRepoSelector({});
       toast.success("Access token created");
     },
     onError: () => toast.error("Failed to create access token"),
@@ -221,6 +255,7 @@ export default function AccessTokensPage() {
     },
     { id: "prefix", header: "Token Prefix", cell: (t) => <TokenPrefix prefix={t.token_prefix} /> },
     { id: "scopes", header: "Scopes", cell: (t) => <ScopeBadges scopes={t.scopes} /> },
+    { id: "repo_access", header: "Repo Access", cell: renderRepoAccess },
     { id: "expires", header: "Expires", accessor: (t) => t.expires_at ?? "", cell: (t) => <DateCell value={t.expires_at} /> },
     { id: "last_used", header: "Last Used", accessor: (t) => t.last_used_at ?? "", cell: (t) => <DateCell value={t.last_used_at} /> },
     { id: "created", header: "Created", accessor: (t) => t.created_at, sortable: true, cell: (t) => <DateCell value={t.created_at} /> },
@@ -304,7 +339,7 @@ export default function AccessTokensPage() {
             <div>
               <h2 className="text-lg font-semibold">Access Tokens</h2>
               <p className="text-sm text-muted-foreground">
-                Personal access tokens for CLI and CI/CD authentication.
+                Personal access tokens for CLI and CI/CD authentication. Tokens can be scoped to specific repositories.
               </p>
             </div>
             <Button onClick={() => setCreateTokenOpen(true)}>
@@ -392,11 +427,12 @@ export default function AccessTokensPage() {
             setTokenName("");
             setTokenScopes(["read"]);
             setTokenExpiry("90");
+            setTokenRepoSelector({});
             setNewlyCreatedToken(null);
           }
         }}
       >
-        <DialogContent className="sm:max-w-md">
+        <DialogContent className="sm:max-w-lg">
           {newlyCreatedToken ? (
             <TokenCreatedAlert
               title="Access Token Created"
@@ -420,16 +456,24 @@ export default function AccessTokensPage() {
               onScopesChange={setTokenScopes}
               availableScopes={availableScopes}
               isPending={createTokenMutation.isPending}
-              onSubmit={() =>
+              onSubmit={() => {
+                const hasSelector =
+                  (tokenRepoSelector.match_formats?.length ?? 0) > 0 ||
+                  Object.keys(tokenRepoSelector.match_labels ?? {}).length > 0 ||
+                  !!tokenRepoSelector.match_pattern;
                 createTokenMutation.mutate({
                   name: tokenName,
                   expires_in_days:
                     tokenExpiry === "0" ? undefined : Number(tokenExpiry),
                   scopes: tokenScopes,
-                })
-              }
+                  repo_selector: hasSelector ? tokenRepoSelector : undefined,
+                });
+              }}
               onCancel={() => setCreateTokenOpen(false)}
               submitLabel="Create Token"
+              showRepoSelector
+              repoSelector={tokenRepoSelector}
+              onRepoSelectorChange={setTokenRepoSelector}
             />
           )}
         </DialogContent>

--- a/src/lib/api/__tests__/profile.test.ts
+++ b/src/lib/api/__tests__/profile.test.ts
@@ -314,6 +314,44 @@ describe("profileApi", () => {
     ).rejects.toBe("invalid request");
   });
 
+  it("createAccessToken passes repo_selector to SDK", async () => {
+    const mockResponse = {
+      id: "tok-scoped",
+      token: "akt_scoped_token",
+      name: "Scoped Token",
+    };
+    mockCreateApiToken.mockResolvedValue({
+      data: mockResponse,
+      error: undefined,
+    });
+
+    const { profileApi } = await import("../profile");
+    const result = await profileApi.createAccessToken({
+      name: "Scoped Token",
+      expires_in_days: 90,
+      scopes: ["read", "write"],
+      repo_selector: {
+        match_formats: ["docker", "npm"],
+        match_pattern: "prod-*",
+        match_labels: { env: "production" },
+      },
+    });
+
+    expect(mockCreateApiToken).toHaveBeenCalledWith({
+      body: {
+        name: "Scoped Token",
+        expires_in_days: 90,
+        scopes: ["read", "write"],
+        repo_selector: {
+          match_formats: ["docker", "npm"],
+          match_pattern: "prod-*",
+          match_labels: { env: "production" },
+        },
+      },
+    });
+    expect(result).toEqual(mockResponse);
+  });
+
   // ---- deleteAccessToken ----
 
   it("deleteAccessToken calls SDK with token id", async () => {

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -59,6 +59,14 @@ export type {
   CreateAccessTokenResponse,
 } from './profile';
 export type {
+  ServiceAccount,
+  ServiceAccountToken,
+  RepoSelector,
+  MatchedRepository,
+  CreateTokenRequest as CreateServiceAccountTokenRequest,
+  CreateTokenResponse as CreateServiceAccountTokenResponse,
+} from './service-accounts';
+export type {
   Webhook,
   WebhookDelivery,
   WebhookEvent,

--- a/src/lib/api/profile.ts
+++ b/src/lib/api/profile.ts
@@ -7,6 +7,7 @@ import {
   revokeApiToken as sdkRevokeApiToken,
 } from '@artifact-keeper/sdk';
 import type { User } from '@/types';
+import type { RepoSelector } from '@/lib/api/service-accounts';
 
 export interface UpdateProfileRequest {
   display_name?: string;
@@ -45,12 +46,15 @@ export interface AccessToken {
   expires_at?: string;
   last_used_at?: string;
   scopes?: string[];
+  repo_selector?: RepoSelector;
+  repository_ids?: string[];
 }
 
 export interface CreateAccessTokenRequest {
   name: string;
   expires_in_days?: number;
   scopes?: string[];
+  repo_selector?: RepoSelector;
 }
 
 export interface CreateAccessTokenResponse {


### PR DESCRIPTION
## Summary

Add repository scoping to the personal access token creation and management UI. The existing access tokens page now supports creating tokens that are limited to specific repositories by format, name pattern, or labels. The token list table includes a new "Repo Access" column showing a summary of each token's scope.

- Wire the existing `TokenCreateForm` + `RepoSelectorForm` components into the access token creation dialog with `showRepoSelector` enabled
- Add `repo_selector` and `repository_ids` fields to `AccessToken` and `CreateAccessTokenRequest` types in the profile API layer
- Add a "Repo Access" column to the access tokens table that displays scope details (format count, pattern, label count) or "All repos" for unscoped tokens
- Export `renderRepoAccess` as a standalone function with dedicated unit tests

Closes #250

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [ ] Playwright E2E spec covers the change
- [x] Responsive layout verified (mobile + desktop)
- [x] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes