### PR TITLE
Add SMTP configuration to admin settings

### DIFF
--- a/src/app/(app)/(admin)/settings/__tests__/page.test.tsx
+++ b/src/app/(app)/(admin)/settings/__tests__/page.test.tsx
@@ -335,6 +335,10 @@ describe("SettingsPage", () => {
 
     const fromInput = screen.getByTestId("smtp-from") as HTMLInputElement;
     expect(fromInput.value).toBe("no-reply@example.com");
+
+    // Password should not be populated from server response
+    const passwordInput = screen.getByTestId("smtp-password") as HTMLInputElement;
+    expect(passwordInput.value).toBe("");
   });
 
   it("disables Save button when form is not dirty", () => {
@@ -382,10 +386,39 @@ describe("SettingsPage", () => {
       host: "smtp.test.com",
       port: 587,
       username: "",
-      password: "",
       from_address: "test@test.com",
       tls_mode: "starttls",
     });
+  });
+
+  it("includes password in save payload only when modified", () => {
+    const mutateFn = vi.fn();
+    mockUseMutation.mockReturnValue(createMutationMock({ mutate: mutateFn }));
+    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<SettingsPage />);
+
+    // Fill required fields
+    fireEvent.change(screen.getByTestId("smtp-host"), {
+      target: { value: "smtp.test.com" },
+    });
+    fireEvent.change(screen.getByTestId("smtp-from"), {
+      target: { value: "test@test.com" },
+    });
+    // Modify the password field
+    fireEvent.change(screen.getByTestId("smtp-password"), {
+      target: { value: "new-secret" },
+    });
+
+    fireEvent.click(screen.getByText("Save SMTP Settings"));
+
+    expect(mutateFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        host: "smtp.test.com",
+        password: "new-secret",
+      })
+    );
   });
 
   it("shows validation error for empty host on save", () => {

--- a/src/app/(app)/(admin)/settings/__tests__/page.test.tsx
+++ b/src/app/(app)/(admin)/settings/__tests__/page.test.tsx
@@ -1,29 +1,54 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import React from "react";
 
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
 
-const mockUseAuth = vi.fn();
+const mockUseAuth = vi.hoisted(() => vi.fn());
 vi.mock("@/providers/auth-provider", () => ({
   useAuth: () => mockUseAuth(),
 }));
 
-const mockUseQuery = vi.fn();
+const mockUseQuery = vi.hoisted(() => vi.fn());
+const mockUseMutation = vi.hoisted(() => vi.fn());
+const mockUseQueryClient = vi.hoisted(() => vi.fn());
 vi.mock("@tanstack/react-query", () => ({
   useQuery: (opts: any) => mockUseQuery(opts),
+  useMutation: (opts: any) => mockUseMutation(opts),
+  useQueryClient: () => mockUseQueryClient(),
+}));
+
+const mockToast = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
+vi.mock("sonner", () => ({
+  toast: mockToast,
 }));
 
 vi.mock("@/lib/api/admin", () => ({
   adminApi: { getHealth: vi.fn() },
 }));
 
+vi.mock("@/lib/api/settings", () => ({
+  settingsApi: {
+    getPasswordPolicy: vi.fn(),
+    getSmtpConfig: vi.fn(),
+    updateSmtpConfig: vi.fn(),
+    sendTestEmail: vi.fn(),
+  },
+}));
+
 vi.mock("lucide-react", () => {
   const icon = () => null;
-  return { Server: icon, HardDrive: icon, Lock: icon, Info: icon };
+  return {
+    Server: icon,
+    HardDrive: icon,
+    Lock: icon,
+    Info: icon,
+    Mail: icon,
+    Loader2: icon,
+  };
 });
 
 vi.mock("@/components/ui/card", () => ({
@@ -35,15 +60,34 @@ vi.mock("@/components/ui/card", () => ({
 }));
 
 vi.mock("@/components/ui/input", () => ({
-  Input: ({ value, ...props }: any) => <input value={value} readOnly {...props} />,
+  Input: ({ value, onChange, id, type, placeholder, ...props }: any) => (
+    <input
+      value={value}
+      onChange={onChange}
+      id={id}
+      type={type}
+      placeholder={placeholder}
+      data-testid={id}
+      readOnly={!onChange}
+      {...props}
+    />
+  ),
 }));
 
 vi.mock("@/components/ui/label", () => ({
-  Label: ({ children }: any) => <label>{children}</label>,
+  Label: ({ children, htmlFor }: any) => <label htmlFor={htmlFor}>{children}</label>,
 }));
 
 vi.mock("@/components/ui/badge", () => ({
   Badge: ({ children }: any) => <span>{children}</span>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, onClick, disabled, ...props }: any) => (
+    <button onClick={onClick} disabled={disabled} {...props}>
+      {children}
+    </button>
+  ),
 }));
 
 vi.mock("@/components/ui/alert", () => ({
@@ -63,6 +107,24 @@ vi.mock("@/components/ui/separator", () => ({
   Separator: () => <hr />,
 }));
 
+vi.mock("@/components/ui/select", () => ({
+  Select: ({ children, value, onValueChange }: any) => (
+    <div data-testid="select-wrapper" data-value={value}>
+      {typeof children === "function"
+        ? children({ value, onValueChange })
+        : children}
+    </div>
+  ),
+  SelectTrigger: ({ children, id }: any) => (
+    <button data-testid={id}>{children}</button>
+  ),
+  SelectValue: ({ placeholder }: any) => <span>{placeholder}</span>,
+  SelectContent: ({ children }: any) => <div>{children}</div>,
+  SelectItem: ({ children, value }: any) => (
+    <option value={value}>{children}</option>
+  ),
+}));
+
 vi.mock("@/components/common/page-header", () => ({
   PageHeader: ({ title }: any) => <h1>{title}</h1>,
 }));
@@ -72,6 +134,22 @@ vi.mock("@/components/common/page-header", () => ({
 // ---------------------------------------------------------------------------
 
 import SettingsPage from "../page";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Creates a mutation mock that captures mutationFn and callbacks */
+function createMutationMock(overrides?: Partial<ReturnType<typeof mockUseMutation>>) {
+  return {
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    isPending: false,
+    isError: false,
+    isSuccess: false,
+    ...overrides,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -87,6 +165,10 @@ describe("SettingsPage", () => {
     vi.clearAllMocks();
     process.env.NEXT_PUBLIC_APP_VERSION = "1.1.0";
     mockUseQuery.mockReturnValue({ data: undefined });
+    mockUseMutation.mockReturnValue(createMutationMock());
+    mockUseQueryClient.mockReturnValue({
+      invalidateQueries: vi.fn(),
+    });
   });
 
   it("shows access denied for non-admin users", () => {
@@ -173,5 +255,346 @@ describe("SettingsPage", () => {
     const inputs = screen.getAllByRole("textbox") as HTMLInputElement[];
     const webInput = inputs.find((i) => i.value === "1.1.0-rc.8");
     expect(webInput).toBeDefined();
+  });
+
+  it("renders the Email tab trigger", () => {
+    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
+
+    render(<SettingsPage />);
+
+    expect(screen.getByText("Email")).toBeDefined();
+  });
+
+  it("renders SMTP Configuration heading", () => {
+    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<SettingsPage />);
+
+    expect(screen.getByText("SMTP Configuration")).toBeDefined();
+  });
+
+  it("renders Send Test Email heading", () => {
+    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<SettingsPage />);
+
+    const elements = screen.getAllByText("Send Test Email");
+    // One heading, one button
+    expect(elements.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders SMTP form fields with placeholders", () => {
+    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<SettingsPage />);
+
+    expect(screen.getByTestId("smtp-host")).toBeDefined();
+    expect(screen.getByTestId("smtp-port")).toBeDefined();
+    expect(screen.getByTestId("smtp-username")).toBeDefined();
+    expect(screen.getByTestId("smtp-password")).toBeDefined();
+    expect(screen.getByTestId("smtp-from")).toBeDefined();
+    expect(screen.getByTestId("smtp-tls")).toBeDefined();
+  });
+
+  it("populates SMTP fields from loaded config", () => {
+    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
+
+    let queryCallIndex = 0;
+    mockUseQuery.mockImplementation(() => {
+      queryCallIndex++;
+      // Third useQuery call is for smtp-config
+      if (queryCallIndex === 3) {
+        return {
+          data: {
+            host: "mail.example.com",
+            port: 465,
+            username: "sender",
+            password: "secret",
+            from_address: "no-reply@example.com",
+            tls_mode: "tls" as const,
+          },
+          isLoading: false,
+        };
+      }
+      return { data: undefined, isLoading: false };
+    });
+
+    render(<SettingsPage />);
+
+    const hostInput = screen.getByTestId("smtp-host") as HTMLInputElement;
+    expect(hostInput.value).toBe("mail.example.com");
+
+    const portInput = screen.getByTestId("smtp-port") as HTMLInputElement;
+    expect(portInput.value).toBe("465");
+
+    const usernameInput = screen.getByTestId("smtp-username") as HTMLInputElement;
+    expect(usernameInput.value).toBe("sender");
+
+    const fromInput = screen.getByTestId("smtp-from") as HTMLInputElement;
+    expect(fromInput.value).toBe("no-reply@example.com");
+  });
+
+  it("disables Save button when form is not dirty", () => {
+    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<SettingsPage />);
+
+    const saveButton = screen.getByText("Save SMTP Settings");
+    expect(saveButton.closest("button")?.disabled).toBe(true);
+  });
+
+  it("enables Save button after editing a field", () => {
+    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<SettingsPage />);
+
+    const hostInput = screen.getByTestId("smtp-host");
+    fireEvent.change(hostInput, { target: { value: "smtp.test.com" } });
+
+    const saveButton = screen.getByText("Save SMTP Settings");
+    expect(saveButton.closest("button")?.disabled).toBe(false);
+  });
+
+  it("calls save mutation with form values on Save click", () => {
+    const mutateFn = vi.fn();
+    mockUseMutation.mockReturnValue(createMutationMock({ mutate: mutateFn }));
+    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<SettingsPage />);
+
+    // Fill required fields
+    fireEvent.change(screen.getByTestId("smtp-host"), {
+      target: { value: "smtp.test.com" },
+    });
+    fireEvent.change(screen.getByTestId("smtp-from"), {
+      target: { value: "test@test.com" },
+    });
+
+    fireEvent.click(screen.getByText("Save SMTP Settings"));
+
+    expect(mutateFn).toHaveBeenCalledWith({
+      host: "smtp.test.com",
+      port: 587,
+      username: "",
+      password: "",
+      from_address: "test@test.com",
+      tls_mode: "starttls",
+    });
+  });
+
+  it("shows validation error for empty host on save", () => {
+    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<SettingsPage />);
+
+    // Make form dirty by setting from address, but leave host blank
+    fireEvent.change(screen.getByTestId("smtp-from"), {
+      target: { value: "test@test.com" },
+    });
+    fireEvent.click(screen.getByText("Save SMTP Settings"));
+
+    expect(mockToast.error).toHaveBeenCalledWith("SMTP host is required");
+  });
+
+  it("shows validation error for empty from address on save", () => {
+    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<SettingsPage />);
+
+    // Make form dirty with a host but no from address
+    fireEvent.change(screen.getByTestId("smtp-host"), {
+      target: { value: "smtp.test.com" },
+    });
+    fireEvent.click(screen.getByText("Save SMTP Settings"));
+
+    expect(mockToast.error).toHaveBeenCalledWith("From address is required");
+  });
+
+  it("shows validation error for invalid port on save", () => {
+    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<SettingsPage />);
+
+    fireEvent.change(screen.getByTestId("smtp-host"), {
+      target: { value: "smtp.test.com" },
+    });
+    fireEvent.change(screen.getByTestId("smtp-port"), {
+      target: { value: "99999" },
+    });
+    fireEvent.click(screen.getByText("Save SMTP Settings"));
+
+    expect(mockToast.error).toHaveBeenCalledWith(
+      "Port must be a number between 1 and 65535"
+    );
+  });
+
+  it("shows validation error for non-numeric port on save", () => {
+    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<SettingsPage />);
+
+    fireEvent.change(screen.getByTestId("smtp-host"), {
+      target: { value: "smtp.test.com" },
+    });
+    fireEvent.change(screen.getByTestId("smtp-port"), {
+      target: { value: "abc" },
+    });
+    fireEvent.click(screen.getByText("Save SMTP Settings"));
+
+    expect(mockToast.error).toHaveBeenCalledWith(
+      "Port must be a number between 1 and 65535"
+    );
+  });
+
+  it("calls test email mutation with recipient", () => {
+    const mutateFn = vi.fn();
+    // Both mutations use the same mutate so we can verify calls regardless of order
+    mockUseMutation.mockReturnValue(createMutationMock({ mutate: mutateFn }));
+    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<SettingsPage />);
+
+    fireEvent.change(screen.getByTestId("test-recipient"), {
+      target: { value: "admin@test.com" },
+    });
+    // Find the Send Test Email button (the one that is a direct <button>, not a heading)
+    const sendButtons = screen.getAllByText("Send Test Email");
+    const sendButton = sendButtons.find(
+      (el) => el.tagName === "BUTTON"
+    );
+    fireEvent.click(sendButton!);
+
+    expect(mutateFn).toHaveBeenCalledWith("admin@test.com");
+  });
+
+  it("shows validation error when sending test email without recipient", () => {
+    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<SettingsPage />);
+
+    const sendButtons = screen.getAllByText("Send Test Email");
+    const sendButton = sendButtons.find((el) => el.closest("button"));
+    fireEvent.click(sendButton!);
+
+    expect(mockToast.error).toHaveBeenCalledWith(
+      "Please enter a recipient email address"
+    );
+  });
+
+  it("renders SMTP field labels", () => {
+    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<SettingsPage />);
+
+    expect(screen.getByText("Host")).toBeDefined();
+    expect(screen.getByText("Port")).toBeDefined();
+    expect(screen.getByText("Username")).toBeDefined();
+    expect(screen.getByText("Password")).toBeDefined();
+    expect(screen.getByText("From Address")).toBeDefined();
+    expect(screen.getByText("TLS Mode")).toBeDefined();
+  });
+
+  it("renders the test recipient input", () => {
+    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<SettingsPage />);
+
+    const recipientInput = screen.getByTestId("test-recipient") as HTMLInputElement;
+    expect(recipientInput).toBeDefined();
+    expect(recipientInput.type).toBe("email");
+  });
+
+  it("trims whitespace from fields before saving", () => {
+    const mutateFn = vi.fn();
+    mockUseMutation.mockReturnValue(createMutationMock({ mutate: mutateFn }));
+    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<SettingsPage />);
+
+    fireEvent.change(screen.getByTestId("smtp-host"), {
+      target: { value: "  smtp.test.com  " },
+    });
+    fireEvent.change(screen.getByTestId("smtp-from"), {
+      target: { value: "  test@test.com  " },
+    });
+    fireEvent.change(screen.getByTestId("smtp-username"), {
+      target: { value: "  user  " },
+    });
+
+    fireEvent.click(screen.getByText("Save SMTP Settings"));
+
+    expect(mutateFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        host: "smtp.test.com",
+        from_address: "test@test.com",
+        username: "user",
+      })
+    );
+  });
+
+  it("password field is type=password", () => {
+    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<SettingsPage />);
+
+    const pwInput = screen.getByTestId("smtp-password") as HTMLInputElement;
+    expect(pwInput.type).toBe("password");
+  });
+
+  it("renders TLS mode options", () => {
+    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<SettingsPage />);
+
+    expect(screen.getByText("None")).toBeDefined();
+    expect(screen.getByText("STARTTLS")).toBeDefined();
+    expect(screen.getByText("TLS")).toBeDefined();
+  });
+
+  it("disables Save button when mutation is pending", () => {
+    mockUseMutation.mockReturnValue(createMutationMock({ isPending: true }));
+    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<SettingsPage />);
+
+    const saveButton = screen.getByText("Save SMTP Settings");
+    expect(saveButton.closest("button")?.disabled).toBe(true);
+  });
+
+  it("disables Send Test Email button when test mutation is pending", () => {
+    let mutationCallIndex = 0;
+    mockUseMutation.mockImplementation(() => {
+      mutationCallIndex++;
+      if (mutationCallIndex === 2) {
+        return createMutationMock({ isPending: true });
+      }
+      return createMutationMock();
+    });
+    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<SettingsPage />);
+
+    const sendButtons = screen.getAllByText("Send Test Email");
+    const sendButton = sendButtons.find((el) => el.closest("button"));
+    expect(sendButton?.closest("button")?.disabled).toBe(true);
   });
 });

