### PR TITLE
fix: skip trailing-slash redirect so /v2/ reaches docker proxy

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -21,6 +21,13 @@ const nextConfig: NextConfig = {
   output: "standalone",
   devIndicators: false,
   transpilePackages: ["@artifact-keeper/sdk"],
+  // Docker Registry HTTP API v2 requires a trailing-slash on the version-check
+  // endpoint (`GET /v2/`). Next.js's default trailing-slash redirect would
+  // turn that into a 308 → `/v2`, which the docker client treats as a failed
+  // auth challenge (the `WWW-Authenticate` header on the 308 is ignored, so
+  // it never proceeds to the token realm). Disabling the redirect lets the
+  // middleware proxy forward `/v2/` verbatim to the backend. See #1007.
+  skipTrailingSlashRedirect: true,
   experimental: {
     // The default proxyClientMaxBodySize is 10 MB, which blocks artifact
     // uploads larger than that through the middleware rewrite proxy. The

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -39,6 +39,18 @@ function createMockNextRequest(pathname: string, search = "") {
   } as unknown as import("next/server").NextRequest;
 }
 
+/**
+ * Asserts that the most recent NextResponse.rewrite() call targeted the given
+ * path on the given backend origin (defaults to the docker-compose default).
+ */
+function expectRewriteTo(pathname: string, origin = "http://backend:8080") {
+  expect(mockRewrite).toHaveBeenCalledTimes(1);
+  const url = mockRewrite.mock.calls[0][0] as URL;
+  expect(url.pathname).toBe(pathname);
+  expect(url.origin).toBe(origin);
+  return url;
+}
+
 describe("middleware", () => {
   it("skips SSE event stream path and calls NextResponse.next()", async () => {
     const { middleware } = await import("../middleware");
@@ -111,16 +123,11 @@ describe("middleware", () => {
     // #1007 — combined with `skipTrailingSlashRedirect` in next.config.ts.
     const { middleware } = await import("../middleware");
 
-    middleware(createMockNextRequest("/v2/"));
-    expect(mockRewrite).toHaveBeenCalledTimes(1);
-    const url = mockRewrite.mock.calls[0][0] as URL;
-    expect(url.pathname).toBe("/v2/");
-    expect(url.origin).toBe("http://backend:8080");
-
-    mockRewrite.mockClear();
-    middleware(createMockNextRequest("/v2"));
-    expect(mockRewrite).toHaveBeenCalledTimes(1);
-    expect((mockRewrite.mock.calls[0][0] as URL).pathname).toBe("/v2");
+    for (const path of ["/v2/", "/v2"]) {
+      mockRewrite.mockClear();
+      middleware(createMockNextRequest(path));
+      expectRewriteTo(path);
+    }
   });
 
   it("exports matcher config for API, health, and native format routes", async () => {

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -104,6 +104,25 @@ describe("middleware", () => {
     }
   });
 
+  it("rewrites Docker Registry v2 ping endpoint (bare /v2/) to backend", async () => {
+    // The docker client hits `GET /v2/` (with trailing slash) for the API
+    // version check during `docker login`. The proxy must forward this verbatim
+    // so the backend's `WWW-Authenticate` challenge reaches the client. See
+    // #1007 — combined with `skipTrailingSlashRedirect` in next.config.ts.
+    const { middleware } = await import("../middleware");
+
+    middleware(createMockNextRequest("/v2/"));
+    expect(mockRewrite).toHaveBeenCalledTimes(1);
+    const url = mockRewrite.mock.calls[0][0] as URL;
+    expect(url.pathname).toBe("/v2/");
+    expect(url.origin).toBe("http://backend:8080");
+
+    mockRewrite.mockClear();
+    middleware(createMockNextRequest("/v2"));
+    expect(mockRewrite).toHaveBeenCalledTimes(1);
+    expect((mockRewrite.mock.calls[0][0] as URL).pathname).toBe("/v2");
+  });
+
   it("exports matcher config for API, health, and native format routes", async () => {
     const { config } = await import("../middleware");
     expect(config.matcher).toContain("/api/:path*");
@@ -111,6 +130,7 @@ describe("middleware", () => {
     expect(config.matcher).toContain("/pypi/:path*");
     expect(config.matcher).toContain("/npm/:path*");
     expect(config.matcher).toContain("/maven/:path*");
+    expect(config.matcher).toContain("/v2");
     expect(config.matcher).toContain("/v2/:path*");
     expect(config.matcher.length).toBeGreaterThan(30);
   });


### PR DESCRIPTION
Fixes artifact-keeper/artifact-keeper#1007.

## Summary

Next.js was 308-redirecting `GET /v2/` → `/v2` *before* middleware ran. The Docker registry client either didn't follow that redirect or dropped the auth challenge across it, surfacing as a bare `401 Unauthorized` with no `WWW-Authenticate` header — `docker login` then failed with no recoverable info. The matcher entry added in #108 (which added `/v2` without trailing slash) was dead code in practice.

Fix: set `skipTrailingSlashRedirect: true` in `next.config.ts`. The existing `/v2/:path*` matcher (where `:path*` matches 0+ segments, including the empty case) now forwards `/v2/` verbatim to the backend, where the Docker registry handler issues its `WWW-Authenticate` challenge and the auth flow completes normally.

## Three-round review

| Round | Role | Result |
|---|---|---|
| R1 | SWE | Fix authored + inline regression test |
| R1 | Test (retroactive) | Test was inline in fix commit; reorder to test→fix not redone (small diff, low risk) |
| R1 | DevOps (retroactive backfill) | ✅ APPROVE — `release/1.1.x` branch doesn't exist for this repo (v1.1.x cuts from main), no backport needed; CI will exercise new test on Node 22; image bake covers the flag |
| R1 | Security (retroactive backfill) | ✅ APPROVE — no auth bypass surface (no web-layer auth/CSRF/rate-limit middleware exists); `BACKEND_URL` is config-time, not request-derived (no SSRF); flag does not relax cookies/CORS |
| R2 | code-simplifier | ✅ jscpd 0% on changed files, vitest coverage 100% on `src/middleware.ts`, 7/7 tests pass, build succeeds |
| R3 | adversarial reviewer (fresh eyes) | ✅ APPROVE — verified trailing-slash flag is safe across all internal `Link` and `router.push` call sites; large-body streaming preserved by `experimental.proxyClientMaxBodySize: 5gb` already in config |

## Follow-ups (filed separately, not part of this PR)

- artifact-keeper-web#336 — e2e/Playwright coverage of Docker `/v2/*` request/response header forwarding (`Authorization`, `WWW-Authenticate`, `Docker-Content-Digest`, etc.) — the unit tests verify path/origin of the rewrite, not real-runtime header passthrough.
- artifact-keeper#1021 — Backend `WWW-Authenticate` realm hostname must advertise external URL, not internal cluster URL — will affect docker login from outside the cluster regardless of the web fix.
- artifact-keeper-web#337 — Harden middleware SSE early-return against trailing-slash variants (`/api/v1/events/stream/` would now miss the equality check). Likely benign (`EventSource` doesn't typically send trailing slashes) but worth defensive coding.

## Out of scope

- CHANGELOG `[1.1.10]` entry mentioning this fix — handled in the version-bump PR per repo convention.
- Audit of `artifact-keeper-site` for stale `/v2/` workaround docs — separate workstream.

## Test plan

- [x] `npx vitest run src/__tests__/middleware.test.ts` — 7/7 passing (incl. 2 new `/v2/` cases)
- [x] `npm run build` — compiled successfully
- [x] `npx tsc --noEmit` — only pre-existing errors in unrelated files (verified present on `origin/main` before this PR)
- [ ] CI to run the same checks on Node 22
- [ ] Manual `docker login repo.example.com` against a deployed image (post-merge)