### PR TITLE
fix(middleware): harden SSE early-return against trailing-slash variants

### DIFF
--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -62,14 +62,18 @@ describe("middleware", () => {
     expect(result).toEqual({ type: "next" });
   });
 
-  it("skips SSE event stream path with trailing slash variant", async () => {
-    // skipTrailingSlashRedirect (set in next.config.ts for /v2/) means
-    // `/api/v1/events/stream/` reaches middleware verbatim instead of being
-    // 308'd to the canonical form. The early-return must treat both forms
-    // equivalently, otherwise SSE gets proxy-rewritten and the long-lived
-    // connection breaks. See #337.
+  it.each([
+    ["/api/v1/events/stream/", "single trailing slash"],
+    ["/api/v1/events/stream///", "multiple trailing slashes"],
+  ])("skips SSE event stream path with %s variant (%s)", async (path) => {
+    // skipTrailingSlashRedirect (set in next.config.ts) means trailing-slash
+    // variants reach middleware verbatim instead of being 308'd to the
+    // canonical form. The early-return must treat all variants equivalently,
+    // otherwise SSE gets proxy-rewritten and the long-lived connection
+    // breaks. The multi-slash case locks in the regex `/\/+$/` against
+    // accidental refactors to a single-slash variant. See #337.
     const { middleware } = await import("../middleware");
-    const request = createMockNextRequest("/api/v1/events/stream/");
+    const request = createMockNextRequest(path);
     const result = middleware(request);
 
     expect(mockNext).toHaveBeenCalled();

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -62,6 +62,21 @@ describe("middleware", () => {
     expect(result).toEqual({ type: "next" });
   });
 
+  it("skips SSE event stream path with trailing slash variant", async () => {
+    // skipTrailingSlashRedirect (set in next.config.ts for /v2/) means
+    // `/api/v1/events/stream/` reaches middleware verbatim instead of being
+    // 308'd to the canonical form. The early-return must treat both forms
+    // equivalently, otherwise SSE gets proxy-rewritten and the long-lived
+    // connection breaks. See #337.
+    const { middleware } = await import("../middleware");
+    const request = createMockNextRequest("/api/v1/events/stream/");
+    const result = middleware(request);
+
+    expect(mockNext).toHaveBeenCalled();
+    expect(mockRewrite).not.toHaveBeenCalled();
+    expect(result).toEqual({ type: "next" });
+  });
+
   it("rewrites other API paths to backend", async () => {
     const { middleware } = await import("../middleware");
     const request = createMockNextRequest("/api/v1/users", "?page=1");

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -11,8 +11,10 @@ export function middleware(request: NextRequest) {
 
   // SSE event stream uses a dedicated App Router route handler for proper
   // streaming support. Middleware rewrites gzip-compress and close the
-  // connection, which breaks long-lived SSE connections.
-  if (pathname === "/api/v1/events/stream") {
+  // connection, which breaks long-lived SSE connections. Trailing-slash
+  // variants must match too: `skipTrailingSlashRedirect` (next.config.ts)
+  // means `/api/v1/events/stream/` reaches us verbatim. See #337.
+  if (pathname.replace(/\/+$/, "") === "/api/v1/events/stream") {
     return NextResponse.next();
   }
 


### PR DESCRIPTION
## Summary

- Hardens the `/api/v1/events/stream` early-return in `src/middleware.ts` against trailing-slash variants by stripping trailing slashes before the equality check.
- Adds a parameterized regression test covering single-slash and multi-slash variants.

## Why

`skipTrailingSlashRedirect: true` (added in #338 for the docker `/v2/` proxy) disables Next.js's automatic 308 to the canonical form for **all** paths, not just `/v2/`. A request to `/api/v1/events/stream/` would have previously been redirected; now it reaches middleware verbatim and fails the `pathname === "/api/v1/events/stream"` check, getting proxy-rewritten. The rewrite path gzip-compresses and closes the response, so any SSE caller that includes a trailing slash sees its long-lived connection break.

## Review process

Three rounds, per the team-of-four / three-round process:

- **R1 build** — failing-test commit (`776302e`) reproduces the bug; fix commit (`22cb962`) applies `pathname.replace(/\/+$/, "")`. Test fails on main; passes after fix.
- **R2 gates** — vitest pass (1898/1898), middleware coverage 100%/100%/100%/100%, lint clean (no new warnings), jscpd N/A on a 6-line change.
- **R3 fresh-eyes** — adversarial review verdict was *ship*, with one nit: the regex `/\/+$/` handles any number of trailing slashes but only single-slash was tested. Commit `c724131` adds a parameterized case for multi-slash to lock in the regex behavior against a future refactor to `/\/$/`.

## Test plan

- [x] `npx vitest run src/__tests__/middleware.test.ts` — 9/9 pass
- [x] `npm test` — 1898/1898 pass
- [x] `npm run lint` — 0 errors
- [x] Failing-test commit fails on `main`; passes after the fix
- [x] Verified `/api/v1/events/stream`, `/api/v1/events/stream/`, `/api/v1/events/stream///` all early-return without rewriting

## Acceptance criteria (from #337)

- [x] `/api/v1/events/stream/` is treated identically to `/api/v1/events/stream`
- [x] Unit test in `src/__tests__/middleware.test.ts` exercises both forms

Closes #337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)