### PR TITLE
test(e2e): add Docker /v2/* header forwarding suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,6 +383,37 @@ jobs:
         if: always()
         run: docker compose -f docker-compose.e2e.yml down -v
 
+  e2e-docker-proxy:
+    name: E2E Docker /v2/* Header Forwarding
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      # No docker compose stack — this suite uses an in-process Node fixture
+      # registry to verify the Next.js middleware proxy preserves Docker
+      # request/response headers end to end. See issue #336.
+      - name: Run Docker /v2/* header-forwarding tests
+        run: npm run test:e2e:docker-proxy
+
+      - name: Upload test report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: playwright-docker-proxy
+          path: playwright-report/
+          retention-days: 7
+
   e2e-docs-export:
     name: E2E Docs Screenshot Export
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,12 +397,13 @@ jobs:
 
       - run: npm ci
 
-      - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
-
-      # No docker compose stack — this suite uses an in-process Node fixture
-      # registry to verify the Next.js middleware proxy preserves Docker
-      # request/response headers end to end. See issue #336.
+      # This suite uses Playwright's `request` API only — no browser is
+      # launched, so we skip `playwright install --with-deps` (saves ~90s
+      # plus chromium dependency install bandwidth).
+      #
+      # No docker compose stack either — the suite uses an in-process Node
+      # fixture registry to verify the Next.js middleware proxy preserves
+      # Docker request/response headers end to end. See issue #336.
       - name: Run Docker /v2/* header-forwarding tests
         run: npm run test:e2e:docker-proxy
 

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ next-env.d.ts
 
 # tutorial recordings
 e2e/tutorials/output/
+
+# Worktrees created by Claude Code agents
+.claude/worktrees/

--- a/e2e/fixtures/docker-registry-fixture.ts
+++ b/e2e/fixtures/docker-registry-fixture.ts
@@ -1,0 +1,184 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+
+/**
+ * Captured request seen by the fixture registry. The headers map preserves the
+ * raw casing-insensitive form returned by Node — keys are lowercased — and
+ * values are stringified so consumers can do simple equality checks.
+ */
+export interface RecordedRequest {
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+  body: Buffer;
+}
+
+/**
+ * Configurable response for a given path. Headers passed here are written on
+ * the response verbatim; tests rely on this to verify Docker-specific response
+ * headers survive the Next.js proxy layer.
+ */
+export interface FixtureResponseSpec {
+  status: number;
+  headers?: Record<string, string>;
+  body?: Buffer | string;
+}
+
+export interface FixtureRegistry {
+  url: string;
+  port: number;
+  recordedRequests: RecordedRequest[];
+  setResponse: (path: string, spec: FixtureResponseSpec) => void;
+  reset: () => void;
+  close: () => Promise<void>;
+}
+
+interface CreateOptions {
+  port?: number;
+  host?: string;
+}
+
+/**
+ * Stand up an in-process HTTP server that pretends to be the upstream Docker
+ * registry backend. The web layer's middleware proxy will rewrite /v2/*
+ * requests here when BACKEND_URL points at this server's URL, letting tests
+ * assert end-to-end which headers survive the Next.js fetch-and-forward path.
+ */
+export function createFixtureRegistry(options: CreateOptions = {}): Promise<FixtureRegistry> {
+  const recordedRequests: RecordedRequest[] = [];
+  const responseMap = new Map<string, FixtureResponseSpec>();
+
+  const readBody = (req: IncomingMessage): Promise<Buffer> =>
+    new Promise((resolveBody) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => resolveBody(Buffer.concat(chunks)));
+    });
+
+  const handler = async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
+    const url = req.url ?? "/";
+
+    // ---- Control plane (used only by the test process) -----------------
+    // Routed under __fixture so it can never collide with the Docker
+    // Registry namespace, which is rooted at /v2.
+    if (url.startsWith("/__fixture/")) {
+      if (req.method === "GET" && url === "/__fixture/requests") {
+        res.statusCode = 200;
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify(recordedRequests.map(serializeRecorded)));
+        return;
+      }
+      if (req.method === "POST" && url === "/__fixture/reset") {
+        recordedRequests.length = 0;
+        responseMap.clear();
+        res.statusCode = 204;
+        res.end();
+        return;
+      }
+      if (req.method === "POST" && url === "/__fixture/responses") {
+        const body = await readBody(req);
+        const parsed = JSON.parse(body.toString("utf8")) as {
+          path: string;
+          spec: FixtureResponseSpec & { body?: string };
+        };
+        responseMap.set(parsed.path, {
+          status: parsed.spec.status,
+          headers: parsed.spec.headers,
+          body: parsed.spec.body,
+        });
+        res.statusCode = 204;
+        res.end();
+        return;
+      }
+      res.statusCode = 404;
+      res.end();
+      return;
+    }
+
+    // ---- Registry-facing path ------------------------------------------
+    const body = await readBody(req);
+    const headers: Record<string, string> = {};
+    for (const [key, value] of Object.entries(req.headers)) {
+      if (typeof value === "string") {
+        headers[key.toLowerCase()] = value;
+      } else if (Array.isArray(value)) {
+        headers[key.toLowerCase()] = value.join(", ");
+      }
+    }
+
+    recordedRequests.push({
+      method: req.method ?? "GET",
+      path: url,
+      headers,
+      body,
+    });
+
+    const pathOnly = url.split("?")[0];
+    const spec = responseMap.get(url) ?? responseMap.get(pathOnly);
+
+    if (!spec) {
+      res.statusCode = 404;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ errors: [{ code: "NOT_FOUND", message: "no fixture configured" }] }));
+      return;
+    }
+
+    res.statusCode = spec.status;
+    for (const [key, value] of Object.entries(spec.headers ?? {})) {
+      res.setHeader(key, value);
+    }
+    if (spec.body !== undefined) {
+      res.end(typeof spec.body === "string" ? Buffer.from(spec.body) : spec.body);
+    } else {
+      res.end();
+    }
+  };
+
+  function serializeRecorded(r: RecordedRequest): {
+    method: string;
+    path: string;
+    headers: Record<string, string>;
+    bodyBase64: string;
+  } {
+    return {
+      method: r.method,
+      path: r.path,
+      headers: r.headers,
+      bodyBase64: r.body.toString("base64"),
+    };
+  }
+
+  const server: Server = createServer((req, res) => {
+    handler(req, res).catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      if (!res.headersSent) {
+        res.statusCode = 500;
+        res.setHeader("content-type", "application/json");
+      }
+      res.end(JSON.stringify({ errors: [{ code: "FIXTURE_ERROR", message }] }));
+    });
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(options.port ?? 0, options.host ?? "127.0.0.1", () => {
+      const address = server.address() as AddressInfo;
+      const port = address.port;
+      const url = `http://127.0.0.1:${port}`;
+      resolve({
+        url,
+        port,
+        recordedRequests,
+        setResponse: (path, spec) => responseMap.set(path, spec),
+        reset: () => {
+          recordedRequests.length = 0;
+          responseMap.clear();
+        },
+        close: () =>
+          new Promise<void>((resolveClose, rejectClose) => {
+            server.close((err) => (err ? rejectClose(err) : resolveClose()));
+          }),
+      });
+    });
+  });
+}

--- a/e2e/fixtures/docker-registry-fixture.ts
+++ b/e2e/fixtures/docker-registry-fixture.ts
@@ -14,6 +14,17 @@ export interface RecordedRequest {
 }
 
 /**
+ * Wire shape returned by the GET /__fixture/requests control endpoint. Body is
+ * base64-encoded so binary blobs round-trip through JSON unchanged.
+ */
+export interface SerializedRecordedRequest {
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+  bodyBase64: string;
+}
+
+/**
  * Configurable response for a given path. Headers passed here are written on
  * the response verbatim; tests rely on this to verify Docker-specific response
  * headers survive the Next.js proxy layer.
@@ -63,9 +74,15 @@ export function createFixtureRegistry(options: CreateOptions = {}): Promise<Fixt
     // Registry namespace, which is rooted at /v2.
     if (url.startsWith("/__fixture/")) {
       if (req.method === "GET" && url === "/__fixture/requests") {
+        const serialized: SerializedRecordedRequest[] = recordedRequests.map((r) => ({
+          method: r.method,
+          path: r.path,
+          headers: r.headers,
+          bodyBase64: r.body.toString("base64"),
+        }));
         res.statusCode = 200;
         res.setHeader("content-type", "application/json");
-        res.end(JSON.stringify(recordedRequests.map(serializeRecorded)));
+        res.end(JSON.stringify(serialized));
         return;
       }
       if (req.method === "POST" && url === "/__fixture/reset") {
@@ -81,11 +98,7 @@ export function createFixtureRegistry(options: CreateOptions = {}): Promise<Fixt
           path: string;
           spec: FixtureResponseSpec & { body?: string };
         };
-        responseMap.set(parsed.path, {
-          status: parsed.spec.status,
-          headers: parsed.spec.headers,
-          body: parsed.spec.body,
-        });
+        responseMap.set(parsed.path, parsed.spec);
         res.statusCode = 204;
         res.end();
         return;
@@ -133,20 +146,6 @@ export function createFixtureRegistry(options: CreateOptions = {}): Promise<Fixt
       res.end();
     }
   };
-
-  function serializeRecorded(r: RecordedRequest): {
-    method: string;
-    path: string;
-    headers: Record<string, string>;
-    bodyBase64: string;
-  } {
-    return {
-      method: r.method,
-      path: r.path,
-      headers: r.headers,
-      bodyBase64: r.body.toString("base64"),
-    };
-  }
 
   const server: Server = createServer((req, res) => {
     handler(req, res).catch((err: unknown) => {

--- a/e2e/fixtures/run-docker-registry-fixture.ts
+++ b/e2e/fixtures/run-docker-registry-fixture.ts
@@ -1,0 +1,33 @@
+import { createFixtureRegistry } from "./docker-registry-fixture";
+
+/**
+ * Tiny entry point used by Playwright's webServer to boot the fixture as
+ * its own process. Reads PORT from env (deterministic so the Next.js process
+ * can be configured via BACKEND_URL), prints the URL on stdout, and stays
+ * alive until killed by Playwright.
+ */
+async function main(): Promise<void> {
+  const port = process.env.FIXTURE_PORT ? Number(process.env.FIXTURE_PORT) : 4500;
+  if (!Number.isFinite(port) || port <= 0) {
+    throw new Error(`invalid FIXTURE_PORT: ${process.env.FIXTURE_PORT}`);
+  }
+
+  const fixture = await createFixtureRegistry({ port });
+  process.stdout.write(`docker-registry-fixture listening on ${fixture.url}\n`);
+
+  const shutdown = async (): Promise<void> => {
+    await fixture.close();
+    process.exit(0);
+  };
+  process.on("SIGTERM", () => {
+    void shutdown();
+  });
+  process.on("SIGINT", () => {
+    void shutdown();
+  });
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(`fixture failed to start: ${String(err)}\n`);
+  process.exit(1);
+});

--- a/e2e/fixtures/run-docker-registry-fixture.ts
+++ b/e2e/fixtures/run-docker-registry-fixture.ts
@@ -15,16 +15,20 @@ async function main(): Promise<void> {
   const fixture = await createFixtureRegistry({ port });
   process.stdout.write(`docker-registry-fixture listening on ${fixture.url}\n`);
 
+  let shuttingDown = false;
   const shutdown = async (): Promise<void> => {
-    await fixture.close();
-    process.exit(0);
+    if (shuttingDown) return;
+    shuttingDown = true;
+    try {
+      await fixture.close();
+      process.exit(0);
+    } catch (err) {
+      process.stderr.write(`fixture close failed: ${String(err)}\n`);
+      process.exit(1);
+    }
   };
-  process.on("SIGTERM", () => {
-    void shutdown();
-  });
-  process.on("SIGINT", () => {
-    void shutdown();
-  });
+  process.on("SIGTERM", () => void shutdown());
+  process.on("SIGINT", () => void shutdown());
 }
 
 main().catch((err: unknown) => {

--- a/e2e/suites/docker-proxy/header-forwarding.spec.ts
+++ b/e2e/suites/docker-proxy/header-forwarding.spec.ts
@@ -1,0 +1,174 @@
+import { test, expect, request as pwRequest, type APIRequestContext } from "@playwright/test";
+
+/**
+ * End-to-end coverage for issue #336 — verify that the Next.js middleware
+ * proxy preserves Docker-Distribution-API headers in both directions.
+ *
+ * Unit tests (src/__tests__/middleware.test.ts) only assert that
+ * NextResponse.rewrite() is called with the right URL; they cannot verify
+ * what Next.js does at runtime when it follows that rewrite. These tests
+ * point a real Next.js (next start) at a fixture HTTP server and observe
+ * what the fixture sees and what the client receives.
+ */
+
+interface RecordedRequestSerialized {
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+  bodyBase64: string;
+}
+
+const FIXTURE_PORT = Number(process.env.FIXTURE_PORT ?? 4500);
+const FIXTURE_URL = `http://127.0.0.1:${FIXTURE_PORT}`;
+const WEB_BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3001";
+
+async function setFixtureResponse(
+  control: APIRequestContext,
+  path: string,
+  spec: { status: number; headers?: Record<string, string>; body?: string },
+): Promise<void> {
+  const res = await control.post(`${FIXTURE_URL}/__fixture/responses`, {
+    data: { path, spec },
+  });
+  expect(res.status(), "fixture setResponse").toBe(204);
+}
+
+async function resetFixture(control: APIRequestContext): Promise<void> {
+  const res = await control.post(`${FIXTURE_URL}/__fixture/reset`);
+  expect(res.status(), "fixture reset").toBe(204);
+}
+
+async function getRecordedRequests(
+  control: APIRequestContext,
+): Promise<RecordedRequestSerialized[]> {
+  const res = await control.get(`${FIXTURE_URL}/__fixture/requests`);
+  expect(res.status(), "fixture requests").toBe(200);
+  return (await res.json()) as RecordedRequestSerialized[];
+}
+
+test.describe("Docker /v2/* header forwarding through Next.js middleware", () => {
+  let control: APIRequestContext;
+  let client: APIRequestContext;
+
+  test.beforeAll(async () => {
+    control = await pwRequest.newContext();
+    // Separate client context — extraHTTPHeaders applied per-request below
+    // since each test parametrizes a different header.
+    client = await pwRequest.newContext({ baseURL: WEB_BASE_URL });
+  });
+
+  test.afterAll(async () => {
+    await control.dispose();
+    await client.dispose();
+  });
+
+  test.beforeEach(async () => {
+    await resetFixture(control);
+  });
+
+  // ------------------------------------------------------------------
+  // Request headers (web --> backend) — issue #336
+  // ------------------------------------------------------------------
+  const requestHeaderCases: Array<{ name: string; value: string }> = [
+    { name: "Authorization", value: "Bearer test-token-abc123" },
+    { name: "Content-Length", value: "0" },
+    { name: "Content-Range", value: "bytes 0-1023/2048" },
+    { name: "Content-Type", value: "application/vnd.docker.distribution.manifest.v2+json" },
+    { name: "Docker-Distribution-API-Version", value: "registry/2.0" },
+  ];
+
+  for (const { name, value } of requestHeaderCases) {
+    test(`forwards request header ${name} to backend`, async () => {
+      const path = `/v2/test-repo/manifests/header-${name.toLowerCase()}`;
+      await setFixtureResponse(control, path, { status: 200 });
+
+      const res = await client.get(path, { headers: { [name]: value } });
+      expect(res.status()).toBe(200);
+
+      const recorded = await getRecordedRequests(control);
+      expect(recorded.length).toBeGreaterThanOrEqual(1);
+      const seen = recorded.find((r) => r.path === path);
+      expect(seen, `fixture should have observed ${path}`).toBeDefined();
+      expect(seen!.headers[name.toLowerCase()]).toBe(value);
+    });
+  }
+
+  // ------------------------------------------------------------------
+  // Response headers (backend --> web --> client) — issue #336
+  // ------------------------------------------------------------------
+  const responseHeaderCases: Array<{ name: string; value: string }> = [
+    {
+      name: "WWW-Authenticate",
+      value: 'Bearer realm="https://example.test/token",service="registry"',
+    },
+    {
+      name: "Docker-Content-Digest",
+      value: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd",
+    },
+    { name: "Docker-Upload-UUID", value: "11111111-2222-3333-4444-555555555555" },
+    { name: "Range", value: "0-1023" },
+    { name: "Location", value: "/v2/test-repo/blobs/uploads/abc123?_state=xyz" },
+  ];
+
+  for (const { name, value } of responseHeaderCases) {
+    test(`propagates response header ${name} back to client`, async () => {
+      const path = `/v2/test-repo/blobs/header-${name.toLowerCase()}`;
+      await setFixtureResponse(control, path, {
+        // 401 keeps WWW-Authenticate semantically correct without changing
+        // behavior for the other headers.
+        status: name === "WWW-Authenticate" ? 401 : 200,
+        headers: { [name]: value },
+      });
+
+      const res = await client.get(path);
+      expect(res.status()).toBe(name === "WWW-Authenticate" ? 401 : 200);
+      const headers = res.headers();
+      expect(headers[name.toLowerCase()]).toBe(value);
+    });
+  }
+
+  // ------------------------------------------------------------------
+  // Realistic flow: docker login pings /v2/, gets WWW-Authenticate,
+  // then follows up to a token endpoint. This is the exact sequence
+  // #1007 was trying to fix; we verify the proxy hand-off works.
+  // ------------------------------------------------------------------
+  test("docker login flow: GET /v2/ returns 401 + WWW-Authenticate, follow-up succeeds", async () => {
+    await setFixtureResponse(control, "/v2/", {
+      status: 401,
+      headers: {
+        "WWW-Authenticate": 'Bearer realm="http://127.0.0.1/token",service="registry"',
+        "Docker-Distribution-API-Version": "registry/2.0",
+      },
+    });
+    await setFixtureResponse(control, "/v2/library/alpine/manifests/latest", {
+      status: 200,
+      headers: {
+        "Docker-Content-Digest": "sha256:deadbeef".padEnd(71, "0"),
+        "Content-Type": "application/vnd.docker.distribution.manifest.v2+json",
+      },
+      body: '{"schemaVersion":2}',
+    });
+
+    const ping = await client.get("/v2/", {
+      headers: { "Docker-Distribution-API-Version": "registry/2.0" },
+    });
+    expect(ping.status()).toBe(401);
+    expect(ping.headers()["www-authenticate"]).toContain("Bearer");
+    expect(ping.headers()["docker-distribution-api-version"]).toBe("registry/2.0");
+
+    const manifest = await client.get("/v2/library/alpine/manifests/latest", {
+      headers: { Authorization: "Bearer issued-by-token-realm" },
+    });
+    expect(manifest.status()).toBe(200);
+    expect(manifest.headers()["docker-content-digest"]).toMatch(/^sha256:/);
+
+    const recorded = await getRecordedRequests(control);
+    const pingRecord = recorded.find((r) => r.path === "/v2/");
+    expect(pingRecord, "fixture saw /v2/ ping").toBeDefined();
+    expect(pingRecord!.headers["docker-distribution-api-version"]).toBe("registry/2.0");
+
+    const manifestRecord = recorded.find((r) => r.path === "/v2/library/alpine/manifests/latest");
+    expect(manifestRecord, "fixture saw manifest GET").toBeDefined();
+    expect(manifestRecord!.headers["authorization"]).toBe("Bearer issued-by-token-realm");
+  });
+});

--- a/e2e/suites/docker-proxy/header-forwarding.spec.ts
+++ b/e2e/suites/docker-proxy/header-forwarding.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect, request as pwRequest, type APIRequestContext } from "@playwright/test";
 
+import type { SerializedRecordedRequest } from "../../fixtures/docker-registry-fixture";
+
 /**
  * End-to-end coverage for issue #336 — verify that the Next.js middleware
  * proxy preserves Docker-Distribution-API headers in both directions.
@@ -10,13 +12,6 @@ import { test, expect, request as pwRequest, type APIRequestContext } from "@pla
  * point a real Next.js (next start) at a fixture HTTP server and observe
  * what the fixture sees and what the client receives.
  */
-
-interface RecordedRequestSerialized {
-  method: string;
-  path: string;
-  headers: Record<string, string>;
-  bodyBase64: string;
-}
 
 const FIXTURE_PORT = Number(process.env.FIXTURE_PORT ?? 4500);
 const FIXTURE_URL = `http://127.0.0.1:${FIXTURE_PORT}`;
@@ -40,10 +35,10 @@ async function resetFixture(control: APIRequestContext): Promise<void> {
 
 async function getRecordedRequests(
   control: APIRequestContext,
-): Promise<RecordedRequestSerialized[]> {
+): Promise<SerializedRecordedRequest[]> {
   const res = await control.get(`${FIXTURE_URL}/__fixture/requests`);
   expect(res.status(), "fixture requests").toBe(200);
-  return (await res.json()) as RecordedRequestSerialized[];
+  return (await res.json()) as SerializedRecordedRequest[];
 }
 
 test.describe("Docker /v2/* header forwarding through Next.js middleware", () => {
@@ -100,7 +95,6 @@ test.describe("Docker /v2/* header forwarding through Next.js middleware", () =>
       expect(res.status()).toBe(200);
 
       const recorded = await getRecordedRequests(control);
-      expect(recorded.length).toBeGreaterThanOrEqual(1);
       const seen = recorded.find((r) => r.path === path);
       expect(seen, `fixture should have observed ${path}`).toBeDefined();
       expect(seen!.headers[name.toLowerCase()]).toBe(value);

--- a/e2e/suites/docker-proxy/header-forwarding.spec.ts
+++ b/e2e/suites/docker-proxy/header-forwarding.spec.ts
@@ -172,6 +172,44 @@ test.describe("Docker /v2/* header forwarding through Next.js middleware", () =>
   }
 
   // ------------------------------------------------------------------
+  // Hop-by-hop header characterization (RFC 7230 §6.1).
+  //
+  // We don't prescribe whether the middleware proxy strips or forwards
+  // hop-by-hop headers — undici and Next's fetch internals decide. The
+  // test captures the CURRENT behavior so that if a future refactor
+  // changes it, a deliberate decision must be made. If you change this,
+  // verify production parity (e.g. docker push with HTTP/1.1 keep-alive)
+  // before flipping the assertion.
+  // ------------------------------------------------------------------
+  test("characterizes hop-by-hop request headers reaching the backend", async () => {
+    const path = "/v2/test-repo/manifests/hop-by-hop-req";
+    await setFixtureResponse(control, path, { status: 200 });
+
+    await client.get(path, {
+      headers: {
+        Connection: "close",
+        "Keep-Alive": "timeout=5",
+        TE: "trailers",
+      },
+    });
+
+    const recorded = await getRecordedRequests(control);
+    const seen = recorded.find((r) => r.path === path);
+    expect(seen).toBeDefined();
+    // Observed behavior as of 2026-05: Next.js's middleware proxy forwards
+    // hop-by-hop request headers to the backend verbatim. RFC 7230 §6.1
+    // says intermediaries SHOULD strip these (Connection, Keep-Alive, TE,
+    // and the headers named in Connection), but Next considers itself a
+    // server rather than an intermediary. The docker client doesn't depend
+    // on any of this either way, so the test pins the status quo. If a
+    // future refactor adds proper hop-by-hop stripping, update these
+    // assertions deliberately and confirm a real `docker push` still works.
+    expect(seen!.headers["connection"]).toBe("close");
+    expect(seen!.headers["keep-alive"]).toBe("timeout=5");
+    expect(seen!.headers["te"]).toBe("trailers");
+  });
+
+  // ------------------------------------------------------------------
   // Realistic flow: docker login pings /v2/, gets WWW-Authenticate,
   // then follows up to a token endpoint. This is the exact sequence
   // #1007 was trying to fix; we verify the proxy hand-off works.

--- a/e2e/suites/docker-proxy/header-forwarding.spec.ts
+++ b/e2e/suites/docker-proxy/header-forwarding.spec.ts
@@ -66,12 +66,26 @@ test.describe("Docker /v2/* header forwarding through Next.js middleware", () =>
     await resetFixture(control);
   });
 
+  // The fixture instance is shared by all tests in this describe; per-test
+  // isolation depends on `workers: 1` + `fullyParallel: false` in
+  // playwright-docker-proxy.config.ts plus the `beforeEach(reset)` above.
+  // If parallelism is ever enabled, these tests would observe each other's
+  // recorded requests — flip the spec to filter by a per-test correlation
+  // header (e.g. `x-test-id`) before relaxing the worker count.
+
   // ------------------------------------------------------------------
-  // Request headers (web --> backend) — issue #336
+  // Request headers (web --> backend) — issue #336.
+  //
+  // Note on Content-Length: it isn't covered here because Next.js's fetch
+  // path recomputes it for the upstream request — asserting a literal value
+  // tests undici, not the middleware. The body-bearing POST test below
+  // covers Content-Length forwarding indirectly (length implied by body).
   // ------------------------------------------------------------------
   const requestHeaderCases: Array<{ name: string; value: string }> = [
+    // Lock-in: middleware MUST forward Authorization for Docker login to
+    // work. If a future hardening pass strips auth defensively, replace
+    // this assertion with a path-allow-list check rather than removing it.
     { name: "Authorization", value: "Bearer test-token-abc123" },
-    { name: "Content-Length", value: "0" },
     { name: "Content-Range", value: "bytes 0-1023/2048" },
     { name: "Content-Type", value: "application/vnd.docker.distribution.manifest.v2+json" },
     { name: "Docker-Distribution-API-Version", value: "registry/2.0" },
@@ -92,6 +106,42 @@ test.describe("Docker /v2/* header forwarding through Next.js middleware", () =>
       expect(seen!.headers[name.toLowerCase()]).toBe(value);
     });
   }
+
+  // ------------------------------------------------------------------
+  // Body forwarding on PATCH blob upload — exercises the realistic Docker
+  // push code path. This is where Content-Length and Content-Range matter:
+  // the Docker client streams blob chunks via PATCH /v2/<name>/blobs/uploads/<uuid>
+  // with `Content-Range: bytes <start>-<end>/<total>`. If middleware drops
+  // either header (or mangles the body), the upload never completes.
+  // ------------------------------------------------------------------
+  test("forwards request body, Content-Length, and Content-Range on PATCH blob upload", async () => {
+    const path = "/v2/test-repo/blobs/uploads/blob-upload-uuid-1";
+    await setFixtureResponse(control, path, {
+      status: 202,
+      headers: { "Docker-Upload-UUID": "blob-upload-uuid-1", Range: "0-1023" },
+    });
+
+    const chunk = Buffer.alloc(1024, 0xab);
+    const res = await client.fetch(path, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/octet-stream",
+        "Content-Range": "bytes 0-1023/2048",
+      },
+      data: chunk,
+    });
+    expect(res.status()).toBe(202);
+
+    const recorded = await getRecordedRequests(control);
+    const seen = recorded.find((r) => r.path === path);
+    expect(seen, `fixture should have observed ${path}`).toBeDefined();
+    expect(seen!.method).toBe("PATCH");
+    expect(seen!.headers["content-range"]).toBe("bytes 0-1023/2048");
+    // Content-Length is set by the HTTP layer; assert it's a positive number
+    // matching the body length rather than a literal string we passed.
+    expect(Number(seen!.headers["content-length"])).toBe(chunk.length);
+    expect(Buffer.from(seen!.bodyBase64, "base64").length).toBe(chunk.length);
+  });
 
   // ------------------------------------------------------------------
   // Response headers (backend --> web --> client) — issue #336

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,7 @@ const eslintConfig = defineConfig([
     "next-env.d.ts",
     // Git worktrees, test reports, and coverage output
     ".worktrees/**",
+    ".claude/worktrees/**",
     "playwright-report/**",
     "coverage/**",
   ]),

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:ci": "playwright test --reporter=github",
     "test:e2e:docs-export": "npx tsx e2e/scripts/generate-docs-manifest.ts",
+    "test:e2e:docker-proxy": "playwright test --config playwright-docker-proxy.config.ts",
     "tutorial:record": "playwright test --config playwright-tutorials.config.ts",
     "tutorial:record:one": "playwright test --config playwright-tutorials.config.ts -g",
     "tutorial:manifest": "npx tsx e2e/tutorials/scripts/generate-manifest.ts",

--- a/playwright-docker-proxy.config.ts
+++ b/playwright-docker-proxy.config.ts
@@ -46,7 +46,10 @@ export default defineConfig({
       // output: standalone" warning emitted at startup is benign for our
       // purposes: middleware still runs and rewrites are followed; the
       // warning concerns asset/image caching paths which we don't exercise.
-      command: `npm run build && npx next start --port ${WEB_PORT}`,
+      // --hostname 127.0.0.1 keeps the Next process off the runner's external
+      // interfaces — no reason for this short-lived test server to be reachable
+      // beyond loopback.
+      command: `npm run build && npx next start --hostname 127.0.0.1 --port ${WEB_PORT}`,
       url: BASE_URL,
       reuseExistingServer: !process.env.CI,
       timeout: 240_000,

--- a/playwright-docker-proxy.config.ts
+++ b/playwright-docker-proxy.config.ts
@@ -1,0 +1,59 @@
+import { defineConfig } from "@playwright/test";
+
+/**
+ * Dedicated config for issue #336 — exercises the Docker /v2/* middleware
+ * proxy against a fixture HTTP backend (no real registry, no docker daemon).
+ *
+ * Boots two processes via `webServer`:
+ *   1. The fixture HTTP server on FIXTURE_PORT (acts as the "backend").
+ *   2. A real Next.js production server (next start) with BACKEND_URL
+ *      pointing at the fixture, so middleware rewrites land there.
+ *
+ * Kept separate from playwright.config.ts because that config's webServer
+ * (currently none) and project setup target the docker-compose stack with
+ * the real backend; this suite intentionally bypasses the backend.
+ */
+
+const FIXTURE_PORT = Number(process.env.FIXTURE_PORT ?? 4500);
+const WEB_PORT = Number(process.env.DOCKER_PROXY_WEB_PORT ?? 3001);
+const BASE_URL = `http://127.0.0.1:${WEB_PORT}`;
+
+export default defineConfig({
+  testDir: "./e2e/suites/docker-proxy",
+  fullyParallel: false,
+  workers: 1,
+  retries: process.env.CI ? 1 : 0,
+  forbidOnly: !!process.env.CI,
+  reporter: [["list"]],
+  expect: { timeout: 10_000 },
+  timeout: 30_000,
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+  },
+  webServer: [
+    {
+      command: `npx tsx e2e/fixtures/run-docker-registry-fixture.ts`,
+      url: `http://127.0.0.1:${FIXTURE_PORT}/__fixture/requests`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 30_000,
+      env: { FIXTURE_PORT: String(FIXTURE_PORT) },
+    },
+    {
+      // `next start` (not `next dev`) — middleware behavior under dev mode
+      // diverges from production; this suite exists specifically to verify
+      // the production rewrite path. The "next start does not work with
+      // output: standalone" warning emitted at startup is benign for our
+      // purposes: middleware still runs and rewrites are followed; the
+      // warning concerns asset/image caching paths which we don't exercise.
+      command: `npm run build && npx next start --port ${WEB_PORT}`,
+      url: BASE_URL,
+      reuseExistingServer: !process.env.CI,
+      timeout: 240_000,
+      env: {
+        BACKEND_URL: `http://127.0.0.1:${FIXTURE_PORT}`,
+        NODE_ENV: "production",
+      },
+    },
+  ],
+});

--- a/playwright-docker-proxy.config.ts
+++ b/playwright-docker-proxy.config.ts
@@ -40,22 +40,22 @@ export default defineConfig({
       env: { FIXTURE_PORT: String(FIXTURE_PORT) },
     },
     {
-      // `next start` (not `next dev`) — middleware behavior under dev mode
-      // diverges from production; this suite exists specifically to verify
-      // the production rewrite path. The "next start does not work with
-      // output: standalone" warning emitted at startup is benign for our
-      // purposes: middleware still runs and rewrites are followed; the
-      // warning concerns asset/image caching paths which we don't exercise.
-      // --hostname 127.0.0.1 keeps the Next process off the runner's external
-      // interfaces — no reason for this short-lived test server to be reachable
-      // beyond loopback.
-      command: `npm run build && npx next start --hostname 127.0.0.1 --port ${WEB_PORT}`,
+      // Run the standalone server (`node .next/standalone/server.js`) — same
+      // entry point the production Docker image uses. `next start` was the
+      // initial choice but it explicitly does not work with
+      // `output: "standalone"` (see next.config.ts) and may exercise a
+      // different middleware/proxy code path than production. HOSTNAME is
+      // pinned to 127.0.0.1 so the test server isn't reachable beyond
+      // loopback on shared CI runners.
+      command: `npm run build && node .next/standalone/server.js`,
       url: BASE_URL,
-      reuseExistingServer: !process.env.CI,
+      reuseExistingServer: false,
       timeout: 240_000,
       env: {
         BACKEND_URL: `http://127.0.0.1:${FIXTURE_PORT}`,
         NODE_ENV: "production",
+        PORT: String(WEB_PORT),
+        HOSTNAME: "127.0.0.1",
       },
     },
   ],


### PR DESCRIPTION
## Summary

Adds a Playwright e2e suite that asserts the Next.js middleware proxy preserves Docker registry headers in both directions when proxying `/v2/*` to the backend. Closes #336.

- New fixture HTTP server at `e2e/fixtures/docker-registry-fixture.ts` with a control plane (`/__fixture/{requests,reset,responses}`) and registry plane.
- New spec at `e2e/suites/docker-proxy/header-forwarding.spec.ts` — 12 tests covering all 9 headers from the issue plus a PATCH blob-upload body case, a hop-by-hop characterization test, and a realistic docker-login flow.
- New `playwright-docker-proxy.config.ts` that boots the fixture and a real Next.js standalone server (same entry point as the production Docker image) via `webServer`.
- New CI job `e2e-docker-proxy` in `.github/workflows/ci.yml` — no docker compose stack, no chromium install (request API only).

## Why

Unit tests only verify `NextResponse.rewrite()` is called with the right URL. They cannot verify what Next.js does at runtime when it follows that rewrite — specifically whether Docker-required headers (Authorization, WWW-Authenticate, Docker-Content-Digest, Docker-Upload-UUID, Range, Location, Content-Range, etc.) survive the proxy. This surfaced during the round-3 adversarial review of #1007.

## Review process

Three rounds, per the team-of-four / three-round process:

- **R1 build** — SWE agent built the fixture + spec + config + CI job. Three parallel reviewers (Test/DevOps/Security) flagged: Content-Length-on-GET tested undici not middleware; document `workers=1` invariant; tighten fixture launcher shutdown; bind Next to 127.0.0.1; drop unused chromium install. All addressed in `b109161`.
- **R2 simplifier + gates** — code-simplifier removed 7 lines (deduplicated `RecordedRequestSerialized`, inlined a single-use helper, dropped a redundant assertion). Lint clean; 11/11 e2e pass. Also fixed an eslint ignore so it no longer scans agent worktrees. (`b1029d9`, `22aba6d`)
- **R3 adversarial** — fresh-eyes reviewer found the spec was running against `next start` instead of the production standalone server, which can exercise a different middleware code path. Switched to `node .next/standalone/server.js`. Also added a hop-by-hop characterization test — finding: Next.js currently forwards `Connection`, `Keep-Alive`, and `TE` to the backend verbatim, contrary to RFC 7230 §6.1 (the docker client doesn't depend on this either way; test pins the status quo). (`eeaab1b`)

## Test plan

- [x] `npm run test:e2e:docker-proxy` — 12/12 pass against standalone server
- [x] `npm run lint` — 0 errors (33 pre-existing warnings unchanged)
- [x] `npm test` — vitest unaffected
- [x] All 9 headers called out in #336 covered (5 request + 5 response — Content-Length covered indirectly via PATCH body length)
- [x] Production parity: spec runs the same standalone server entry point as the Docker image
- [x] CI integration tested locally; e2e-docker-proxy job is self-contained (no docker compose, no chromium)

## Acceptance criteria (from #336)

- [x] Playwright e2e test under `e2e/suites/` exercises `/v2/*` through middleware
- [x] Each request header in the issue verified at the fixture
- [x] Each response header verified at the client
- [x] Test runs in CI

## Findings worth noting

- Next.js's middleware proxy currently forwards hop-by-hop headers (`Connection`, `Keep-Alive`, `TE`) to the backend. Not a bug we hit today — flagging as a future hardening lead.
- `next start` does not work with `output: "standalone"`. The original config was running the test against a different code path than production; fixed in R3.

## Follow-ups

- Reuse the build artifact across the four e2e CI jobs (each currently re-runs `npm run build`).
- Streaming-body upload test (Transfer-Encoding: chunked) for blob uploads larger than the buffered body case.
- Consider a real `docker push` via subprocess for the strongest interpretation of #336 (issue allows fixture, but real client is the gold standard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)