--- a/src/app/(app)/(admin)/settings/page.tsx
+++ b/src/app/(app)/(admin)/settings/page.tsx
@@ -101,7 +101,8 @@ function SmtpSettingsForm({
   const [host, setHost] = useState(initialConfig?.host ?? "");
   const [port, setPort] = useState(String(initialConfig?.port ?? 587));
   const [username, setUsername] = useState(initialConfig?.username ?? "");
-  const [password, setPassword] = useState(initialConfig?.password ?? "");
+  const [password, setPassword] = useState("");
+  const [passwordDirty, setPasswordDirty] = useState(false);
   const [fromAddress, setFromAddress] = useState(
     initialConfig?.from_address ?? ""
   );
@@ -154,14 +155,17 @@ function SmtpSettingsForm({
       toast.error("From address is required");
       return;
     }
-    saveMutation.mutate({
+    const payload: Record<string, unknown> = {
       host: host.trim(),
       port: portNum,
       username: username.trim(),
-      password,
       from_address: fromAddress.trim(),
       tls_mode: tlsMode,
-    });
+    };
+    if (passwordDirty) {
+      payload.password = password;
+    }
+    saveMutation.mutate(payload as unknown as SmtpConfig);
   }
 
   function handleSendTest() {
@@ -237,7 +241,11 @@ function SmtpSettingsForm({
                 placeholder="********"
                 autoComplete="new-password"
                 value={password}
-                onChange={(e) => handleFieldChange(setPassword)(e.target.value)}
+                onChange={(e) => {
+                  setPassword(e.target.value);
+                  setPasswordDirty(true);
+                  setFormDirty(true);
+                }}
               />
               <p className="text-xs text-muted-foreground">
                 Stored encrypted on the server. Leave blank to keep the existing value.

--- a/src/app/(app)/(admin)/settings/page.tsx
+++ b/src/app/(app)/(admin)/settings/page.tsx
@@ -1,21 +1,31 @@
 "use client";
 
+import { useState } from "react";
 import { useAuth } from "@/providers/auth-provider";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { adminApi } from "@/lib/api/admin";
 import { settingsApi } from "@/lib/api/settings";
-import { Server, HardDrive, Lock, Info } from "lucide-react";
+import { Server, HardDrive, Lock, Info, Mail, Loader2 } from "lucide-react";
 
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Separator } from "@/components/ui/separator";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 import { PageHeader } from "@/components/common/page-header";
-import type { PasswordPolicy } from "@/lib/api/settings";
+import type { PasswordPolicy, SmtpConfig, SmtpTlsMode } from "@/lib/api/settings";
 
 // -- helpers --
 
@@ -54,6 +64,275 @@ function formatPasswordPolicy(policy: PasswordPolicy | undefined): string {
     parts.push(`${policy.history_count} password history`);
   }
   return parts.join("; ");
+}
+
+// -- SMTP settings tab --
+
+function SmtpSettingsTab() {
+  const { data: smtpConfig, isLoading, dataUpdatedAt } = useQuery({
+    queryKey: ["smtp-config"],
+    queryFn: () => settingsApi.getSmtpConfig(),
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="flex items-center justify-center py-12">
+          <Loader2 className="size-6 animate-spin text-muted-foreground" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Remount the form when query data changes so initial state resets
+  // without needing setState inside an effect.
+  return <SmtpSettingsForm key={dataUpdatedAt} initialConfig={smtpConfig} />;
+}
+
+function SmtpSettingsForm({
+  initialConfig,
+}: {
+  initialConfig: SmtpConfig | undefined;
+}) {
+  const queryClient = useQueryClient();
+
+  const [host, setHost] = useState(initialConfig?.host ?? "");
+  const [port, setPort] = useState(String(initialConfig?.port ?? 587));
+  const [username, setUsername] = useState(initialConfig?.username ?? "");
+  const [password, setPassword] = useState(initialConfig?.password ?? "");
+  const [fromAddress, setFromAddress] = useState(
+    initialConfig?.from_address ?? ""
+  );
+  const [tlsMode, setTlsMode] = useState<SmtpTlsMode>(
+    initialConfig?.tls_mode ?? "starttls"
+  );
+  const [testRecipient, setTestRecipient] = useState("");
+  const [formDirty, setFormDirty] = useState(false);
+
+  const saveMutation = useMutation({
+    mutationFn: (config: SmtpConfig) => settingsApi.updateSmtpConfig(config),
+    onSuccess: () => {
+      toast.success("SMTP configuration saved");
+      queryClient.invalidateQueries({ queryKey: ["smtp-config"] });
+      setFormDirty(false);
+    },
+    onError: () => toast.error("Failed to save SMTP configuration"),
+  });
+
+  const testMutation = useMutation({
+    mutationFn: (recipient: string) => settingsApi.sendTestEmail(recipient),
+    onSuccess: (result) => {
+      if (result.success) {
+        toast.success(result.message || "Test email sent successfully");
+      } else {
+        toast.error(result.message || "Test email failed");
+      }
+    },
+    onError: () => toast.error("Failed to send test email"),
+  });
+
+  function handleFieldChange<T>(setter: (v: T) => void) {
+    return (value: T) => {
+      setter(value);
+      setFormDirty(true);
+    };
+  }
+
+  function handleSave() {
+    const portNum = parseInt(port, 10);
+    if (isNaN(portNum) || portNum < 1 || portNum > 65535) {
+      toast.error("Port must be a number between 1 and 65535");
+      return;
+    }
+    if (!host.trim()) {
+      toast.error("SMTP host is required");
+      return;
+    }
+    if (!fromAddress.trim()) {
+      toast.error("From address is required");
+      return;
+    }
+    saveMutation.mutate({
+      host: host.trim(),
+      port: portNum,
+      username: username.trim(),
+      password,
+      from_address: fromAddress.trim(),
+      tls_mode: tlsMode,
+    });
+  }
+
+  function handleSendTest() {
+    if (!testRecipient.trim()) {
+      toast.error("Please enter a recipient email address");
+      return;
+    }
+    testMutation.mutate(testRecipient.trim());
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">SMTP Configuration</CardTitle>
+          <CardDescription>
+            Configure the outbound email server used for notifications, password
+            resets, and other system emails.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="smtp-host">Host</Label>
+              <Input
+                id="smtp-host"
+                placeholder="smtp.example.com"
+                value={host}
+                onChange={(e) => handleFieldChange(setHost)(e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                Hostname or IP address of the SMTP server.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="smtp-port">Port</Label>
+              <Input
+                id="smtp-port"
+                type="number"
+                min={1}
+                max={65535}
+                placeholder="587"
+                value={port}
+                onChange={(e) => handleFieldChange(setPort)(e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                Common ports: 25 (SMTP), 465 (SMTPS), 587 (Submission).
+              </p>
+            </div>
+          </div>
+
+          <Separator />
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="smtp-username">Username</Label>
+              <Input
+                id="smtp-username"
+                placeholder="user@example.com"
+                autoComplete="off"
+                value={username}
+                onChange={(e) => handleFieldChange(setUsername)(e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                Leave blank if the server does not require authentication.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="smtp-password">Password</Label>
+              <Input
+                id="smtp-password"
+                type="password"
+                placeholder="********"
+                autoComplete="new-password"
+                value={password}
+                onChange={(e) => handleFieldChange(setPassword)(e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                Stored encrypted on the server. Leave blank to keep the existing value.
+              </p>
+            </div>
+          </div>
+
+          <Separator />
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="smtp-from">From Address</Label>
+              <Input
+                id="smtp-from"
+                type="email"
+                placeholder="noreply@example.com"
+                value={fromAddress}
+                onChange={(e) => handleFieldChange(setFromAddress)(e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                The sender address used in outgoing emails.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="smtp-tls">TLS Mode</Label>
+              <Select
+                value={tlsMode}
+                onValueChange={(v) => handleFieldChange(setTlsMode)(v as SmtpTlsMode)}
+              >
+                <SelectTrigger id="smtp-tls">
+                  <SelectValue placeholder="Select TLS mode" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">None</SelectItem>
+                  <SelectItem value="starttls">STARTTLS</SelectItem>
+                  <SelectItem value="tls">TLS</SelectItem>
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                STARTTLS upgrades an unencrypted connection. TLS connects with encryption from the start.
+              </p>
+            </div>
+          </div>
+
+          <Separator />
+
+          <div className="flex justify-end">
+            <Button
+              onClick={handleSave}
+              disabled={saveMutation.isPending || !formDirty}
+            >
+              {saveMutation.isPending && (
+                <Loader2 className="size-4 mr-2 animate-spin" />
+              )}
+              Save SMTP Settings
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Send Test Email</CardTitle>
+          <CardDescription>
+            Verify the SMTP configuration by sending a test message. Save any
+            pending changes before testing.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-end gap-3">
+            <div className="flex-1 space-y-2">
+              <Label htmlFor="test-recipient">Recipient</Label>
+              <Input
+                id="test-recipient"
+                type="email"
+                placeholder="admin@example.com"
+                value={testRecipient}
+                onChange={(e) => setTestRecipient(e.target.value)}
+              />
+            </div>
+            <Button
+              variant="outline"
+              onClick={handleSendTest}
+              disabled={testMutation.isPending}
+            >
+              {testMutation.isPending && (
+                <Loader2 className="size-4 mr-2 animate-spin" />
+              )}
+              Send Test Email
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
 }
 
 // -- page --
@@ -115,6 +394,10 @@ export default function SettingsPage() {
           <TabsTrigger value="auth">
             <Lock className="size-4 mr-1.5" />
             Authentication
+          </TabsTrigger>
+          <TabsTrigger value="email">
+            <Mail className="size-4 mr-1.5" />
+            Email
           </TabsTrigger>
         </TabsList>
 
@@ -241,6 +524,10 @@ export default function SettingsPage() {
               />
             </CardContent>
           </Card>
+        </TabsContent>
+
+        <TabsContent value="email" className="mt-4">
+          <SmtpSettingsTab />
         </TabsContent>
       </Tabs>
     </div>

--- a/src/lib/api/__tests__/settings.test.ts
+++ b/src/lib/api/__tests__/settings.test.ts
@@ -8,8 +8,18 @@ vi.mock("@artifact-keeper/sdk", () => ({
   getSettings: (...args: unknown[]) => mockGetSettings(...args),
 }));
 
+const mockApiFetch = vi.fn();
+
+vi.mock("@/lib/api/fetch", () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}));
+
 describe("settingsApi", () => {
   beforeEach(() => vi.clearAllMocks());
+
+  // -------------------------------------------------------------------------
+  // Password policy tests (existing)
+  // -------------------------------------------------------------------------
 
   it("getPasswordPolicy returns defaults when server has no policy fields", async () => {
     mockGetSettings.mockResolvedValue({
@@ -91,5 +101,202 @@ describe("settingsApi", () => {
     const mod = await import("../settings");
     const policy = await mod.settingsApi.getPasswordPolicy();
     expect(policy.min_length).toBe(20);
+  });
+
+  // -------------------------------------------------------------------------
+  // SMTP config tests
+  // -------------------------------------------------------------------------
+
+  it("getSmtpConfig returns defaults when server has no SMTP fields", async () => {
+    mockGetSettings.mockResolvedValue({
+      data: { storage_backend: "fs" },
+      error: undefined,
+    });
+    const mod = await import("../settings");
+    const config = await mod.settingsApi.getSmtpConfig();
+    expect(config).toEqual(mod.DEFAULT_SMTP_CONFIG);
+  });
+
+  it("getSmtpConfig extracts nested smtp_config object", async () => {
+    mockGetSettings.mockResolvedValue({
+      data: {
+        smtp_config: {
+          host: "mail.example.com",
+          port: 465,
+          username: "user",
+          password: "pass",
+          from_address: "noreply@example.com",
+          tls_mode: "tls",
+        },
+      },
+      error: undefined,
+    });
+    const mod = await import("../settings");
+    const config = await mod.settingsApi.getSmtpConfig();
+    expect(config.host).toBe("mail.example.com");
+    expect(config.port).toBe(465);
+    expect(config.username).toBe("user");
+    expect(config.password).toBe("pass");
+    expect(config.from_address).toBe("noreply@example.com");
+    expect(config.tls_mode).toBe("tls");
+  });
+
+  it("getSmtpConfig extracts nested smtp object (alternative key)", async () => {
+    mockGetSettings.mockResolvedValue({
+      data: {
+        smtp: {
+          host: "smtp.alt.com",
+          port: 25,
+          username: "alt-user",
+          password: "",
+          from_address: "alerts@alt.com",
+          tls_mode: "none",
+        },
+      },
+      error: undefined,
+    });
+    const mod = await import("../settings");
+    const config = await mod.settingsApi.getSmtpConfig();
+    expect(config.host).toBe("smtp.alt.com");
+    expect(config.port).toBe(25);
+    expect(config.tls_mode).toBe("none");
+  });
+
+  it("getSmtpConfig reads flat smtp_* fields", async () => {
+    mockGetSettings.mockResolvedValue({
+      data: {
+        smtp_host: "flat.example.com",
+        smtp_port: 587,
+        smtp_username: "flat-user",
+        smtp_from_address: "flat@example.com",
+        smtp_tls_mode: "starttls",
+      },
+      error: undefined,
+    });
+    const mod = await import("../settings");
+    const config = await mod.settingsApi.getSmtpConfig();
+    expect(config.host).toBe("flat.example.com");
+    expect(config.port).toBe(587);
+    expect(config.username).toBe("flat-user");
+    expect(config.from_address).toBe("flat@example.com");
+    expect(config.tls_mode).toBe("starttls");
+  });
+
+  it("getSmtpConfig prefers smtp_config over flat fields", async () => {
+    mockGetSettings.mockResolvedValue({
+      data: {
+        smtp_host: "flat.example.com",
+        smtp_config: { host: "nested.example.com" },
+      },
+      error: undefined,
+    });
+    const mod = await import("../settings");
+    const config = await mod.settingsApi.getSmtpConfig();
+    expect(config.host).toBe("nested.example.com");
+  });
+
+  it("getSmtpConfig returns defaults on SDK error", async () => {
+    mockGetSettings.mockResolvedValue({
+      data: undefined,
+      error: "unauthorized",
+    });
+    const mod = await import("../settings");
+    const config = await mod.settingsApi.getSmtpConfig();
+    expect(config).toEqual(mod.DEFAULT_SMTP_CONFIG);
+  });
+
+  it("getSmtpConfig returns defaults when SDK throws", async () => {
+    mockGetSettings.mockRejectedValue(new Error("network error"));
+    const mod = await import("../settings");
+    const config = await mod.settingsApi.getSmtpConfig();
+    expect(config).toEqual(mod.DEFAULT_SMTP_CONFIG);
+  });
+
+  it("getSmtpConfig uses default tls_mode for invalid values", async () => {
+    mockGetSettings.mockResolvedValue({
+      data: {
+        smtp_config: {
+          host: "mail.example.com",
+          tls_mode: "invalid",
+        },
+      },
+      error: undefined,
+    });
+    const mod = await import("../settings");
+    const config = await mod.settingsApi.getSmtpConfig();
+    expect(config.tls_mode).toBe("starttls");
+  });
+
+  it("getSmtpConfig uses default tls_mode for flat invalid values", async () => {
+    mockGetSettings.mockResolvedValue({
+      data: {
+        smtp_tls_mode: "bogus",
+      },
+      error: undefined,
+    });
+    const mod = await import("../settings");
+    const config = await mod.settingsApi.getSmtpConfig();
+    expect(config.tls_mode).toBe("starttls");
+  });
+
+  // -------------------------------------------------------------------------
+  // updateSmtpConfig tests
+  // -------------------------------------------------------------------------
+
+  it("updateSmtpConfig calls PUT /api/v1/admin/smtp", async () => {
+    mockApiFetch.mockResolvedValue(undefined);
+    const mod = await import("../settings");
+    const config = {
+      host: "smtp.test.com",
+      port: 587,
+      username: "user",
+      password: "pass",
+      from_address: "test@test.com",
+      tls_mode: "starttls" as const,
+    };
+    await mod.settingsApi.updateSmtpConfig(config);
+    expect(mockApiFetch).toHaveBeenCalledWith("/api/v1/admin/smtp", {
+      method: "PUT",
+      body: JSON.stringify(config),
+    });
+  });
+
+  it("updateSmtpConfig propagates errors", async () => {
+    mockApiFetch.mockRejectedValue(new Error("API error 500: server error"));
+    const mod = await import("../settings");
+    await expect(
+      mod.settingsApi.updateSmtpConfig({
+        host: "smtp.test.com",
+        port: 587,
+        username: "",
+        password: "",
+        from_address: "test@test.com",
+        tls_mode: "starttls",
+      })
+    ).rejects.toThrow("API error 500");
+  });
+
+  // -------------------------------------------------------------------------
+  // sendTestEmail tests
+  // -------------------------------------------------------------------------
+
+  it("sendTestEmail calls POST /api/v1/admin/smtp/test", async () => {
+    const response = { success: true, message: "Email sent" };
+    mockApiFetch.mockResolvedValue(response);
+    const mod = await import("../settings");
+    const result = await mod.settingsApi.sendTestEmail("admin@test.com");
+    expect(mockApiFetch).toHaveBeenCalledWith("/api/v1/admin/smtp/test", {
+      method: "POST",
+      body: JSON.stringify({ recipient: "admin@test.com" }),
+    });
+    expect(result).toEqual(response);
+  });
+
+  it("sendTestEmail propagates errors", async () => {
+    mockApiFetch.mockRejectedValue(new Error("API error 502: bad gateway"));
+    const mod = await import("../settings");
+    await expect(
+      mod.settingsApi.sendTestEmail("admin@test.com")
+    ).rejects.toThrow("API error 502");
   });
 });

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -1,5 +1,6 @@
 import "@/lib/sdk-client";
 import { getSettings } from "@artifact-keeper/sdk";
+import { apiFetch } from "@/lib/api/fetch";
 
 export interface PasswordPolicy {
   min_length: number;
@@ -8,6 +9,26 @@ export interface PasswordPolicy {
   require_digit: boolean;
   require_special: boolean;
   history_count: number;
+}
+
+export type SmtpTlsMode = "none" | "starttls" | "tls";
+
+export interface SmtpConfig {
+  host: string;
+  port: number;
+  username: string;
+  password: string;
+  from_address: string;
+  tls_mode: SmtpTlsMode;
+}
+
+export interface SendTestEmailRequest {
+  recipient: string;
+}
+
+export interface SendTestEmailResponse {
+  success: boolean;
+  message: string;
 }
 
 /**
@@ -84,6 +105,102 @@ export const settingsApi = {
       return DEFAULT_PASSWORD_POLICY;
     }
   },
+
+  /**
+   * Fetch the SMTP configuration from system settings.
+   *
+   * The backend includes SMTP fields in the /api/v1/admin/settings response
+   * but the SDK type definition does not yet declare them. We extract the
+   * smtp_config object (or individual smtp_* fields) from the raw response
+   * and merge with defaults.
+   */
+  getSmtpConfig: async (): Promise<SmtpConfig> => {
+    try {
+      const { data, error } = await getSettings();
+      if (error) return DEFAULT_SMTP_CONFIG;
+
+      const raw = data as unknown as Record<string, unknown>;
+      const serverSmtp =
+        (raw?.smtp_config as Partial<SmtpConfig>) ??
+        (raw?.smtp as Partial<SmtpConfig>) ??
+        {};
+
+      return {
+        host:
+          typeof serverSmtp.host === "string"
+            ? serverSmtp.host
+            : (typeof raw?.smtp_host === "string"
+                ? raw.smtp_host
+                : DEFAULT_SMTP_CONFIG.host),
+        port:
+          typeof serverSmtp.port === "number"
+            ? serverSmtp.port
+            : (typeof raw?.smtp_port === "number"
+                ? raw.smtp_port
+                : DEFAULT_SMTP_CONFIG.port),
+        username:
+          typeof serverSmtp.username === "string"
+            ? serverSmtp.username
+            : (typeof raw?.smtp_username === "string"
+                ? raw.smtp_username
+                : DEFAULT_SMTP_CONFIG.username),
+        password:
+          typeof serverSmtp.password === "string"
+            ? serverSmtp.password
+            : DEFAULT_SMTP_CONFIG.password,
+        from_address:
+          typeof serverSmtp.from_address === "string"
+            ? serverSmtp.from_address
+            : (typeof raw?.smtp_from_address === "string"
+                ? raw.smtp_from_address
+                : DEFAULT_SMTP_CONFIG.from_address),
+        tls_mode:
+          isValidTlsMode(serverSmtp.tls_mode)
+            ? serverSmtp.tls_mode
+            : (isValidTlsMode(raw?.smtp_tls_mode)
+                ? (raw.smtp_tls_mode as SmtpTlsMode)
+                : DEFAULT_SMTP_CONFIG.tls_mode),
+      };
+    } catch {
+      return DEFAULT_SMTP_CONFIG;
+    }
+  },
+
+  /**
+   * Save SMTP configuration. Uses the /api/v1/admin/smtp endpoint which
+   * is not yet in the generated SDK.
+   */
+  updateSmtpConfig: async (config: SmtpConfig): Promise<void> => {
+    await apiFetch<void>("/api/v1/admin/smtp", {
+      method: "PUT",
+      body: JSON.stringify(config),
+    });
+  },
+
+  /**
+   * Send a test email through the configured SMTP server.
+   */
+  sendTestEmail: async (recipient: string): Promise<SendTestEmailResponse> => {
+    return apiFetch<SendTestEmailResponse>("/api/v1/admin/smtp/test", {
+      method: "POST",
+      body: JSON.stringify({ recipient }),
+    });
+  },
 };
+
+function isValidTlsMode(value: unknown): value is SmtpTlsMode {
+  return value === "none" || value === "starttls" || value === "tls";
+}
+
+const DEFAULT_SMTP_CONFIG: SmtpConfig = {
+  host: "",
+  port: 587,
+  username: "",
+  password: "",
+  from_address: "",
+  tls_mode: "starttls",
+};
+
+export { DEFAULT_SMTP_CONFIG };
 
 export default settingsApi;


### PR DESCRIPTION
## Summary

Adds an "Email" tab to the admin settings page with a full SMTP configuration form and test email functionality. Closes #262.

- New `SmtpConfig` types and API methods in `src/lib/api/settings.ts` for reading config from `GET /api/v1/admin/settings`, saving via `PUT /api/v1/admin/smtp`, and sending test emails via `POST /api/v1/admin/smtp/test`
- Editable form with fields for Host, Port, Username, Password (masked), From Address, and TLS Mode (none/starttls/tls) with client-side validation
- "Send Test Email" card with recipient input to verify the SMTP configuration
- Form uses a key-based remount pattern to sync query data into local state without calling setState in an effect, satisfying the strict React Compiler lint rules
- 48 unit tests across the page component and API module covering rendering, field population, validation errors, mutation calls, edge cases, and error handling

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [ ] Playwright E2E spec covers the change
- [x] Responsive layout verified (mobile + desktop)
- [x] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes