### PR TITLE
ci(release): add release/1.1.x branch + :1.1-dev tag rule + v1.1.8 postmortem

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Docker Publish
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release/1.1.x']
     tags: ['v*']
   workflow_dispatch:
     inputs:
@@ -131,6 +131,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.1-dev,enable=${{ github.ref == format('refs/heads/{0}', 'release/1.1.x') }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
@@ -146,6 +147,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.1-dev,enable=${{ github.ref == format('refs/heads/{0}', 'release/1.1.x') }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,6 +12,11 @@ pull_request_rules:
       - check-success=build
       - check-success=e2e
       - "#approved-reviews-by>=1"
+      # Scope auto-merge to PRs targeting main only. Maintenance branches
+      # (release/1.1.x and similar) overwrite floating dev tags on push,
+      # so dependency bumps onto them must go through human review even
+      # if they pass CI. See #320 / #331.
+      - base=main
     actions:
       queue:
         name: default

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -31,6 +31,16 @@ pull_request_rules:
           - needs-review
           - major-update
 
+  - name: Flag Dependabot PRs targeting maintenance branches
+    conditions:
+      - author=dependabot[bot]
+      - "base!=main"
+    actions:
+      label:
+        add:
+          - needs-review
+          - maintenance-branch
+
   - name: Require E2E for page changes
     conditions:
       - "files~=^src/app/"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **`release/1.1.x` maintenance branch + `:1.1-dev` Docker tag rule** (#331) - mirrors `artifact-keeper#890`; pushes to `release/1.1.x` now publish `ghcr.io/artifact-keeper/artifact-keeper-web:1.1-dev` so the v1.1.x release-gate can test a true v1.1.x web/backend pair.
+
+### Notes
+- **v1.1.8 web image is permanently unavailable** (#320) - the web release process stopped at v1.1.3 while the backend continued through v1.1.8. There is no v1.1.8 source ref to rebuild from; backfilling would falsify provenance. See [docs/release-history/v1.1.8-web-postmortem.md](docs/release-history/v1.1.8-web-postmortem.md). Recurrence is prevented by `artifact-keeper#882` (image-publish gate).
+
 ## [1.1.0] - 2026-04-19
 
 First stable release of Artifact Keeper Web. Platform parity with `artifact-keeper` 1.1.0 backend. Consolidates `1.1.0-rc.5` through `1.1.0-rc.9` and post-RC work.

--- a/docs/release-history/v1.1.8-web-postmortem.md
+++ b/docs/release-history/v1.1.8-web-postmortem.md
@@ -29,18 +29,23 @@ That assumption broke. The version tag history of `artifact-keeper-web` is:
 | v1.1.3     | 304cb71a    | lightweight | 2026-04-20 17:56:24 -0500   |
 
 (Note that v1.1.1 sorts before v1.1.0 by creator date — both point at
-the same SHA. v1.1.1 appears to be a lightweight tag created in error
-four minutes before the annotated v1.1.0 on the same commit. This is a
-separate process anomaly worth flagging — the rest of the v1.1.x
-sequence are all lightweight tags, which means there is no signed
-release boundary on the web repo at all from v1.1.1 onward.)
+the same SHA. v1.1.1 was either an erroneous duplicate or a deliberate
+retag whose stale lightweight tag was never cleaned up after the
+annotated v1.1.0 was created four minutes later. The intent is no
+longer recoverable. Either way, v1.1.2 and v1.1.3 are also lightweight
+tags, which means there is no signed release boundary on the web repo
+from v1.1.1 onward — a separate hygiene issue not addressed here.)
 
 There is **no `v1.1.4`, `v1.1.5`, ... `v1.1.8`, or `v1.1.9` tag** in this
 repo. `package.json` is currently at `1.1.3`. The web release process
 effectively stopped at v1.1.3 while the backend continued through v1.1.4,
 v1.1.5, v1.1.6, v1.1.7, v1.1.8 (and now v1.1.9). **The v1.1.4 through
 v1.1.7 web tags are accepted as a permanent gap** — there is no plan to
-backfill any of them either.
+backfill any of them either. (If a CVE forces a v1.1.x patch before
+v1.1.9 ships, cut v1.1.4 from the v1.1.3 SHA on `release/1.1.x` — the
+gap above v1.1.3 is reservable, not poisoned. The "do not backfill"
+decision below applies specifically to v1.1.8 because the *backend* has
+already shipped under that tag.)
 
 `gh run list --workflow docker-publish.yml --limit 50` confirms the same
 picture from the workflow side: there are no runs triggered by a `v1.1.8`

--- a/docs/release-history/v1.1.8-web-postmortem.md
+++ b/docs/release-history/v1.1.8-web-postmortem.md
@@ -1,0 +1,99 @@
+# Postmortem: v1.1.8 web image never published
+
+**Issue:** https://github.com/artifact-keeper/artifact-keeper-web/issues/320
+**Date written:** 2026-05-04
+**Status:** Resolved (documented, not backfilled)
+
+## Summary
+
+`ghcr.io/artifact-keeper/artifact-keeper-web:1.1.8` does not exist. The
+Helm chart for backend v1.1.8 references this image, so fresh installs of
+the v1.1.8 chart fail with `ImagePullBackOff` on the web component.
+
+## Root cause
+
+The backend repo (`artifact-keeper`) and the web repo (`artifact-keeper-web`)
+ship as independent Git repos, each with its own tag history and Docker
+publish workflow. The Helm chart in the backend repo pins both `backend.tag`
+and `web.tag` to the same value by default, on the assumption that the two
+repos cut matching version tags.
+
+That assumption broke. The version tag history of `artifact-keeper-web` is:
+
+| Tag        | Commit SHA                                | Created           |
+|------------|-------------------------------------------|-------------------|
+| v1.1.0-rc.1 to rc.9 | (various)                        | 2026-02 to 04     |
+| v1.1.0     | f7b32f6143fbb1a1df9519945cd4f640be6c11bd  | 2026-04-19        |
+| v1.1.1     | f7b32f6143fbb1a1df9519945cd4f640be6c11bd  | 2026-04-20        |
+| v1.1.2     | 8b10b104aac0ce5bc323b6bee77a754f6fa3d76e  | 2026-04-20        |
+| v1.1.3     | 304cb71a22921855217e8612f2b5a813eeae22ca  | 2026-04-20        |
+
+There is **no `v1.1.4`, `v1.1.5`, ... `v1.1.8`, or `v1.1.9` tag** in this
+repo. `package.json` is currently at `1.1.3`. The web release process
+effectively stopped at v1.1.3 while the backend continued through v1.1.4,
+v1.1.5, v1.1.6, v1.1.7, v1.1.8 (and now v1.1.9).
+
+`gh run list --workflow docker-publish.yml --limit 50` confirms the same
+picture from the workflow side: there are no runs triggered by a `v1.1.8`
+tag push, because no such tag exists. The publish workflow did not "fail
+to run for v1.1.8" — it was never invited.
+
+The chart's Helm values for v1.1.8 still pin `web.tag: 1.1.8` because that
+is the chart's default convention. Pulling that image gives 404, hence the
+`ImagePullBackOff` reported in #320.
+
+## Why it happened
+
+- No release-train automation forces the web repo to cut a tag for every
+  backend tag. The two repos drift independently.
+- The Helm chart has no defensive default like `web.tag: latest` or
+  fall-through to the latest available web version.
+- There is no image-publish gate in the release workflow that would catch
+  a pinned-but-missing image at release time. That gate is tracked in
+  `artifact-keeper#882`.
+
+## Decision
+
+**Do not backfill `ghcr.io/.../artifact-keeper-web:1.1.8`.**
+
+Reasoning:
+
+1. There is no `v1.1.8` source ref in this repo to build from. The closest
+   "what should have been v1.1.8" is `v1.1.3` (commit
+   `304cb71a22921855217e8612f2b5a813eeae22ca`), but synthesizing a
+   `:1.1.8` tag from a `v1.1.3` source ref would create a permanent
+   provenance lie: the image labels, attestations, and SBOM would all
+   point at v1.1.3 while the tag claims v1.1.8.
+2. The backend v1.1.8 chart is already in users' hands and any backfilled
+   image would not match the integrity expectations the chart was built
+   under.
+3. The fix is forward, not backward: ship the next stable web tag and
+   re-pin the chart to it.
+
+**Action taken:**
+
+- Document v1.1.8 web as permanently unrecoverable (this file).
+- Note in the changelog that v1.1.8 web was never published.
+- The next web stable tag should be `v1.1.9`, cut from current `main` (or
+  from the new `release/1.1.x` branch introduced in #331), so the v1.1.9
+  chart can pin a real `web:1.1.9` image.
+
+## Prevention
+
+The longer-term gate is `artifact-keeper#882` — a release-time check that
+fails the release if any image referenced by the chart is not resolvable
+on the registry. That work is not in scope for this PR but is the correct
+place to prevent recurrence.
+
+The companion change in `artifact-keeper-web#331` (this PR) adds a
+`release/1.1.x` branch and a `:1.1-dev` floating tag, so the v1.1.x
+release-gate can stop relying on the `:dev` tag (which floats with `main`)
+and instead test against a true v1.1.x web image.
+
+## Related
+
+- artifact-keeper-web#331 — `release/1.1.x` branch + `:1.1-dev` tag rule
+- artifact-keeper#882 — image-publish gate (prevent recurrence)
+- artifact-keeper#886 — v1.1.9 stability release tracking
+- artifact-keeper#890 — backend-side `release/1.1.x` + `:1.1-dev` rule
+  (the pattern this mirrors)

--- a/docs/release-history/v1.1.8-web-postmortem.md
+++ b/docs/release-history/v1.1.8-web-postmortem.md
@@ -20,18 +20,27 @@ repos cut matching version tags.
 
 That assumption broke. The version tag history of `artifact-keeper-web` is:
 
-| Tag        | Commit SHA                                | Created           |
-|------------|-------------------------------------------|-------------------|
-| v1.1.0-rc.1 to rc.9 | (various)                        | 2026-02 to 04     |
-| v1.1.0     | f7b32f6143fbb1a1df9519945cd4f640be6c11bd  | 2026-04-19        |
-| v1.1.1     | f7b32f6143fbb1a1df9519945cd4f640be6c11bd  | 2026-04-20        |
-| v1.1.2     | 8b10b104aac0ce5bc323b6bee77a754f6fa3d76e  | 2026-04-20        |
-| v1.1.3     | 304cb71a22921855217e8612f2b5a813eeae22ca  | 2026-04-20        |
+| Tag        | Commit SHA  | Tag type    | Creator date (creatordate)  |
+|------------|-------------|-------------|-----------------------------|
+| v1.1.0-rc.1 to rc.9 | (various) | (mixed)  | 2026-02 to 04               |
+| v1.1.1     | f7b32f61    | lightweight | 2026-04-19 14:42:52 -0500   |
+| v1.1.0     | f7b32f61    | annotated   | 2026-04-19 14:46:10 -0500   |
+| v1.1.2     | 8b10b104    | lightweight | 2026-04-20 17:36:25 -0500   |
+| v1.1.3     | 304cb71a    | lightweight | 2026-04-20 17:56:24 -0500   |
+
+(Note that v1.1.1 sorts before v1.1.0 by creator date — both point at
+the same SHA. v1.1.1 appears to be a lightweight tag created in error
+four minutes before the annotated v1.1.0 on the same commit. This is a
+separate process anomaly worth flagging — the rest of the v1.1.x
+sequence are all lightweight tags, which means there is no signed
+release boundary on the web repo at all from v1.1.1 onward.)
 
 There is **no `v1.1.4`, `v1.1.5`, ... `v1.1.8`, or `v1.1.9` tag** in this
 repo. `package.json` is currently at `1.1.3`. The web release process
 effectively stopped at v1.1.3 while the backend continued through v1.1.4,
-v1.1.5, v1.1.6, v1.1.7, v1.1.8 (and now v1.1.9).
+v1.1.5, v1.1.6, v1.1.7, v1.1.8 (and now v1.1.9). **The v1.1.4 through
+v1.1.7 web tags are accepted as a permanent gap** — there is no plan to
+backfill any of them either.
 
 `gh run list --workflow docker-publish.yml --limit 50` confirms the same
 picture from the workflow side: there are no runs triggered by a `v1.1.8`
@@ -70,13 +79,58 @@ Reasoning:
 3. The fix is forward, not backward: ship the next stable web tag and
    re-pin the chart to it.
 
+**Alternatives considered and rejected:**
+
+- *Tombstone manifest at `:1.1.8`* — publish a manifest that immediately
+  errors with a clear "this tag was never released" message. Rejected:
+  there is no Docker registry primitive for an "intentionally broken"
+  tag; any manifest we publish gets pulled and the user sees a runtime
+  error instead of `ImagePullBackOff`. The current 404 is in fact a
+  clearer signal than a fabricated tombstone.
+- *`:1.1.8-mitigation` floating tag pointing at a v1.1.3 build* — same
+  provenance objection as backfill, with extra confusion about which
+  tag is canonical.
+- *Chart-side hotfix re-pinning `web.tag = 1.1.3` in a v1.1.8.1 chart* —
+  this lives in the backend repo's chart code, not here. Tracked
+  separately in `artifact-keeper#886` (v1.1.9 release tracking) where
+  the next chart will pin a real v1.1.9 web image.
+
 **Action taken:**
 
 - Document v1.1.8 web as permanently unrecoverable (this file).
 - Note in the changelog that v1.1.8 web was never published.
-- The next web stable tag should be `v1.1.9`, cut from current `main` (or
-  from the new `release/1.1.x` branch introduced in #331), so the v1.1.9
-  chart can pin a real `web:1.1.9` image.
+- The next web stable tag should be `v1.1.9`, cut from the new
+  `release/1.1.x` branch introduced in #331 (preferred — keeps
+  v1.1.x maintenance separate from `main`'s drift). The v1.1.9 chart
+  will then pin a real `web:1.1.9` image.
+
+## Workaround for affected operators
+
+If a fresh install or upgrade landed on the v1.1.8 chart and you are
+hitting `ImagePullBackOff` on the web component:
+
+```sh
+# Pin the web image explicitly to the last known-good v1.1.x web tag
+# until v1.1.9 ships.
+helm upgrade <release> <chart> --reuse-values \
+  --set web.image.tag=1.1.3
+```
+
+Caveats:
+
+- v1.1.3 web does not contain the changes that landed in backend v1.1.4
+  through v1.1.8. If the chart's web/backend pairing assumes a feature
+  parity (e.g. SDK contract changes), the UI may misbehave. None of the
+  v1.1.4-v1.1.8 backend changes broke the frontend's API surface in a
+  way we know of, so this should be cosmetic in practice.
+- The floating `:dev` tag (which tracks `main`) and, once cut, the
+  `:1.1-dev` tag (this PR — tracks `release/1.1.x`) are alternatives,
+  but they are intentionally **mutable** — not appropriate for
+  production pinning. They exist for the release-gate, not for
+  end-user installs.
+
+When v1.1.9 ships, switch back to `--set web.image.tag=1.1.9` (or
+remove the override and consume the chart default).
 
 ## Prevention
 
@@ -88,12 +142,20 @@ place to prevent recurrence.
 The companion change in `artifact-keeper-web#331` (this PR) adds a
 `release/1.1.x` branch and a `:1.1-dev` floating tag, so the v1.1.x
 release-gate can stop relying on the `:dev` tag (which floats with `main`)
-and instead test against a true v1.1.x web image.
+and instead test against a true v1.1.x web image. **`:1.1-dev` is a
+mutable floating tag** intended only for the release-gate. It is not
+appropriate for chart pinning or user installs; charts should pin a
+specific `:1.1.x` semver tag.
+
+Operational note: the `release/1.1.x` branch should be created with
+branch protection (require PR + review + status checks) **before** any
+push to it, since pushes to that branch overwrite `:1.1-dev`. The same
+trust model applies as the existing `:dev` tag on `main`.
 
 ## Related
 
 - artifact-keeper-web#331 — `release/1.1.x` branch + `:1.1-dev` tag rule
 - artifact-keeper#882 — image-publish gate (prevent recurrence)
 - artifact-keeper#886 — v1.1.9 stability release tracking
-- artifact-keeper#890 — backend-side `release/1.1.x` + `:1.1-dev` rule
-  (the pattern this mirrors)
+- artifact-keeper#890 (PR) — backend-side `release/1.1.x` + `:1.1-dev`
+  rule (the pattern this mirrors)


### PR DESCRIPTION
## Summary

Closes **#331**: adds `release/1.1.x` to `.github/workflows/docker-publish.yml`'s push triggers and a `:1.1-dev` raw tag rule that fires on push to that branch (in both ghcr.io and Docker Hub metadata steps). Mirrors backend-side `artifact-keeper#890`.

Closes **#320**: postmortem at `docs/release-history/v1.1.8-web-postmortem.md` with root cause, decision (don't backfill, roll forward to v1.1.9), operator workaround, and prevention pointer.

Bonus hardening prompted by R1 security review:
- Mergify auto-merge for Dependabot is now scoped to `base=main`. PRs to maintenance branches get a `needs-review` + `maintenance-branch` label instead.

## Why

Two related symptoms:

- The release-gate v1.1.9 smoke test deployed the chart with `web_tag=1.1-dev`, which produced `ImagePullBackOff` because `:1.1-dev` doesn't exist on web (#331).
- Same root cause is also why v1.1.8 web is missing on ghcr.io: the web release process stopped at v1.1.3 while the backend continued. The chart's default `web.tag = backend.tag` blindly produced `web:1.1.8`, and that image never existed (#320).

## Review process

Three rounds, per the team-of-four / three-round process:

- **R1 build** — SWE agent built the workflow change, postmortem, and CHANGELOG entry. Three parallel reviewers (DevOps / Release-eng / Security):
  - DevOps: ship.
  - Security: ship + minors (mutable-tag note, mergify scope).
  - Release-eng: fix-then-ship — tag dates were the *push* dates not creator dates; missing operator workaround; v1.1.1 is a lightweight tag (separate hygiene issue). All addressed in `c5f08b3`.
- **R2 gates** — YAML parses cleanly via Python yaml.safe_load; both `:1.1-dev` rules present (ghcr + Docker Hub); lint clean (0 errors); 1897/1897 unit tests pass.
- **R3 adversarial** — fresh-eyes reviewer identified 1 blocker (branch creation deferred — not in scope here; see "Deferred" below), 1 latent major (`merge.outputs.version` resolves to branch ref not `:1.1-dev` — no current consumer reads it on branch pushes; filing as follow-up if it bites), and several worthwhile minors addressed in `7ad1b05`: soften v1.1.1 framing, add CVE-path-forward sentence, label Dependabot PRs to maintenance branches.

## Deferred (shared-state actions for the user)

These are intentionally **not** done in this PR:

1. **Cut `release/1.1.x` branch** from `v1.1.3` (commit `304cb71a`). Required for AC#1 of #331. The branch should be created with branch protection (require PR + 1 review + status checks) **before** any push to it — once it exists, pushes overwrite `:1.1-dev`.
2. **First push to `release/1.1.x`** that fires the publish workflow and produces the first `:1.1-dev` web image. Required for AC#3/#4.
3. **Re-running the v1.1.8 release**: the postmortem documents that this is intentionally not done — the recommendation is to roll forward to v1.1.9 cut from `release/1.1.x`.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docker-publish.yml'))"` — YAML valid
- [x] Both `1.1-dev` rule occurrences present (ghcr + Docker Hub metadata blocks)
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 1897/1897 pass
- [x] `enable` predicate walked through for every event type (tag push, PR, workflow_dispatch, push to main, push to release/1.1.x): only the last produces `:1.1-dev`. `:dev` and `:latest` rules unaffected.
- [x] Operator workaround `helm upgrade --set web.image.tag=1.1.3` verified — v1.1.3 web image exists on ghcr.io (200 on manifest probe), v1.1.4-1.1.8 confirmed 404.

## Acceptance criteria

**#331:**
- [ ] `release/1.1.x` branch exists on this repo — **deferred to user (shared-state)**
- [x] `docker-publish.yml` builds `:1.1-dev` on push to that branch — **workflow ready**
- [ ] `:1.1-dev` resolvable on ghcr.io — **deferred (depends on #1)**
- [ ] Release-gate can use `web_tag=1.1-dev` — **deferred (depends on #3)**

**#320:**
- [x] Root cause identified
- [x] Documented decision: 1.1.8 is permanently unavailable; roll forward to 1.1.9
- [x] Recurrence prevention referenced (`artifact-keeper#882`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)