### PR TITLE
chore: bump react-hook-form from 7.72.1 to 7.74.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "radix-ui": "^1.4.3",
         "react": "19.2.5",
         "react-dom": "19.2.5",
-        "react-hook-form": "^7.74.0",
+        "react-hook-form": "^7.75.0",
         "react-markdown": "^10.1.0",
         "react-qr-code": "^2.0.18",
         "react-resizable-panels": "^4.10.0",
@@ -12604,9 +12604,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.74.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.74.0.tgz",
-      "integrity": "sha512-yR6wHr99p9wFv686jhRWVSFhUvDvNbdUf2dKlbno8/VKOCuoNobDGC6S+M2dua9A9Yo8vpcrp8assIYbsZCQ9g==",
+      "version": "7.75.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.75.0.tgz",
+      "integrity": "sha512-Ovv94H+0p3sJ7B9B5QxPuCP1u8V/cHuVGyH55cSwodYDtoJwK+fqk3vjfIgSX59I2U/bU4z0nRJ9HMLpNiWEmw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,9 @@
         "next": "16.2.4",
         "next-themes": "^0.4.6",
         "radix-ui": "^1.4.3",
-        "react": "^19.2.5",
-        "react-dom": "^19.2.5",
-        "react-hook-form": "^7.72.1",
+        "react": "19.2.5",
+        "react-dom": "19.2.5",
+        "react-hook-form": "^7.74.0",
         "react-markdown": "^10.1.0",
         "react-qr-code": "^2.0.18",
         "react-resizable-panels": "^4.10.0",
@@ -12604,9 +12604,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.72.1",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.1.tgz",
-      "integrity": "sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==",
+      "version": "7.74.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.74.0.tgz",
+      "integrity": "sha512-yR6wHr99p9wFv686jhRWVSFhUvDvNbdUf2dKlbno8/VKOCuoNobDGC6S+M2dua9A9Yo8vpcrp8assIYbsZCQ9g==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.5",
     "react-dom": "19.2.5",
-    "react-hook-form": "^7.74.0",
+    "react-hook-form": "^7.75.0",
     "react-markdown": "^10.1.0",
     "react-qr-code": "^2.0.18",
     "react-resizable-panels": "^4.10.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.5",
     "react-dom": "19.2.5",
-    "react-hook-form": "^7.72.1",
+    "react-hook-form": "^7.74.0",
     "react-markdown": "^10.1.0",
     "react-qr-code": "^2.0.18",
     "react-resizable-panels": "^4.10.0",


### PR DESCRIPTION
Closes #323 — recreated cleanly off main since the original dependabot branch had conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)