### PR TITLE
Display password reuse rejection message on change password

### DIFF
--- a/src/app/(app)/(protected)/profile/__tests__/page.test.tsx
+++ b/src/app/(app)/(protected)/profile/__tests__/page.test.tsx
@@ -1,0 +1,378 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+
+// ---------------------------------------------------------------------------
+// Hoisted mock fns so they can be referenced in vi.mock factories
+// ---------------------------------------------------------------------------
+
+const {
+  mockToastSuccess,
+  mockToastError,
+  mockChangePassword,
+  mockRefreshUser,
+  mockUseMutation,
+  mockProfileUpdate,
+} = vi.hoisted(() => ({
+  mockToastSuccess: vi.fn(),
+  mockToastError: vi.fn(),
+  mockChangePassword: vi.fn(),
+  mockRefreshUser: vi.fn(),
+  mockUseMutation: vi.fn(),
+  mockProfileUpdate: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("sonner", () => ({
+  toast: { success: mockToastSuccess, error: mockToastError },
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, ...props }: any) => <a {...props}>{children}</a>,
+}));
+
+vi.mock("@/providers/auth-provider", () => ({
+  useAuth: () => ({
+    user: {
+      id: "u1",
+      username: "testuser",
+      email: "test@example.com",
+      display_name: "Test User",
+      is_admin: false,
+      totp_enabled: false,
+    },
+    refreshUser: mockRefreshUser,
+    changePassword: mockChangePassword,
+  }),
+}));
+
+vi.mock("@/lib/api/profile", () => ({
+  profileApi: { update: mockProfileUpdate },
+}));
+
+vi.mock("@/lib/api/totp", () => ({
+  totpApi: { setup: vi.fn(), enable: vi.fn(), disable: vi.fn() },
+}));
+
+vi.mock("react-qr-code", () => ({
+  default: () => <div data-testid="qr-code" />,
+}));
+
+vi.mock("lucide-react", () => {
+  const stub = (name: string) => {
+    const Icon = (props: any) => <span data-testid={`icon-${name}`} {...props} />;
+    Icon.displayName = name;
+    return Icon;
+  };
+  return {
+    User: stub("User"),
+    Key: stub("Key"),
+    Shield: stub("Shield"),
+    Lock: stub("Lock"),
+    AlertTriangle: stub("AlertTriangle"),
+    Info: stub("Info"),
+    ExternalLink: stub("ExternalLink"),
+  };
+});
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, asChild: _asChild, ...props }: any) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("@/components/ui/input", () => ({
+  Input: (props: any) => <input {...props} />,
+}));
+
+vi.mock("@/components/ui/label", () => ({
+  Label: ({ children, ...props }: any) => <label {...props}>{children}</label>,
+}));
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: any) => <span>{children}</span>,
+}));
+
+vi.mock("@/components/ui/card", () => ({
+  Card: ({ children }: any) => <div>{children}</div>,
+  CardContent: ({ children }: any) => <div>{children}</div>,
+  CardHeader: ({ children }: any) => <div>{children}</div>,
+  CardTitle: ({ children }: any) => <h3>{children}</h3>,
+  CardDescription: ({ children }: any) => <p>{children}</p>,
+}));
+
+vi.mock("@/components/ui/tabs", () => ({
+  Tabs: ({ children }: any) => <div>{children}</div>,
+  TabsList: ({ children }: any) => <div>{children}</div>,
+  TabsTrigger: ({ children }: any) => <button>{children}</button>,
+  TabsContent: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/alert", () => ({
+  Alert: ({ children }: any) => <div>{children}</div>,
+  AlertTitle: ({ children }: any) => <div>{children}</div>,
+  AlertDescription: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/common/page-header", () => ({
+  PageHeader: ({ title }: any) => <h1>{title}</h1>,
+}));
+
+vi.mock("@/components/common/copy-button", () => ({
+  CopyButton: () => <button>Copy</button>,
+}));
+
+vi.mock("@/components/common/password-policy-hint", () => ({
+  PasswordPolicyHint: () => <div data-testid="password-policy-hint" />,
+}));
+
+mockUseMutation.mockImplementation((opts: any) => {
+  const mutate = vi.fn(async (...args: any[]) => {
+    try {
+      await opts.mutationFn(...args);
+      opts.onSuccess?.();
+    } catch (err: unknown) {
+      opts.onError?.(err);
+    }
+  });
+  const result = { mutate, isPending: false };
+  return result;
+});
+
+vi.mock("@tanstack/react-query", () => ({
+  useMutation: (opts: any) => mockUseMutation(opts),
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test
+// ---------------------------------------------------------------------------
+
+import ProfilePage from "../page";
+import { PASSWORD_REUSE_MESSAGE } from "@/lib/error-utils";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ProfilePage", () => {
+  beforeEach(() => {
+    mockToastSuccess.mockReset();
+    mockToastError.mockReset();
+    mockChangePassword.mockReset();
+    mockRefreshUser.mockReset();
+    mockProfileUpdate.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders the profile page with tabs", () => {
+    render(<ProfilePage />);
+    expect(screen.getByText("My Profile")).toBeInTheDocument();
+    // "Change Password" appears as both a heading and a submit button
+    const changePwElements = screen.getAllByText("Change Password");
+    expect(changePwElements.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows generic error toast for non-reuse password errors", async () => {
+    mockChangePassword.mockRejectedValue(new Error("Invalid current password"));
+
+    render(<ProfilePage />);
+
+    // Fill in password fields
+    const currentPwInput = screen.getByPlaceholderText("Enter current password");
+    const newPwInput = screen.getByPlaceholderText("Enter new password");
+    const confirmPwInput = screen.getByPlaceholderText("Confirm new password");
+
+    fireEvent.change(currentPwInput, { target: { value: "oldpass123" } });
+    fireEvent.change(newPwInput, { target: { value: "newpass123" } });
+    fireEvent.change(confirmPwInput, { target: { value: "newpass123" } });
+
+    // Submit password change form
+    const submitBtns = screen.getAllByText("Change Password");
+    // The second one is the submit button (first is the card title)
+    const submitBtn = submitBtns.find(
+      (el) => el.tagName === "BUTTON" && el.getAttribute("type") === "submit"
+    );
+    expect(submitBtn).toBeDefined();
+    fireEvent.click(submitBtn!);
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Invalid current password");
+    });
+  });
+
+  it("shows password reuse message for password history errors", async () => {
+    mockChangePassword.mockRejectedValue({
+      error: "Password matches password history",
+    });
+
+    render(<ProfilePage />);
+
+    const currentPwInput = screen.getByPlaceholderText("Enter current password");
+    const newPwInput = screen.getByPlaceholderText("Enter new password");
+    const confirmPwInput = screen.getByPlaceholderText("Confirm new password");
+
+    fireEvent.change(currentPwInput, { target: { value: "oldpass123" } });
+    fireEvent.change(newPwInput, { target: { value: "newpass123" } });
+    fireEvent.change(confirmPwInput, { target: { value: "newpass123" } });
+
+    const submitBtns = screen.getAllByText("Change Password");
+    const submitBtn = submitBtns.find(
+      (el) => el.tagName === "BUTTON" && el.getAttribute("type") === "submit"
+    );
+    fireEvent.click(submitBtn!);
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(PASSWORD_REUSE_MESSAGE);
+    });
+
+    // The inline error should also be visible
+    await waitFor(() => {
+      const errorEl = screen.getByRole("alert");
+      expect(errorEl).toHaveTextContent(PASSWORD_REUSE_MESSAGE);
+    });
+  });
+
+  it("shows inline error that clears when user edits new password", async () => {
+    mockChangePassword.mockRejectedValue({
+      error: "Password matches password history",
+    });
+
+    render(<ProfilePage />);
+
+    const currentPwInput = screen.getByPlaceholderText("Enter current password");
+    const newPwInput = screen.getByPlaceholderText("Enter new password");
+    const confirmPwInput = screen.getByPlaceholderText("Confirm new password");
+
+    fireEvent.change(currentPwInput, { target: { value: "oldpass123" } });
+    fireEvent.change(newPwInput, { target: { value: "newpass123" } });
+    fireEvent.change(confirmPwInput, { target: { value: "newpass123" } });
+
+    const submitBtns = screen.getAllByText("Change Password");
+    const submitBtn = submitBtns.find(
+      (el) => el.tagName === "BUTTON" && el.getAttribute("type") === "submit"
+    );
+    fireEvent.click(submitBtn!);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    // Editing the new password field should clear the inline error
+    fireEvent.change(newPwInput, { target: { value: "different456" } });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+  });
+
+  it("clears fields and shows success toast on successful password change", async () => {
+    mockChangePassword.mockResolvedValue(undefined);
+
+    render(<ProfilePage />);
+
+    const currentPwInput = screen.getByPlaceholderText("Enter current password");
+    const newPwInput = screen.getByPlaceholderText("Enter new password");
+    const confirmPwInput = screen.getByPlaceholderText("Confirm new password");
+
+    fireEvent.change(currentPwInput, { target: { value: "oldpass123" } });
+    fireEvent.change(newPwInput, { target: { value: "newpass123" } });
+    fireEvent.change(confirmPwInput, { target: { value: "newpass123" } });
+
+    const submitBtns = screen.getAllByText("Change Password");
+    const submitBtn = submitBtns.find(
+      (el) => el.tagName === "BUTTON" && el.getAttribute("type") === "submit"
+    );
+    fireEvent.click(submitBtn!);
+
+    await waitFor(() => {
+      expect(mockToastSuccess).toHaveBeenCalledWith(
+        "Password changed successfully"
+      );
+    });
+  });
+
+  it("shows mismatch toast when passwords do not match", () => {
+    render(<ProfilePage />);
+
+    const currentPwInput = screen.getByPlaceholderText("Enter current password");
+    const newPwInput = screen.getByPlaceholderText("Enter new password");
+    const confirmPwInput = screen.getByPlaceholderText("Confirm new password");
+
+    fireEvent.change(currentPwInput, { target: { value: "oldpass123" } });
+    fireEvent.change(newPwInput, { target: { value: "newpass123" } });
+    fireEvent.change(confirmPwInput, { target: { value: "different" } });
+
+    const submitBtns = screen.getAllByText("Change Password");
+    const submitBtn = submitBtns.find(
+      (el) => el.tagName === "BUTTON" && el.getAttribute("type") === "submit"
+    );
+    fireEvent.click(submitBtn!);
+
+    expect(mockToastError).toHaveBeenCalledWith("Passwords do not match");
+    expect(mockChangePassword).not.toHaveBeenCalled();
+  });
+
+  it("shows length toast when password is too short", () => {
+    render(<ProfilePage />);
+
+    const currentPwInput = screen.getByPlaceholderText("Enter current password");
+    const newPwInput = screen.getByPlaceholderText("Enter new password");
+    const confirmPwInput = screen.getByPlaceholderText("Confirm new password");
+
+    fireEvent.change(currentPwInput, { target: { value: "oldpass123" } });
+    fireEvent.change(newPwInput, { target: { value: "short" } });
+    fireEvent.change(confirmPwInput, { target: { value: "short" } });
+
+    const submitBtns = screen.getAllByText("Change Password");
+    const submitBtn = submitBtns.find(
+      (el) => el.tagName === "BUTTON" && el.getAttribute("type") === "submit"
+    );
+    fireEvent.click(submitBtn!);
+
+    expect(mockToastError).toHaveBeenCalledWith(
+      "Password must be at least 8 characters"
+    );
+    expect(mockChangePassword).not.toHaveBeenCalled();
+  });
+
+  it("shows password reuse message for body.message error shape", async () => {
+    mockChangePassword.mockRejectedValue({
+      body: { message: "Password was previously used" },
+    });
+
+    render(<ProfilePage />);
+
+    const currentPwInput = screen.getByPlaceholderText("Enter current password");
+    const newPwInput = screen.getByPlaceholderText("Enter new password");
+    const confirmPwInput = screen.getByPlaceholderText("Confirm new password");
+
+    fireEvent.change(currentPwInput, { target: { value: "oldpass123" } });
+    fireEvent.change(newPwInput, { target: { value: "newpass123" } });
+    fireEvent.change(confirmPwInput, { target: { value: "newpass123" } });
+
+    const submitBtns = screen.getAllByText("Change Password");
+    const submitBtn = submitBtns.find(
+      (el) => el.tagName === "BUTTON" && el.getAttribute("type") === "submit"
+    );
+    fireEvent.click(submitBtn!);
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(PASSWORD_REUSE_MESSAGE);
+    });
+  });
+});

