### PR TITLE
fix: cap access token dialog height to prevent viewport overflow

### DIFF
--- a/src/app/(app)/(protected)/access-tokens/page.tsx
+++ b/src/app/(app)/(protected)/access-tokens/page.tsx
@@ -432,7 +432,7 @@ export default function AccessTokensPage() {
           }
         }}
       >
-        <DialogContent className="sm:max-w-lg">
+        <DialogContent className="sm:max-w-lg max-h-[90vh] overflow-y-auto">
           {newlyCreatedToken ? (
             <TokenCreatedAlert
               title="Access Token Created"


### PR DESCRIPTION
## Summary

Fixes the remaining red E2E Interactions shards on main (shard 1/3 and 2/3) after PR #301 partially addressed the regression introduced in PR #294.

PR #294 added `RepoSelectorForm` (224 lines: 12 format checkboxes, name pattern input, labels editor, preview panel) to the Create Access Token dialog. The `DialogContent` was widened to `sm:max-w-lg` but kept the default height and overflow behavior, so in Playwright's 1280x720 viewport the `DialogFooter` sat below the visible area. Radix `DialogContent` is a `position: fixed` portal, so Playwright's `scrollIntoViewIfNeeded` had nothing to scroll; clicks on the submit and cancel buttons retried `element is outside of the viewport` until the tests timed out.

PR #301 fixed the strict-mode `/name/i` collision with the new "Name Pattern" label, but did not address this layout issue. The `auth/access-tokens.spec.ts` test at line 54 stayed red on `df9ca72`.

The one-line change adopts the pattern already established by `quality-gates/page.tsx:256`, `webhooks/page.tsx:478`, `settings/sso/page.tsx:337,821`, and `migration/page.tsx:1033`: cap the dialog at 90vh and allow content to scroll inside.

```diff
-        <DialogContent className="sm:max-w-lg">
+        <DialogContent className="sm:max-w-lg max-h-[90vh] overflow-y-auto">
```

### Failing tests that should go green

- `e2e/suites/interactions/auth/access-tokens.spec.ts:54` "can create an access token and see the token value"
- `e2e/suites/interactions/integrations/access-tokens.spec.ts:59` "clicking Create Token opens dialog with form fields"
- `e2e/suites/interactions/integrations/access-tokens.spec.ts:146` "create an access token and see the secret"

## Test Checklist
- [ ] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

Local verification:
- `npm run lint`: 0 errors, 33 pre-existing warnings (unchanged)
- `npm test`: 1834/1834 passing
- `npm run build`: succeeds

No new tests needed: the existing failing specs cover the dialog interaction and will validate the fix end-to-end.

## UI Changes
- [x] Playwright E2E spec covers the change
- [x] Responsive layout verified (mobile + desktop)
- [x] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes

Layout: the dialog now caps at 90vh and scrolls internally when content overflows, matching four other dialogs in the app. No visual change on viewports where the form fits.

Accessibility: `overflow-y: auto` makes the container a keyboard scroll parent, so users who Tab through the form can reach the submit and cancel buttons even when the form is taller than the viewport. Radix focus ring behavior is unchanged.