--- a/src/app/(app)/(protected)/profile/page.tsx
+++ b/src/app/(app)/(protected)/profile/page.tsx
@@ -19,7 +19,11 @@ import { profileApi } from "@/lib/api/profile";
 import { totpApi } from "@/lib/api/totp";
 import type { TotpSetupResponse } from "@/lib/api/totp";
 import { useAuth } from "@/providers/auth-provider";
-import { toUserMessage } from "@/lib/error-utils";
+import {
+  toUserMessage,
+  isPasswordReuseError,
+  PASSWORD_REUSE_MESSAGE,
+} from "@/lib/error-utils";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -84,16 +88,27 @@ export default function ProfilePage() {
     onError: () => toast.error("Failed to update profile"),
   });
 
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+
   const passwordMutation = useMutation({
     mutationFn: () => changePassword(currentPassword, newPassword),
     onSuccess: () => {
       setCurrentPassword("");
       setNewPassword("");
       setConfirmPassword("");
+      setPasswordError(null);
       toast.success("Password changed successfully");
     },
-    onError: () =>
-      toast.error("Failed to change password. Check your current password."),
+    onError: (err: unknown) => {
+      if (isPasswordReuseError(err)) {
+        setPasswordError(PASSWORD_REUSE_MESSAGE);
+        toast.error(PASSWORD_REUSE_MESSAGE);
+      } else {
+        const msg = toUserMessage(err, "Failed to change password. Check your current password.");
+        setPasswordError(null);
+        toast.error(msg);
+      }
+    },
   });
 
   return (
@@ -270,12 +285,22 @@ export default function ProfilePage() {
                     id="new-password"
                     type="password"
                     value={newPassword}
-                    onChange={(e) => setNewPassword(e.target.value)}
+                    onChange={(e) => {
+                      setNewPassword(e.target.value);
+                      setPasswordError(null);
+                    }}
                     placeholder="Enter new password"
                     required
                     minLength={8}
+                    aria-invalid={!!passwordError}
+                    aria-describedby={passwordError ? "new-password-error" : undefined}
                   />
                   <PasswordPolicyHint password={newPassword} />
+                  {passwordError && (
+                    <p id="new-password-error" className="text-sm text-destructive" role="alert">
+                      {passwordError}
+                    </p>
+                  )}
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="confirm-password">Confirm New Password</Label>

--- a/src/app/(auth)/change-password/__tests__/page.test.tsx
+++ b/src/app/(auth)/change-password/__tests__/page.test.tsx
@@ -1,0 +1,244 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+
+// ---------------------------------------------------------------------------
+// Mocks (must be before component import)
+// ---------------------------------------------------------------------------
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const mockChangePassword = vi.fn();
+const mockLogout = vi.fn();
+vi.mock("@/providers/auth-provider", () => ({
+  useAuth: () => ({
+    changePassword: mockChangePassword,
+    logout: mockLogout,
+    setupRequired: false,
+  }),
+}));
+
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: any[]) => mockToastSuccess(...args),
+    error: (...args: any[]) => mockToastError(...args),
+  },
+}));
+
+vi.mock("@hookform/resolvers/zod", () => ({
+  zodResolver: () => async (values: any) => ({ values, errors: {} }),
+}));
+
+vi.mock("lucide-react", () => {
+  const stub = (name: string) => {
+    const Icon = (props: any) => <span data-testid={`icon-${name}`} {...props} />;
+    Icon.displayName = name;
+    return Icon;
+  };
+  return {
+    Lock: stub("Lock"),
+    Shield: stub("Shield"),
+    Loader2: stub("Loader2"),
+    Info: stub("Info"),
+  };
+});
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: any) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("@/components/ui/input", () => ({
+  Input: (props: any) => <input {...props} />,
+}));
+
+vi.mock("@/components/ui/card", () => ({
+  Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  CardContent: ({ children }: any) => <div>{children}</div>,
+  CardHeader: ({ children }: any) => <div>{children}</div>,
+  CardTitle: ({ children }: any) => <h3>{children}</h3>,
+  CardDescription: ({ children }: any) => <p>{children}</p>,
+}));
+
+// The shadcn Form component is a FormProvider wrapper.
+// The real <form> element with onSubmit is a direct child in the component.
+// We just render children so the nested <form> works normally.
+vi.mock("@/components/ui/form", () => ({
+  Form: ({ children }: any) => <div data-testid="form-provider">{children}</div>,
+  FormControl: ({ children }: any) => <div>{children}</div>,
+  FormField: ({ render, name }: any) => {
+    const field = {
+      value: "",
+      onChange: vi.fn(),
+      onBlur: vi.fn(),
+      name,
+      ref: vi.fn(),
+    };
+    return <div data-testid={`form-field-${name}`}>{render({ field })}</div>;
+  },
+  FormItem: ({ children }: any) => <div>{children}</div>,
+  FormLabel: ({ children }: any) => <label>{children}</label>,
+  FormMessage: () => <span data-testid="form-message" />,
+}));
+
+vi.mock("@/components/common/password-policy-hint", () => ({
+  PasswordPolicyHint: () => <div data-testid="password-policy-hint" />,
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test
+// ---------------------------------------------------------------------------
+
+import ChangePasswordPage from "../page";
+import { PASSWORD_REUSE_MESSAGE } from "@/lib/error-utils";
+
+// ---------------------------------------------------------------------------
+// Helper: find and submit the form
+// ---------------------------------------------------------------------------
+
+function submitForm() {
+  const form = document.querySelector("form");
+  expect(form).not.toBeNull();
+  fireEvent.submit(form!);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ChangePasswordPage", () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+    mockChangePassword.mockReset();
+    mockLogout.mockReset();
+    mockToastSuccess.mockReset();
+    mockToastError.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders the heading and form fields", () => {
+    render(<ChangePasswordPage />);
+    const headings = screen.getAllByText("Change Password");
+    expect(headings.length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Current Password")).toBeInTheDocument();
+    expect(screen.getByText("New Password")).toBeInTheDocument();
+    expect(screen.getByText("Confirm New Password")).toBeInTheDocument();
+  });
+
+  it("renders the password policy hint", () => {
+    render(<ChangePasswordPage />);
+    expect(screen.getByTestId("password-policy-hint")).toBeInTheDocument();
+  });
+
+  it("shows success toast and redirects on successful password change", async () => {
+    mockChangePassword.mockResolvedValue(undefined);
+    render(<ChangePasswordPage />);
+
+    submitForm();
+
+    await waitFor(() => {
+      expect(mockToastSuccess).toHaveBeenCalledWith(
+        "Password changed successfully!"
+      );
+    });
+    expect(mockPush).toHaveBeenCalledWith("/");
+  });
+
+  it("shows password reuse toast on password history error", async () => {
+    mockChangePassword.mockRejectedValue({
+      error: "Password matches password history",
+    });
+
+    render(<ChangePasswordPage />);
+    submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(PASSWORD_REUSE_MESSAGE);
+    });
+
+    // Should not redirect
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("shows password reuse toast for body.message error shape", async () => {
+    mockChangePassword.mockRejectedValue({
+      body: { message: "Password was previously used" },
+    });
+
+    render(<ChangePasswordPage />);
+    submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(PASSWORD_REUSE_MESSAGE);
+    });
+  });
+
+  it("shows generic error toast for non-reuse errors", async () => {
+    mockChangePassword.mockRejectedValue(
+      new Error("Invalid current password")
+    );
+
+    render(<ChangePasswordPage />);
+    submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Invalid current password");
+    });
+  });
+
+  it("does not show reuse message for unrelated errors", async () => {
+    mockChangePassword.mockRejectedValue(
+      new Error("Network error")
+    );
+
+    render(<ChangePasswordPage />);
+    submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Network error");
+    });
+    expect(mockToastError).not.toHaveBeenCalledWith(PASSWORD_REUSE_MESSAGE);
+  });
+
+  it("falls back to default message for unknown error shapes", async () => {
+    mockChangePassword.mockRejectedValue(42);
+
+    render(<ChangePasswordPage />);
+    submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Failed to change password.");
+    });
+  });
+
+  it("calls logout and redirects when logout button is clicked", async () => {
+    mockLogout.mockResolvedValue(undefined);
+    render(<ChangePasswordPage />);
+
+    const logoutBtn = screen.getByText("Logout instead");
+    fireEvent.click(logoutBtn);
+
+    await waitFor(() => {
+      expect(mockLogout).toHaveBeenCalled();
+    });
+    expect(mockPush).toHaveBeenCalledWith("/");
+  });
+});

--- a/src/app/(auth)/change-password/page.tsx
+++ b/src/app/(auth)/change-password/page.tsx
@@ -8,7 +8,11 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { Lock, Shield, Loader2, Info } from "lucide-react";
 import { toast } from "sonner";
 import { useAuth } from "@/providers/auth-provider";
-import { toUserMessage } from "@/lib/error-utils";
+import {
+  toUserMessage,
+  isPasswordReuseError,
+  PASSWORD_REUSE_MESSAGE,
+} from "@/lib/error-utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -62,7 +66,12 @@ export default function ChangePasswordPage() {
       toast.success("Password changed successfully!");
       router.push("/");
     } catch (err) {
-      toast.error(toUserMessage(err, "Failed to change password."));
+      if (isPasswordReuseError(err)) {
+        form.setError("newPassword", { message: PASSWORD_REUSE_MESSAGE });
+        toast.error(PASSWORD_REUSE_MESSAGE);
+      } else {
+        toast.error(toUserMessage(err, "Failed to change password."));
+      }
     } finally {
       setIsLoading(false);
     }

--- a/src/lib/__tests__/error-utils.test.ts
+++ b/src/lib/__tests__/error-utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { toUserMessage, isAccountLocked } from "../error-utils";
+import {
+  toUserMessage,
+  isAccountLocked,
+  isPasswordReuseError,
+  PASSWORD_REUSE_MESSAGE,
+} from "../error-utils";
 
 describe("toUserMessage", () => {
   const FALLBACK = "Something went wrong";
@@ -235,5 +240,76 @@ describe("isAccountLocked", () => {
     expect(
       isAccountLocked({ body: { error: "File is locked" } })
     ).toBe(false);
+  });
+});
+
+describe("isPasswordReuseError", () => {
+  it("detects 'password history' in an Error message", () => {
+    expect(
+      isPasswordReuseError(new Error("Password matches password history"))
+    ).toBe(true);
+  });
+
+  it("detects 'previously used' in an SDK error object", () => {
+    expect(
+      isPasswordReuseError({ error: "This password was previously used" })
+    ).toBe(true);
+  });
+
+  it("detects 'recently used' in a plain string", () => {
+    expect(isPasswordReuseError("Password was recently used")).toBe(true);
+  });
+
+  it("detects 'password reuse' in a body.message", () => {
+    expect(
+      isPasswordReuseError({
+        body: { message: "password reuse is not allowed" },
+      })
+    ).toBe(true);
+  });
+
+  it("detects 'password was used' in a message field", () => {
+    expect(
+      isPasswordReuseError({ message: "This password was used before" })
+    ).toBe(true);
+  });
+
+  it("detects 'already been used' in an error field", () => {
+    expect(
+      isPasswordReuseError({ error: "Password has already been used" })
+    ).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(
+      isPasswordReuseError(new Error("PASSWORD HISTORY violation"))
+    ).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isPasswordReuseError(new Error("Invalid credentials"))).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isPasswordReuseError(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isPasswordReuseError(undefined)).toBe(false);
+  });
+
+  it("returns false for an empty object", () => {
+    expect(isPasswordReuseError({})).toBe(false);
+  });
+
+  it("returns false for an empty string", () => {
+    expect(isPasswordReuseError("")).toBe(false);
+  });
+});
+
+describe("PASSWORD_REUSE_MESSAGE", () => {
+  it("is a non-empty string", () => {
+    expect(typeof PASSWORD_REUSE_MESSAGE).toBe("string");
+    expect(PASSWORD_REUSE_MESSAGE.length).toBeGreaterThan(0);
   });
 });

--- a/src/lib/error-utils.ts
+++ b/src/lib/error-utils.ts
@@ -102,3 +102,36 @@ export function toUserMessage(error: unknown, fallback: string): string {
 
   return fallback;
 }
+
+/**
+ * Patterns the backend uses when rejecting a password that was recently used.
+ * Kept as a single source of truth so both the change-password page and
+ * the profile security tab can detect this specific error.
+ */
+const PASSWORD_REUSE_PATTERNS = [
+  'password history',
+  'previously used',
+  'recently used',
+  'password reuse',
+  'password was used',
+  'already been used',
+];
+
+/**
+ * User-facing message shown when the backend rejects a password due to
+ * password history rules.
+ */
+export const PASSWORD_REUSE_MESSAGE =
+  'This password was used recently. Please choose a different password.';
+
+/**
+ * Check whether an error from the backend indicates the submitted password
+ * was rejected because it matches a recently used password.
+ *
+ * Works with any error shape accepted by `toUserMessage`: Error instances,
+ * SDK error objects, wrapped HTTP errors, and plain strings.
+ */
+export function isPasswordReuseError(error: unknown): boolean {
+  const msg = toUserMessage(error, '').toLowerCase();
+  return PASSWORD_REUSE_PATTERNS.some((pattern) => msg.includes(pattern));
+}


### PR DESCRIPTION
## Summary

- Add `isPasswordReuseError` helper and `PASSWORD_REUSE_MESSAGE` constant to `error-utils.ts` so password history rejections from the backend are detected across all SDK error shapes (Error instances, `{ error }`, `{ message }`, `{ body: { message } }`)
- Fix the profile page (`/profile` Security tab) where `passwordMutation.onError` discarded the actual error and showed a hardcoded generic message; it now extracts the real message and shows a clear inline error with `role="alert"` and `aria-invalid` when the password was recently used
- Fix the change-password page (`/change-password`) to set a form-level error on the `newPassword` field via `react-hook-form` `setError`, so the `FormMessage` renders the reuse message directly below the input

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [ ] Playwright E2E spec covers the change
- [x] Responsive layout verified (mobile + desktop)
- [x] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes

Closes #264