### PR TITLE
refactor: extract mutationErrorToast helper to deduplicate ~120 callsites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`release/1.1.x` maintenance branch + `:1.1-dev` Docker tag rule** (#331) - mirrors `artifact-keeper#890`; pushes to `release/1.1.x` now publish `ghcr.io/artifact-keeper/artifact-keeper-web:1.1-dev` so the v1.1.x release-gate can test a true v1.1.x web/backend pair.
 
 ### Changed
+- **Extract `mutationErrorToast` helper to deduplicate ~125 mutation `onError` callsites** (#354) - the pattern `onError: (err) => toast.error(toUserMessage(err, "Failed to <action>"))` was repeated across most pages; collapsed to `onError: mutationErrorToast("Failed to <action>")` in 36 files (-145 LOC). Centralizes future tweaks (HTTP status prefix, truncation, telemetry) to one place. User-visible toast strings are unchanged.
 - **Type-safe API layer — replace double-casts with adapters and zod** (#206) - removed all `as unknown as T` and `as never` casts in 15 of `src/lib/api/*.ts` files. Each SDK call now goes through an adapter function or a Set-backed narrowing helper that warns on unknown enum values. `assertData` (new in `fetch.ts`) rejects empty body responses with a contextual error. `settings.ts` uses zod `.safeParse()` at the trust boundary for `getPasswordPolicy`/`getSmtpConfig`. Public `xxxApi` return types unchanged so consumer code is untouched.
 
 ### Fixed

--- a/src/app/(app)/(admin)/analytics/page.tsx
+++ b/src/app/(app)/(admin)/analytics/page.tsx
@@ -15,7 +15,7 @@ import {
 } from "lucide-react";
 import { useAuth } from "@/providers/auth-provider";
 import analyticsApi from "@/lib/api/analytics";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import { formatBytes, formatDate } from "@/lib/utils";
 import { PageHeader } from "@/components/common/page-header";
 import { StatCard } from "@/components/common/stat-card";
@@ -40,7 +40,6 @@ import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertTitle } from "@/components/ui/alert";
-
 
 export default function AnalyticsPage() {
   const { user } = useAuth();
@@ -84,9 +83,7 @@ export default function AnalyticsPage() {
       queryClient.invalidateQueries({ queryKey: ["analytics-growth"] });
       queryClient.invalidateQueries({ queryKey: ["analytics-trend"] });
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to capture snapshot"));
-    },
+    onError: mutationErrorToast("Failed to capture snapshot"),
   });
 
   if (!user?.is_admin) {

--- a/src/app/(app)/(admin)/approvals/page.tsx
+++ b/src/app/(app)/(admin)/approvals/page.tsx
@@ -16,7 +16,7 @@ import {
 import { toast } from "sonner";
 import { useAuth } from "@/providers/auth-provider";
 import approvalsApi from "@/lib/api/approvals";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import type { ApprovalRequest } from "@/types/promotion";
 import { APPROVAL_STATUS_COLORS } from "@/types/promotion";
 import { formatDate } from "@/lib/utils";
@@ -166,9 +166,7 @@ export default function ApprovalsPage() {
       queryClient.invalidateQueries({ queryKey: ["approvals"] });
       resetActionDialog();
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to approve request"));
-    },
+    onError: mutationErrorToast("Failed to approve request"),
   });
 
   const rejectMutation = useMutation({
@@ -179,9 +177,7 @@ export default function ApprovalsPage() {
       queryClient.invalidateQueries({ queryKey: ["approvals"] });
       resetActionDialog();
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to reject request"));
-    },
+    onError: mutationErrorToast("Failed to reject request"),
   });
 
   const isActioning = approveMutation.isPending || rejectMutation.isPending;

--- a/src/app/(app)/(admin)/backups/page.tsx
+++ b/src/app/(app)/(admin)/backups/page.tsx
@@ -30,7 +30,7 @@ import {
   deleteBackup,
 } from "@artifact-keeper/sdk";
 import { useAuth } from "@/providers/auth-provider";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import { formatBytes } from "@/lib/utils";
 
 import { Button } from "@/components/ui/button";
@@ -181,9 +181,7 @@ export default function BackupsPage() {
       setCreateOpen(false);
       setBackupType("full");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to create backup"));
-    },
+    onError: mutationErrorToast("Failed to create backup"),
   });
 
   const executeMutation = useMutation({
@@ -195,9 +193,7 @@ export default function BackupsPage() {
       toast.success("Backup started");
       queryClient.invalidateQueries({ queryKey: ["backups"] });
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to start backup"));
-    },
+    onError: mutationErrorToast("Failed to start backup"),
   });
 
   const cancelMutation = useMutation({
@@ -209,9 +205,7 @@ export default function BackupsPage() {
       toast.success("Backup cancelled");
       queryClient.invalidateQueries({ queryKey: ["backups"] });
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to cancel backup"));
-    },
+    onError: mutationErrorToast("Failed to cancel backup"),
   });
 
   const restoreMutation = useMutation({
@@ -228,9 +222,7 @@ export default function BackupsPage() {
       setRestoreOpen(false);
       setSelectedBackup(null);
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to start restore"));
-    },
+    onError: mutationErrorToast("Failed to start restore"),
   });
 
   const deleteMutation = useMutation({
@@ -244,9 +236,7 @@ export default function BackupsPage() {
       setDeleteOpen(false);
       setSelectedBackup(null);
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to delete backup"));
-    },
+    onError: mutationErrorToast("Failed to delete backup"),
   });
 
   // -- handlers --

--- a/src/app/(app)/(admin)/groups/page.tsx
+++ b/src/app/(app)/(admin)/groups/page.tsx
@@ -15,7 +15,7 @@ import { toast } from "sonner";
 
 import { groupsApi } from "@/lib/api/groups";
 import { adminApi } from "@/lib/api/admin";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import { invalidateGroup } from "@/lib/query-keys";
 import { useAuth } from "@/providers/auth-provider";
 import type { Group, GroupMember } from "@/types/groups";
@@ -113,9 +113,7 @@ export default function GroupsPage() {
       setCreateOpen(false);
       setForm(EMPTY_FORM);
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to create group"));
-    },
+    onError: mutationErrorToast("Failed to create group"),
   });
 
   const updateMutation = useMutation({
@@ -127,9 +125,7 @@ export default function GroupsPage() {
       setEditOpen(false);
       setSelectedGroup(null);
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to update group"));
-    },
+    onError: mutationErrorToast("Failed to update group"),
   });
 
   const deleteMutation = useMutation({
@@ -140,9 +136,7 @@ export default function GroupsPage() {
       setDeleteOpen(false);
       setSelectedGroup(null);
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to delete group"));
-    },
+    onError: mutationErrorToast("Failed to delete group"),
   });
 
   const addMemberMutation = useMutation({
@@ -156,9 +150,7 @@ export default function GroupsPage() {
       invalidateGroup(queryClient, "groups");
       setAddUserId("");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to add member"));
-    },
+    onError: mutationErrorToast("Failed to add member"),
   });
 
   const removeMemberMutation = useMutation({
@@ -171,9 +163,7 @@ export default function GroupsPage() {
       });
       invalidateGroup(queryClient, "groups");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to remove member"));
-    },
+    onError: mutationErrorToast("Failed to remove member"),
   });
 
   // -- handlers --

--- a/src/app/(app)/(admin)/license-policies/page.tsx
+++ b/src/app/(app)/(admin)/license-policies/page.tsx
@@ -16,7 +16,7 @@ import {
 import { toast } from "sonner";
 
 import sbomApi from "@/lib/api/sbom";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import { useAuth } from "@/providers/auth-provider";
 import type {
   LicensePolicy,
@@ -121,9 +121,7 @@ export default function LicensePoliciesPage() {
       setForm(EMPTY_FORM);
       toast.success(selectedPolicy ? "Policy updated" : "Policy created");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to save policy"));
-    },
+    onError: mutationErrorToast("Failed to save policy"),
   });
 
   const deleteMutation = useMutation({
@@ -134,9 +132,7 @@ export default function LicensePoliciesPage() {
       setSelectedPolicy(null);
       toast.success("Policy deleted");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to delete policy"));
-    },
+    onError: mutationErrorToast("Failed to delete policy"),
   });
 
   const toggleMutation = useMutation({
@@ -155,9 +151,7 @@ export default function LicensePoliciesPage() {
       queryClient.invalidateQueries({ queryKey: ["license-policies"] });
       toast.success(`Policy ${policy.is_enabled ? "disabled" : "enabled"}`);
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to toggle policy"));
-    },
+    onError: mutationErrorToast("Failed to toggle policy"),
   });
 
   // -- handlers --

--- a/src/app/(app)/(admin)/lifecycle/page.tsx
+++ b/src/app/(app)/(admin)/lifecycle/page.tsx
@@ -16,7 +16,7 @@ import {
 } from "lucide-react";
 import { useAuth } from "@/providers/auth-provider";
 import lifecycleApi from "@/lib/api/lifecycle";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import { formatBytes } from "@/lib/utils";
 import type {
   LifecyclePolicy,
@@ -114,9 +114,7 @@ export default function LifecyclePage() {
       setCreateOpen(false);
       resetForm();
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to create policy"));
-    },
+    onError: mutationErrorToast("Failed to create policy"),
   });
 
   const deleteMutation = useMutation({
@@ -126,9 +124,7 @@ export default function LifecyclePage() {
       queryClient.invalidateQueries({ queryKey: ["lifecycle-policies"] });
       setDeleteTarget(null);
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to delete policy"));
-    },
+    onError: mutationErrorToast("Failed to delete policy"),
   });
 
   const toggleMutation = useMutation({
@@ -137,9 +133,7 @@ export default function LifecyclePage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["lifecycle-policies"] });
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to update policy"));
-    },
+    onError: mutationErrorToast("Failed to update policy"),
   });
 
   const executeMutation = useMutation({
@@ -150,17 +144,13 @@ export default function LifecyclePage() {
       );
       queryClient.invalidateQueries({ queryKey: ["lifecycle-policies"] });
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Execution failed"));
-    },
+    onError: mutationErrorToast("Execution failed"),
   });
 
   const previewMutation = useMutation({
     mutationFn: (id: string) => lifecycleApi.preview(id),
     onSuccess: (result) => setPreviewResult(result),
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Preview failed"));
-    },
+    onError: mutationErrorToast("Preview failed"),
   });
 
   const executeAllMutation = useMutation({
@@ -176,9 +166,7 @@ export default function LifecyclePage() {
       );
       queryClient.invalidateQueries({ queryKey: ["lifecycle-policies"] });
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Execute all failed"));
-    },
+    onError: mutationErrorToast("Execute all failed"),
   });
 
   function resetForm() {

--- a/src/app/(app)/(admin)/migration/page.tsx
+++ b/src/app/(app)/(admin)/migration/page.tsx
@@ -23,7 +23,7 @@ import {
 import { toast } from "sonner";
 
 import { migrationApi } from "@/lib/api/migration";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import { formatBytes } from "@/lib/utils";
 import type {
   AuthType,
@@ -236,9 +236,7 @@ export default function MigrationPage() {
       setConnForm(INITIAL_CONN_FORM);
       toast.success("Connection created");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to create connection"));
-    },
+    onError: mutationErrorToast("Failed to create connection"),
   });
 
   const deleteConnMutation = useMutation({
@@ -250,9 +248,7 @@ export default function MigrationPage() {
       setDeleteConnId(null);
       toast.success("Connection deleted");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to delete connection"));
-    },
+    onError: mutationErrorToast("Failed to delete connection"),
   });
 
   const testConnMutation = useMutation({
@@ -266,9 +262,7 @@ export default function MigrationPage() {
         toast.error(`Connection failed: ${result.message}`);
       }
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to test connection"));
-    },
+    onError: mutationErrorToast("Failed to test connection"),
   });
 
   // -- Migration mutations --
@@ -285,9 +279,7 @@ export default function MigrationPage() {
       });
       toast.success("Migration job created");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to create migration"));
-    },
+    onError: mutationErrorToast("Failed to create migration"),
   });
 
   const startMigMutation = useMutation({
@@ -297,9 +289,7 @@ export default function MigrationPage() {
       startStream(job.id);
       toast.success("Migration started");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to start migration"));
-    },
+    onError: mutationErrorToast("Failed to start migration"),
   });
 
   const pauseMigMutation = useMutation({
@@ -308,9 +298,7 @@ export default function MigrationPage() {
       queryClient.invalidateQueries({ queryKey: ["migration", "jobs"] });
       toast.success("Migration paused");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to pause migration"));
-    },
+    onError: mutationErrorToast("Failed to pause migration"),
   });
 
   const resumeMigMutation = useMutation({
@@ -320,9 +308,7 @@ export default function MigrationPage() {
       startStream(job.id);
       toast.success("Migration resumed");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to resume migration"));
-    },
+    onError: mutationErrorToast("Failed to resume migration"),
   });
 
   const cancelMigMutation = useMutation({
@@ -331,9 +317,7 @@ export default function MigrationPage() {
       queryClient.invalidateQueries({ queryKey: ["migration", "jobs"] });
       toast.success("Migration cancelled");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to cancel migration"));
-    },
+    onError: mutationErrorToast("Failed to cancel migration"),
   });
 
   const deleteMigMutation = useMutation({
@@ -343,9 +327,7 @@ export default function MigrationPage() {
       setDeleteMigId(null);
       toast.success("Migration deleted");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to delete migration"));
-    },
+    onError: mutationErrorToast("Failed to delete migration"),
   });
 
   // -- Connection columns --

--- a/src/app/(app)/(admin)/monitoring/page.tsx
+++ b/src/app/(app)/(admin)/monitoring/page.tsx
@@ -17,7 +17,7 @@ import {
 } from "lucide-react";
 import { useAuth } from "@/providers/auth-provider";
 import monitoringApi from "@/lib/api/monitoring";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import type { AlertState } from "@/types/monitoring";
 import { PageHeader } from "@/components/common/page-header";
 import { EmptyState } from "@/components/common/empty-state";
@@ -107,9 +107,7 @@ export default function MonitoringPage() {
       queryClient.invalidateQueries({ queryKey: ["monitoring-alerts"] });
       queryClient.invalidateQueries({ queryKey: ["monitoring-log"] });
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Health check failed"));
-    },
+    onError: mutationErrorToast("Health check failed"),
   });
 
   const suppressMutation = useMutation({
@@ -120,9 +118,7 @@ export default function MonitoringPage() {
       queryClient.invalidateQueries({ queryKey: ["monitoring-alerts"] });
       setSuppressTarget(null);
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to suppress alert"));
-    },
+    onError: mutationErrorToast("Failed to suppress alert"),
   });
 
   function handleSuppress() {

--- a/src/app/(app)/(admin)/permissions/page.tsx
+++ b/src/app/(app)/(admin)/permissions/page.tsx
@@ -16,7 +16,7 @@ import type {
 import { groupsApi } from "@/lib/api/groups";
 import { repositoriesApi } from "@/lib/api/repositories";
 import { adminApi } from "@/lib/api/admin";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import { useAuth } from "@/providers/auth-provider";
 import type { User, Repository } from "@/types";
 import type { Group } from "@/types/groups";
@@ -166,9 +166,7 @@ export default function PermissionsPage() {
       setCreateOpen(false);
       setForm(EMPTY_FORM);
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to create permission"));
-    },
+    onError: mutationErrorToast("Failed to create permission"),
   });
 
   const updateMutation = useMutation({
@@ -185,9 +183,7 @@ export default function PermissionsPage() {
       setEditOpen(false);
       setSelectedPermission(null);
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to update permission"));
-    },
+    onError: mutationErrorToast("Failed to update permission"),
   });
 
   const deleteMutation = useMutation({
@@ -198,9 +194,7 @@ export default function PermissionsPage() {
       setDeleteOpen(false);
       setSelectedPermission(null);
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to delete permission"));
-    },
+    onError: mutationErrorToast("Failed to delete permission"),
   });
 
   // -- handlers --

--- a/src/app/(app)/(admin)/quality-gates/page.tsx
+++ b/src/app/(app)/(admin)/quality-gates/page.tsx
@@ -18,7 +18,7 @@ import {
 } from "lucide-react";
 import { useAuth } from "@/providers/auth-provider";
 import qualityGatesApi from "@/lib/api/quality-gates";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import type {
   QualityGate,
   CreateQualityGateRequest,
@@ -504,9 +504,7 @@ export default function QualityGatesPage() {
       setCreateOpen(false);
       setCreateForm(emptyForm);
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to create quality gate"));
-    },
+    onError: mutationErrorToast("Failed to create quality gate"),
   });
 
   const updateMutation = useMutation({
@@ -517,9 +515,7 @@ export default function QualityGatesPage() {
       queryClient.invalidateQueries({ queryKey: ["quality-gates"] });
       setEditTarget(null);
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to update quality gate"));
-    },
+    onError: mutationErrorToast("Failed to update quality gate"),
   });
 
   const deleteMutation = useMutation({
@@ -529,9 +525,7 @@ export default function QualityGatesPage() {
       queryClient.invalidateQueries({ queryKey: ["quality-gates"] });
       setDeleteTarget(null);
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to delete quality gate"));
-    },
+    onError: mutationErrorToast("Failed to delete quality gate"),
   });
 
   const toggleMutation = useMutation({
@@ -540,9 +534,7 @@ export default function QualityGatesPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["quality-gates"] });
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to update quality gate"));
-    },
+    onError: mutationErrorToast("Failed to update quality gate"),
   });
 
   // -- Helpers --

--- a/src/app/(app)/(admin)/security/dt-projects/[uuid]/page.tsx
+++ b/src/app/(app)/(admin)/security/dt-projects/[uuid]/page.tsx
@@ -24,7 +24,7 @@ import {
 } from "lucide-react";
 
 import dtApi from "@/lib/api/dependency-track";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import type {
   DtFinding,
   DtComponentFull,
@@ -128,9 +128,7 @@ function FindingTriageRow({
       queryClient.invalidateQueries({ queryKey: ["dt", "project-findings", projectUuid] });
       queryClient.invalidateQueries({ queryKey: ["dt", "project-metrics", projectUuid] });
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to update analysis state"));
-    },
+    onError: mutationErrorToast("Failed to update analysis state"),
   });
 
   const handleSave = () => {
@@ -463,9 +461,7 @@ export default function DtProjectDetailPage() {
       queryClient.invalidateQueries({ queryKey: ["dt", "project-findings", uuid] });
       queryClient.invalidateQueries({ queryKey: ["dt", "project-metrics", uuid] });
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to update some findings"));
-    },
+    onError: mutationErrorToast("Failed to update some findings"),
   });
 
   // -- loading state --

--- a/src/app/(app)/(admin)/security/page.tsx
+++ b/src/app/(app)/(admin)/security/page.tsx
@@ -19,12 +19,10 @@ import {
   XCircle,
 } from "lucide-react";
 
-import { toast } from "sonner";
-
 import "@/lib/sdk-client";
 import { listRepositories } from "@artifact-keeper/sdk";
 import securityApi from "@/lib/api/security";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import dtApi from "@/lib/api/dependency-track";
 import { artifactsApi } from "@/lib/api/artifacts";
 import type { RepoSecurityScore } from "@/types/security";
@@ -233,9 +231,7 @@ export default function SecurityDashboardPage() {
       setSelectedArtifactId(undefined);
       setScanMode("repo");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to trigger scan"));
-    },
+    onError: mutationErrorToast("Failed to trigger scan"),
   });
 
   // -- table columns --

--- a/src/app/(app)/(admin)/security/policies/page.tsx
+++ b/src/app/(app)/(admin)/security/policies/page.tsx
@@ -6,7 +6,7 @@ import { Plus, Pencil, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
 import securityApi from "@/lib/api/security";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import type {
   ScanPolicy,
   CreatePolicyRequest,
@@ -225,9 +225,7 @@ export default function SecurityPoliciesPage() {
       setCreateForm({ ...DEFAULT_FORM });
       toast.success("Policy created.");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to create policy"));
-    },
+    onError: mutationErrorToast("Failed to create policy"),
   });
 
   const updateMutation = useMutation({
@@ -239,9 +237,7 @@ export default function SecurityPoliciesPage() {
       setSelectedPolicy(null);
       toast.success("Policy updated.");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to update policy"));
-    },
+    onError: mutationErrorToast("Failed to update policy"),
   });
 
   const deleteMutation = useMutation({
@@ -252,9 +248,7 @@ export default function SecurityPoliciesPage() {
       setSelectedPolicy(null);
       toast.success("Policy deleted.");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to delete policy"));
-    },
+    onError: mutationErrorToast("Failed to delete policy"),
   });
 
   const handleEdit = useCallback((policy: ScanPolicy) => {

--- a/src/app/(app)/(admin)/security/scans/[id]/page.tsx
+++ b/src/app/(app)/(admin)/security/scans/[id]/page.tsx
@@ -16,7 +16,7 @@ import {
 import { toast } from "sonner";
 
 import securityApi from "@/lib/api/security";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import { isScanIncomplete } from "@/lib/scan-utils";
 import type { ScanFinding } from "@/types/security";
 
@@ -149,9 +149,7 @@ export default function SecurityScanDetailPage() {
       setAckFindingId(null);
       toast.success("Finding acknowledged.");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to acknowledge finding"));
-    },
+    onError: mutationErrorToast("Failed to acknowledge finding"),
   });
 
   const revokeMutation = useMutation({
@@ -165,9 +163,7 @@ export default function SecurityScanDetailPage() {
       setRevokeFindingId(null);
       toast.success("Acknowledgment revoked.");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to revoke acknowledgment"));
-    },
+    onError: mutationErrorToast("Failed to revoke acknowledgment"),
   });
 
   // -- filter findings by severity locally --

--- a/src/app/(app)/(admin)/security/scans/page.tsx
+++ b/src/app/(app)/(admin)/security/scans/page.tsx
@@ -13,7 +13,7 @@ import {
   listScanConfigs,
 } from "@artifact-keeper/sdk";
 import securityApi from "@/lib/api/security";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import { artifactsApi } from "@/lib/api/artifacts";
 import { isScanIncomplete, isScanFailed, isScanClean } from "@/lib/scan-utils";
 import type { ScanResult } from "@/types/security";
@@ -178,9 +178,7 @@ export default function SecurityScansPage() {
       setScanMode("repo");
       toast.success(`Scan queued for ${res.artifacts_queued} artifact(s).`);
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to trigger scan"));
-    },
+    onError: mutationErrorToast("Failed to trigger scan"),
   });
 
   // -- table columns --

--- a/src/app/(app)/(admin)/service-accounts/page.tsx
+++ b/src/app/(app)/(admin)/service-accounts/page.tsx
@@ -14,7 +14,7 @@ import {
 import { toast } from "sonner";
 
 import { serviceAccountsApi } from "@/lib/api/service-accounts";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import type {
   ServiceAccount,
   ServiceAccountToken,
@@ -146,9 +146,7 @@ export default function ServiceAccountsPage() {
       setCreateDescription("");
       toast.success("Service account created");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to create service account"));
-    },
+    onError: mutationErrorToast("Failed to create service account"),
   });
 
   const updateMutation = useMutation({
@@ -167,9 +165,7 @@ export default function ServiceAccountsPage() {
       setEditAccount(null);
       toast.success("Service account updated");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to update service account"));
-    },
+    onError: mutationErrorToast("Failed to update service account"),
   });
 
   const deleteMutation = useMutation({
@@ -180,9 +176,7 @@ export default function ServiceAccountsPage() {
       setDeleteAccount(null);
       toast.success("Service account deleted");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to delete service account"));
-    },
+    onError: mutationErrorToast("Failed to delete service account"),
   });
 
   const createTokenMutation = useMutation({
@@ -200,9 +194,7 @@ export default function ServiceAccountsPage() {
       setTokenRepoSelector({});
       toast.success("Token created");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to create token"));
-    },
+    onError: mutationErrorToast("Failed to create token"),
   });
 
   const revokeTokenMutation = useMutation({
@@ -216,9 +208,7 @@ export default function ServiceAccountsPage() {
       setRevokeTokenId(null);
       toast.success("Token revoked");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to revoke token"));
-    },
+    onError: mutationErrorToast("Failed to revoke token"),
   });
 
   // Handlers

--- a/src/app/(app)/(admin)/settings/page.tsx
+++ b/src/app/(app)/(admin)/settings/page.tsx
@@ -6,7 +6,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { adminApi } from "@/lib/api/admin";
 import { settingsApi } from "@/lib/api/settings";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import { formatBytes } from "@/lib/utils";
 import { Server, HardDrive, Lock, Info, Mail, Loader2 } from "lucide-react";
 
@@ -132,9 +132,7 @@ function SmtpSettingsForm({
       queryClient.invalidateQueries({ queryKey: ["smtp-config"] });
       setFormDirty(false);
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to save SMTP configuration"));
-    },
+    onError: mutationErrorToast("Failed to save SMTP configuration"),
   });
 
   const testMutation = useMutation({
@@ -146,9 +144,7 @@ function SmtpSettingsForm({
         toast.error(result.message || "Test email failed");
       }
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to send test email"));
-    },
+    onError: mutationErrorToast("Failed to send test email"),
   });
 
   function handleFieldChange<T>(setter: (v: T) => void) {

--- a/src/app/(app)/(admin)/settings/sso/page.tsx
+++ b/src/app/(app)/(admin)/settings/sso/page.tsx
@@ -20,7 +20,7 @@ import {
 
 import { useAuth } from "@/providers/auth-provider";
 import { ssoApi } from "@/lib/api/sso";
-import { toUserMessage } from "@/lib/error-utils";
+import { toUserMessage, mutationErrorToast } from "@/lib/error-utils";
 import type {
   OidcConfig,
   LdapConfig,
@@ -103,9 +103,7 @@ function OidcTab() {
       toast.success("OIDC provider created successfully");
       closeDialog();
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to create OIDC provider"));
-    },
+    onError: mutationErrorToast("Failed to create OIDC provider"),
   });
 
   const updateMutation = useMutation({
@@ -116,9 +114,7 @@ function OidcTab() {
       toast.success("OIDC provider updated successfully");
       closeDialog();
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to update OIDC provider"));
-    },
+    onError: mutationErrorToast("Failed to update OIDC provider"),
   });
 
   const deleteMutation = useMutation({
@@ -128,9 +124,7 @@ function OidcTab() {
       toast.success("OIDC provider deleted");
       setDeleteTarget(null);
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to delete OIDC provider"));
-    },
+    onError: mutationErrorToast("Failed to delete OIDC provider"),
   });
 
   const toggleMutation = useMutation({
@@ -140,9 +134,7 @@ function OidcTab() {
       queryClient.invalidateQueries({ queryKey: ["sso"] });
       toast.success("OIDC provider status updated");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to toggle OIDC provider"));
-    },
+    onError: mutationErrorToast("Failed to toggle OIDC provider"),
   });
 
   function resetForm() {
@@ -554,9 +546,7 @@ function LdapTab() {
       toast.success("LDAP provider created successfully");
       closeDialog();
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to create LDAP provider"));
-    },
+    onError: mutationErrorToast("Failed to create LDAP provider"),
   });
 
   const updateMutation = useMutation({
@@ -567,9 +557,7 @@ function LdapTab() {
       toast.success("LDAP provider updated successfully");
       closeDialog();
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to update LDAP provider"));
-    },
+    onError: mutationErrorToast("Failed to update LDAP provider"),
   });
 
   const deleteMutation = useMutation({
@@ -579,9 +567,7 @@ function LdapTab() {
       toast.success("LDAP provider deleted");
       setDeleteTarget(null);
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to delete LDAP provider"));
-    },
+    onError: mutationErrorToast("Failed to delete LDAP provider"),
   });
 
   const toggleMutation = useMutation({
@@ -591,9 +577,7 @@ function LdapTab() {
       queryClient.invalidateQueries({ queryKey: ["sso"] });
       toast.success("LDAP provider status updated");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to toggle LDAP provider"));
-    },
+    onError: mutationErrorToast("Failed to toggle LDAP provider"),
   });
 
   const testMutation = useMutation({
@@ -1095,9 +1079,7 @@ function SamlTab() {
       toast.success("SAML provider created successfully");
       closeDialog();
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to create SAML provider"));
-    },
+    onError: mutationErrorToast("Failed to create SAML provider"),
   });
 
   const updateMutation = useMutation({
@@ -1108,9 +1090,7 @@ function SamlTab() {
       toast.success("SAML provider updated successfully");
       closeDialog();
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to update SAML provider"));
-    },
+    onError: mutationErrorToast("Failed to update SAML provider"),
   });
 
   const deleteMutation = useMutation({
@@ -1120,9 +1100,7 @@ function SamlTab() {
       toast.success("SAML provider deleted");
       setDeleteTarget(null);
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to delete SAML provider"));
-    },
+    onError: mutationErrorToast("Failed to delete SAML provider"),
   });
 
   const toggleMutation = useMutation({
@@ -1132,9 +1110,7 @@ function SamlTab() {
       queryClient.invalidateQueries({ queryKey: ["sso"] });
       toast.success("SAML provider status updated");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to toggle SAML provider"));
-    },
+    onError: mutationErrorToast("Failed to toggle SAML provider"),
   });
 
   function resetForm() {

--- a/src/app/(app)/(admin)/telemetry/page.tsx
+++ b/src/app/(app)/(admin)/telemetry/page.tsx
@@ -15,7 +15,7 @@ import {
 } from "lucide-react";
 import { useAuth } from "@/providers/auth-provider";
 import telemetryApi from "@/lib/api/telemetry";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import type { CrashReport, TelemetrySettings } from "@/types/telemetry";
 import { PageHeader } from "@/components/common/page-header";
 import { StatCard } from "@/components/common/stat-card";
@@ -104,9 +104,7 @@ export default function TelemetryPage() {
       toast.success("Settings updated");
       queryClient.invalidateQueries({ queryKey: ["telemetry-settings"] });
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to update settings"));
-    },
+    onError: mutationErrorToast("Failed to update settings"),
   });
 
   const submitMutation = useMutation({
@@ -116,9 +114,7 @@ export default function TelemetryPage() {
       queryClient.invalidateQueries({ queryKey: ["telemetry-crashes"] });
       queryClient.invalidateQueries({ queryKey: ["telemetry-pending"] });
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to submit crash reports"));
-    },
+    onError: mutationErrorToast("Failed to submit crash reports"),
   });
 
   const deleteMutation = useMutation({
@@ -129,9 +125,7 @@ export default function TelemetryPage() {
       queryClient.invalidateQueries({ queryKey: ["telemetry-pending"] });
       setDeleteTarget(null);
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to delete crash report"));
-    },
+    onError: mutationErrorToast("Failed to delete crash report"),
   });
 
   function handleToggle(field: keyof TelemetrySettings, value: boolean) {

--- a/src/app/(app)/(admin)/users/page.tsx
+++ b/src/app/(app)/(admin)/users/page.tsx
@@ -26,7 +26,7 @@ import {
 } from "@artifact-keeper/sdk";
 import { adminApi } from "@/lib/api/admin";
 import type { ApiKey } from "@/lib/api/profile";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import { invalidateGroup } from "@/lib/query-keys";
 import { useAuth } from "@/providers/auth-provider";
 import type { User, CreateUserResponse } from "@/types";
@@ -161,9 +161,7 @@ export default function UsersPage() {
         toast.success("User created successfully");
       }
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to create user"));
-    },
+    onError: mutationErrorToast("Failed to create user"),
   });
 
   const updateMutation = useMutation({
@@ -186,9 +184,7 @@ export default function UsersPage() {
       setEditOpen(false);
       setSelectedUser(null);
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to update user"));
-    },
+    onError: mutationErrorToast("Failed to update user"),
   });
 
   const toggleStatusMutation = useMutation({
@@ -203,9 +199,7 @@ export default function UsersPage() {
       toast.success(`User ${vars.is_active ? "enabled" : "disabled"} successfully`);
       invalidateGroup(queryClient, "users");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to update user status"));
-    },
+    onError: mutationErrorToast("Failed to update user status"),
   });
 
   const resetPasswordMutation = useMutation({
@@ -223,9 +217,7 @@ export default function UsersPage() {
       setPasswordOpen(true);
       queryClient.invalidateQueries({ queryKey: ["admin-users"] });
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to reset password"));
-    },
+    onError: mutationErrorToast("Failed to reset password"),
   });
 
   const deleteMutation = useMutation({
@@ -239,9 +231,7 @@ export default function UsersPage() {
       setDeleteOpen(false);
       setSelectedUser(null);
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to delete user"));
-    },
+    onError: mutationErrorToast("Failed to delete user"),
   });
 
   // -- user tokens query (for the selected user) --
@@ -265,9 +255,7 @@ export default function UsersPage() {
       });
       setRevokeTokenId(null);
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to revoke token"));
-    },
+    onError: mutationErrorToast("Failed to revoke token"),
   });
 
   // -- handlers --

--- a/src/app/(app)/(protected)/access-tokens/page.tsx
+++ b/src/app/(app)/(protected)/access-tokens/page.tsx
@@ -11,7 +11,7 @@ import {
 import { toast } from "sonner";
 
 import { profileApi } from "@/lib/api/profile";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import type {
   ApiKey,
   AccessToken,
@@ -157,9 +157,7 @@ export default function AccessTokensPage() {
       setKeyExpiry("90");
       toast.success("API key created");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to create API key"));
-    },
+    onError: mutationErrorToast("Failed to create API key"),
   });
 
   const revokeKeyMutation = useMutation({
@@ -169,9 +167,7 @@ export default function AccessTokensPage() {
       setRevokeKeyId(null);
       toast.success("API key revoked");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to revoke API key"));
-    },
+    onError: mutationErrorToast("Failed to revoke API key"),
   });
 
   const createTokenMutation = useMutation({
@@ -188,9 +184,7 @@ export default function AccessTokensPage() {
       setTokenRepoSelector({});
       toast.success("Access token created");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to create access token"));
-    },
+    onError: mutationErrorToast("Failed to create access token"),
   });
 
   const revokeTokenMutation = useMutation({
@@ -202,9 +196,7 @@ export default function AccessTokensPage() {
       setRevokeTokenId(null);
       toast.success("Access token revoked");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to revoke access token"));
-    },
+    onError: mutationErrorToast("Failed to revoke access token"),
   });
 
   // Column definitions

--- a/src/app/(app)/(protected)/peers/page.tsx
+++ b/src/app/(app)/(protected)/peers/page.tsx
@@ -15,7 +15,7 @@ import { toast } from "sonner";
 
 import { peersApi } from "@/lib/api/replication";
 import type { PeerInstance } from "@/lib/api/replication";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import { formatBytes, isSafeUrl } from "@/lib/utils";
 
 import { Button } from "@/components/ui/button";
@@ -123,9 +123,7 @@ export default function PeersPage() {
       setForm({ name: "", endpoint_url: "", region: "", api_key: "" });
       toast.success("Peer registered successfully");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to register peer"));
-    },
+    onError: mutationErrorToast("Failed to register peer"),
   });
 
   const unregisterMutation = useMutation({
@@ -135,9 +133,7 @@ export default function PeersPage() {
       setDeleteId(null);
       toast.success("Peer unregistered");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to unregister peer"));
-    },
+    onError: mutationErrorToast("Failed to unregister peer"),
   });
 
   const syncMutation = useMutation({
@@ -146,9 +142,7 @@ export default function PeersPage() {
       queryClient.invalidateQueries({ queryKey: ["peers"] });
       toast.success("Sync triggered");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to trigger sync"));
-    },
+    onError: mutationErrorToast("Failed to trigger sync"),
   });
 
   // -- columns --

--- a/src/app/(app)/(protected)/plugins/page.tsx
+++ b/src/app/(app)/(protected)/plugins/page.tsx
@@ -30,7 +30,7 @@ import {
   installFromGit,
   installFromZip,
 } from "@artifact-keeper/sdk";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -188,9 +188,7 @@ export default function PluginsPage() {
       queryClient.invalidateQueries({ queryKey: ["plugins"] });
       toast.success("Plugin enabled");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to enable plugin"));
-    },
+    onError: mutationErrorToast("Failed to enable plugin"),
   });
 
   const disableMutation = useMutation({
@@ -202,9 +200,7 @@ export default function PluginsPage() {
       queryClient.invalidateQueries({ queryKey: ["plugins"] });
       toast.success("Plugin disabled");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to disable plugin"));
-    },
+    onError: mutationErrorToast("Failed to disable plugin"),
   });
 
   const uninstallMutation = useMutation({
@@ -217,9 +213,7 @@ export default function PluginsPage() {
       setUninstallId(null);
       toast.success("Plugin uninstalled");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to uninstall plugin"));
-    },
+    onError: mutationErrorToast("Failed to uninstall plugin"),
   });
 
   const [configValues, setConfigValues] = useState<Record<string, string>>({});
@@ -242,9 +236,7 @@ export default function PluginsPage() {
       queryClient.invalidateQueries({ queryKey: ["plugin-config"] });
       toast.success("Configuration saved");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to save configuration"));
-    },
+    onError: mutationErrorToast("Failed to save configuration"),
   });
 
   const resetInstallForm = () => {
@@ -270,9 +262,7 @@ export default function PluginsPage() {
         `Plugin "${data?.name ?? "unknown"}" installed successfully`,
       );
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to install plugin from Git"));
-    },
+    onError: mutationErrorToast("Failed to install plugin from Git"),
   });
 
   const installZipMutation = useMutation({
@@ -293,9 +283,7 @@ export default function PluginsPage() {
         `Plugin "${data?.name ?? "unknown"}" installed successfully`,
       );
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to install plugin from ZIP"));
-    },
+    onError: mutationErrorToast("Failed to install plugin from ZIP"),
   });
 
   const isInstalling =

--- a/src/app/(app)/(protected)/profile/page.tsx
+++ b/src/app/(app)/(protected)/profile/page.tsx
@@ -23,6 +23,7 @@ import {
   toUserMessage,
   isPasswordReuseError,
   PASSWORD_REUSE_MESSAGE,
+  mutationErrorToast,
 } from "@/lib/error-utils";
 
 import { Button } from "@/components/ui/button";
@@ -85,9 +86,7 @@ export default function ProfilePage() {
       refreshUser();
       toast.success("Profile updated successfully");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to update profile"));
-    },
+    onError: mutationErrorToast("Failed to update profile"),
   });
 
   const [passwordError, setPasswordError] = useState<string | null>(null);

--- a/src/app/(app)/(protected)/replication/page.tsx
+++ b/src/app/(app)/(protected)/replication/page.tsx
@@ -13,7 +13,7 @@ import { toast } from "sonner";
 
 import { peersApi } from "@/lib/api/replication";
 import type { PeerInstance, PeerConnection } from "@/lib/api/replication";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import { formatBytes } from "@/lib/utils";
 import { repositoriesApi } from "@/lib/api/repositories";
 import type { Repository } from "@/types";
@@ -143,9 +143,7 @@ export default function ReplicationPage() {
       });
       toast.success("Replication settings updated");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to update replication settings"));
-    },
+    onError: mutationErrorToast("Failed to update replication settings"),
   });
 
   // -- subscription repo columns --

--- a/src/app/(app)/(protected)/webhooks/page.tsx
+++ b/src/app/(app)/(protected)/webhooks/page.tsx
@@ -17,7 +17,7 @@ import {
 import { toast } from "sonner";
 
 import { webhooksApi } from "@/lib/api/webhooks";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import type {
   Webhook as WebhookType,
   WebhookDelivery,
@@ -148,9 +148,7 @@ export default function WebhooksPage() {
       resetForm();
       toast.success("Webhook created");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to create webhook"));
-    },
+    onError: mutationErrorToast("Failed to create webhook"),
   });
 
   const deleteMutation = useMutation({
@@ -160,9 +158,7 @@ export default function WebhooksPage() {
       setDeleteId(null);
       toast.success("Webhook deleted");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to delete webhook"));
-    },
+    onError: mutationErrorToast("Failed to delete webhook"),
   });
 
   const enableMutation = useMutation({
@@ -171,9 +167,7 @@ export default function WebhooksPage() {
       queryClient.invalidateQueries({ queryKey: ["webhooks"] });
       toast.success("Webhook enabled");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to enable webhook"));
-    },
+    onError: mutationErrorToast("Failed to enable webhook"),
   });
 
   const disableMutation = useMutation({
@@ -182,9 +176,7 @@ export default function WebhooksPage() {
       queryClient.invalidateQueries({ queryKey: ["webhooks"] });
       toast.success("Webhook disabled");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to disable webhook"));
-    },
+    onError: mutationErrorToast("Failed to disable webhook"),
   });
 
   const testMutation = useMutation({
@@ -199,9 +191,7 @@ export default function WebhooksPage() {
       }
       queryClient.invalidateQueries({ queryKey: ["webhook-deliveries"] });
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to send test"));
-    },
+    onError: mutationErrorToast("Failed to send test"),
   });
 
   const redeliverMutation = useMutation({
@@ -216,9 +206,7 @@ export default function WebhooksPage() {
       toast.success("Redelivery sent");
       queryClient.invalidateQueries({ queryKey: ["webhook-deliveries"] });
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to redeliver"));
-    },
+    onError: mutationErrorToast("Failed to redeliver"),
   });
 
   const resetForm = () => {

--- a/src/app/(app)/repositories/_components/notifications-tab-content.test.tsx
+++ b/src/app/(app)/repositories/_components/notifications-tab-content.test.tsx
@@ -75,6 +75,9 @@ vi.mock("@/lib/api/webhooks", () => ({
 
 vi.mock("@/lib/error-utils", () => ({
   toUserMessage: (_err: unknown, fallback: string) => fallback,
+  mutationErrorToast: (label: string) => () => {
+    mockToastError(label);
+  },
 }));
 
 // Stub out radix tooltip/dialog to avoid portal issues in jsdom

--- a/src/app/(app)/repositories/_components/notifications-tab-content.tsx
+++ b/src/app/(app)/repositories/_components/notifications-tab-content.tsx
@@ -22,7 +22,7 @@ import type {
   WebhookEvent,
   CreateWebhookRequest,
 } from "@/lib/api/webhooks";
-import { toUserMessage } from "@/lib/error-utils";
+import { toUserMessage, mutationErrorToast } from "@/lib/error-utils";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -153,9 +153,7 @@ export function NotificationsTabContent({ repositoryId }: NotificationsTabConten
       resetForm();
       toast.success("Webhook created");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to create webhook"));
-    },
+    onError: mutationErrorToast("Failed to create webhook"),
   });
 
   const deleteMutation = useMutation({

--- a/src/app/(app)/repositories/_components/repo-detail-content.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.tsx
@@ -22,7 +22,7 @@ import {
 import { repositoriesApi } from "@/lib/api/repositories";
 import { artifactsApi } from "@/lib/api/artifacts";
 import securityApi from "@/lib/api/security";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import { isActivelyQuarantined } from "@/lib/quarantine";
 import type { Artifact } from "@/types";
 import type { UpsertScanConfigRequest } from "@/types/security";
@@ -144,9 +144,7 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
       setSelectedArtifact(null);
       toast.success("Artifact deleted");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to delete artifact"));
-    },
+    onError: mutationErrorToast("Failed to delete artifact"),
   });
 
   const scanArtifactMutation = useMutation({
@@ -155,9 +153,7 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
     onSuccess: (res) => {
       toast.success(`Scan queued for ${res.artifacts_queued} artifact(s).`);
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to trigger scan"));
-    },
+    onError: mutationErrorToast("Failed to trigger scan"),
   });
 
   const scanRepoMutation = useMutation({
@@ -166,9 +162,7 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
     onSuccess: (res) => {
       toast.success(`Scan queued for ${res.artifacts_queued} artifact(s).`);
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to trigger scan"));
-    },
+    onError: mutationErrorToast("Failed to trigger scan"),
   });
 
   const updateSecurityMutation = useMutation({
@@ -179,9 +173,7 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
       setSecForm(null); // reset to refetched defaults
       toast.success("Security settings saved");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to save security settings"));
-    },
+    onError: mutationErrorToast("Failed to save security settings"),
   });
 
   // --- handlers ---

--- a/src/app/(app)/repositories/_components/repo-settings-tab.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-settings-tab.test.tsx
@@ -58,9 +58,15 @@ vi.mock("@/lib/api/lifecycle", () => ({
 }));
 
 // Mock error utils
-vi.mock("@/lib/error-utils", () => ({
-  toUserMessage: (_err: unknown, fallback: string) => fallback,
-}));
+vi.mock("@/lib/error-utils", async () => {
+  const { toast } = await import("sonner");
+  return {
+    toUserMessage: (_err: unknown, fallback: string) => fallback,
+    mutationErrorToast: (label: string) => () => {
+      toast.error(label);
+    },
+  };
+});
 
 // Mock utils
 vi.mock("@/lib/utils", () => ({

--- a/src/app/(app)/repositories/_components/repo-settings-tab.tsx
+++ b/src/app/(app)/repositories/_components/repo-settings-tab.tsx
@@ -7,7 +7,7 @@ import { toast } from "sonner";
 
 import { repositoriesApi } from "@/lib/api/repositories";
 import lifecycleApi from "@/lib/api/lifecycle";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import { formatBytes } from "@/lib/utils";
 import type { Repository } from "@/types";
 import type { LifecyclePolicy, PolicyType } from "@/types/lifecycle";
@@ -132,9 +132,7 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
       setQuotaOverrides({});
       toast.success("Repository settings saved");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to save repository settings"));
-    },
+    onError: mutationErrorToast("Failed to save repository settings"),
   });
 
   const handleSave = useCallback(() => {
@@ -175,9 +173,7 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
       });
       toast.success("Cleanup policy deleted");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to delete cleanup policy"));
-    },
+    onError: mutationErrorToast("Failed to delete cleanup policy"),
   });
 
   const executePolicyMutation = useMutation({
@@ -191,9 +187,7 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
         `Policy executed: ${result.artifacts_removed} artifact(s) removed, ${formatBytes(result.bytes_freed)} freed`
       );
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to execute cleanup policy"));
-    },
+    onError: mutationErrorToast("Failed to execute cleanup policy"),
   });
 
   const previewPolicyMutation = useMutation({
@@ -203,9 +197,7 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
         `Preview: ${result.artifacts_matched} artifact(s) would be removed (${formatBytes(result.bytes_freed)})`
       );
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to preview cleanup policy"));
-    },
+    onError: mutationErrorToast("Failed to preview cleanup policy"),
   });
 
   return (

--- a/src/app/(app)/repositories/_components/repositories-content.test.tsx
+++ b/src/app/(app)/repositories/_components/repositories-content.test.tsx
@@ -87,13 +87,19 @@ vi.mock("@/hooks/use-mobile", () => ({
   useIsMobile: () => mockUseIsMobile(),
 }));
 
-vi.mock("@/lib/error-utils", () => ({
-  toUserMessage: (err: unknown, fallback: string) => {
+vi.mock("@/lib/error-utils", () => {
+  const toUserMessage = (err: unknown, fallback: string) => {
     if (err instanceof Error) return err.message;
     if (err && typeof err === "object" && "error" in err) return (err as any).error;
     return fallback;
-  },
-}));
+  };
+  return {
+    toUserMessage,
+    mutationErrorToast: (label: string) => (err: unknown) => {
+      mockToastError(toUserMessage(err, label));
+    },
+  };
+});
 
 vi.mock("lucide-react", () => {
   const stub = (name: string) => {

--- a/src/app/(app)/repositories/_components/repositories-content.tsx
+++ b/src/app/(app)/repositories/_components/repositories-content.tsx
@@ -35,7 +35,7 @@ import {
   ResizableHandle,
 } from "@/components/ui/resizable";
 
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import { FORMAT_GROUPS, TYPE_OPTIONS } from "../_lib/constants";
 import { RepoListItem } from "./repo-list-item";
 import { RepoDetailPanel } from "./repo-detail-panel";
@@ -107,9 +107,7 @@ export function RepositoriesContent() {
         toast.success("Repository created");
       }
     },
-    onError: (err) => {
-      toast.error(toUserMessage(err, "Failed to create repository"));
-    },
+    onError: mutationErrorToast("Failed to create repository"),
   });
 
   const updateMutation = useMutation({
@@ -128,9 +126,7 @@ export function RepositoriesContent() {
       }
       toast.success("Repository updated");
     },
-    onError: (err) => {
-      toast.error(toUserMessage(err, "Failed to update repository"));
-    },
+    onError: mutationErrorToast("Failed to update repository"),
   });
 
   const deleteMutation = useMutation({
@@ -142,9 +138,7 @@ export function RepositoriesContent() {
       if (selectedKey === deletedKey) setSelectedKey(null);
       toast.success("Repository deleted");
     },
-    onError: (err) => {
-      toast.error(toUserMessage(err, "Failed to delete repository"));
-    },
+    onError: mutationErrorToast("Failed to delete repository"),
   });
 
   const upstreamAuthMutation = useMutation({
@@ -154,9 +148,7 @@ export function RepositoriesContent() {
       invalidateAllRepoQueries();
       toast.success("Upstream authentication updated");
     },
-    onError: (err) => {
-      toast.error(toUserMessage(err, "Failed to update upstream authentication"));
-    },
+    onError: mutationErrorToast("Failed to update upstream authentication"),
   });
 
   // --- handlers ---

--- a/src/app/(app)/repositories/_components/sbom-tab-content.tsx
+++ b/src/app/(app)/repositories/_components/sbom-tab-content.tsx
@@ -18,7 +18,7 @@ import {
 import { toast } from "sonner";
 
 import sbomApi from "@/lib/api/sbom";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import type { SbomComponent, SbomFormat, CveHistoryEntry } from "@/types/sbom";
 import type { Artifact } from "@/types";
 
@@ -94,9 +94,7 @@ export function SbomTabContent({ artifact }: SbomTabContentProps) {
       queryClient.invalidateQueries({ queryKey: ["sboms", artifact.id] });
       toast.success("SBOM generated successfully");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to generate SBOM"));
-    },
+    onError: mutationErrorToast("Failed to generate SBOM"),
   });
 
   // Download SBOM as JSON

--- a/src/app/(app)/repositories/_components/security-tab-content.tsx
+++ b/src/app/(app)/repositories/_components/security-tab-content.tsx
@@ -19,7 +19,7 @@ import { toast } from "sonner";
 
 import sbomApi from "@/lib/api/sbom";
 import dtApi from "@/lib/api/dependency-track";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import type { CveHistoryEntry, CveStatus } from "@/types/sbom";
 import type { Artifact } from "@/types";
 import type {
@@ -138,9 +138,7 @@ export function SecurityTabContent({ artifact }: SecurityTabContentProps) {
       queryClient.invalidateQueries({ queryKey: ["cve-history", artifact.id] });
       toast.success("CVE status updated");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to update CVE status"));
-    },
+    onError: mutationErrorToast("Failed to update CVE status"),
   });
 
   // -------------------------------------------------------------------------
@@ -197,9 +195,7 @@ export function SecurityTabContent({ artifact }: SecurityTabContentProps) {
       queryClient.invalidateQueries({ queryKey: ["dt-project-metrics", dtProjectUuid] });
       toast.success("Dependency-Track analysis updated");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to update analysis"));
-    },
+    onError: mutationErrorToast("Failed to update analysis"),
   });
 
   // -------------------------------------------------------------------------

--- a/src/app/(app)/repositories/_components/virtual-members-panel.tsx
+++ b/src/app/(app)/repositories/_components/virtual-members-panel.tsx
@@ -5,7 +5,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Plus, Trash2, ChevronUp, ChevronDown, Loader2 } from "lucide-react";
 
 import { repositoriesApi } from "@/lib/api/repositories";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import type { Repository, VirtualRepoMember } from "@/types";
 import { REPO_TYPE_COLORS } from "@/lib/utils";
 import { toast } from "sonner";
@@ -81,9 +81,7 @@ export function VirtualMembersPanel({ repository }: VirtualMembersPanelProps) {
       queryClient.invalidateQueries({ queryKey: ["repository", repository.key] });
       toast.success("Member added");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to add member"));
-    },
+    onError: mutationErrorToast("Failed to add member"),
   });
 
   const removeMemberMutation = useMutation({
@@ -96,9 +94,7 @@ export function VirtualMembersPanel({ repository }: VirtualMembersPanelProps) {
       setMemberToRemove(null);
       toast.success("Member removed");
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to remove member"));
-    },
+    onError: mutationErrorToast("Failed to remove member"),
   });
 
   const reorderMutation = useMutation({
@@ -108,9 +104,7 @@ export function VirtualMembersPanel({ repository }: VirtualMembersPanelProps) {
       queryClient.invalidateQueries({ queryKey: ["virtual-members", repository.key] });
       queryClient.invalidateQueries({ queryKey: ["repository", repository.key] });
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to reorder members"));
-    },
+    onError: mutationErrorToast("Failed to reorder members"),
   });
 
   const handleMoveUp = (index: number) => {

--- a/src/app/(app)/staging/_components/promotion-dialog.tsx
+++ b/src/app/(app)/staging/_components/promotion-dialog.tsx
@@ -6,7 +6,7 @@ import { ArrowRight, AlertTriangle, XCircle, CheckCircle } from "lucide-react";
 import { toast } from "sonner";
 
 import { promotionApi } from "@/lib/api/promotion";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import type { StagingArtifact, BulkPromoteRequest, PolicyViolation } from "@/types/promotion";
 import type { Repository } from "@/types";
 import { useAuth } from "@/providers/auth-provider";
@@ -103,9 +103,7 @@ export function PromotionDialog({
       setSkipPolicyCheck(false);
       onSuccess?.();
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Promotion failed"));
-    },
+    onError: mutationErrorToast("Promotion failed"),
   });
 
   const handlePromote = () => {

--- a/src/app/(app)/staging/_components/rejection-dialog.tsx
+++ b/src/app/(app)/staging/_components/rejection-dialog.tsx
@@ -6,7 +6,7 @@ import { XCircle } from "lucide-react";
 import { toast } from "sonner";
 
 import { promotionApi } from "@/lib/api/promotion";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import type { StagingArtifact } from "@/types/promotion";
 
 import { Button } from "@/components/ui/button";
@@ -73,9 +73,7 @@ export function RejectionDialog({
       setNotes("");
       onSuccess?.();
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Rejection failed"));
-    },
+    onError: mutationErrorToast("Rejection failed"),
   });
 
   const handleReject = () => {

--- a/src/components/common/repo-selector-form.tsx
+++ b/src/components/common/repo-selector-form.tsx
@@ -3,14 +3,13 @@
 import { useState, useCallback } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { Search, Plus, X } from "lucide-react";
-import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
-import { toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast } from "@/lib/error-utils";
 import type { RepoSelector, MatchedRepository } from "@/lib/api/service-accounts";
 import { serviceAccountsApi } from "@/lib/api/service-accounts";
 
@@ -45,9 +44,7 @@ export function RepoSelectorForm({ value, onChange }: RepoSelectorFormProps) {
     onSuccess: (data) => {
       setPreviewResults(data.matched_repositories);
     },
-    onError: (err: unknown) => {
-      toast.error(toUserMessage(err, "Failed to preview repository selector"));
-    },
+    onError: mutationErrorToast("Failed to preview repository selector"),
   });
 
   const toggleFormat = useCallback(

--- a/src/lib/__tests__/error-utils.test.ts
+++ b/src/lib/__tests__/error-utils.test.ts
@@ -1,10 +1,18 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   toUserMessage,
   isAccountLocked,
   isPasswordReuseError,
+  mutationErrorToast,
   PASSWORD_REUSE_MESSAGE,
 } from "../error-utils";
+import { toast } from "sonner";
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
 
 describe("toUserMessage", () => {
   const FALLBACK = "Something went wrong";
@@ -335,5 +343,65 @@ describe("PASSWORD_REUSE_MESSAGE", () => {
   it("is a non-empty string", () => {
     expect(typeof PASSWORD_REUSE_MESSAGE).toBe("string");
     expect(PASSWORD_REUSE_MESSAGE.length).toBeGreaterThan(0);
+  });
+});
+
+describe("mutationErrorToast", () => {
+  const errorMock = vi.mocked(toast.error);
+
+  beforeEach(() => {
+    errorMock.mockClear();
+  });
+
+  it("toasts the Error message when given a standard Error", () => {
+    const handler = mutationErrorToast("Failed to do thing");
+    handler(new Error("Network down"));
+    expect(errorMock).toHaveBeenCalledTimes(1);
+    expect(errorMock).toHaveBeenCalledWith("Network down");
+  });
+
+  it("toasts the SDK .error string when given an SDK-shaped error", () => {
+    const handler = mutationErrorToast("Failed to do thing");
+    handler({ error: "Forbidden" });
+    expect(errorMock).toHaveBeenCalledWith("Forbidden");
+  });
+
+  it("toasts the fallback label for an unrecognized error shape", () => {
+    const handler = mutationErrorToast("Failed to delete repository");
+    handler({ unrelated: 42 });
+    expect(errorMock).toHaveBeenCalledTimes(1);
+    expect(errorMock).toHaveBeenCalledWith("Failed to delete repository");
+  });
+
+  it("toasts the fallback label for null", () => {
+    const handler = mutationErrorToast("Generic failure");
+    handler(null);
+    expect(errorMock).toHaveBeenCalledWith("Generic failure");
+  });
+
+  it("toasts the fallback label for undefined", () => {
+    const handler = mutationErrorToast("Generic failure");
+    handler(undefined);
+    expect(errorMock).toHaveBeenCalledWith("Generic failure");
+  });
+
+  it("returns a reusable handler that does not produce closure side effects across calls", () => {
+    const handler = mutationErrorToast("Fallback label");
+    handler(new Error("first"));
+    handler(new Error("second"));
+    handler({ error: "third" });
+    expect(errorMock).toHaveBeenCalledTimes(3);
+    expect(errorMock).toHaveBeenNthCalledWith(1, "first");
+    expect(errorMock).toHaveBeenNthCalledWith(2, "second");
+    expect(errorMock).toHaveBeenNthCalledWith(3, "third");
+  });
+
+  it("each invocation creates an independent handler with its own label", () => {
+    const handlerA = mutationErrorToast("Label A");
+    const handlerB = mutationErrorToast("Label B");
+    handlerA({});
+    handlerB({});
+    expect(errorMock).toHaveBeenNthCalledWith(1, "Label A");
+    expect(errorMock).toHaveBeenNthCalledWith(2, "Label B");
   });
 });

--- a/src/lib/error-utils.ts
+++ b/src/lib/error-utils.ts
@@ -15,6 +15,8 @@
  *  7. Anything else falls back to the provided default message
  */
 
+import { toast } from "sonner";
+
 /** Return the value if it is a non-empty string, otherwise undefined. */
 function nonEmptyString(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined;
@@ -145,3 +147,16 @@ export function isPasswordReuseError(error: unknown): boolean {
   const msg = toUserMessage(error, '').toLowerCase();
   return PASSWORD_REUSE_PATTERNS.some((pattern) => msg.includes(pattern));
 }
+
+/**
+ * Returns a TanStack Query `onError` handler that toasts the backend error
+ * via toUserMessage with the given fallback label. Shorthand for the
+ * pattern that appears in ~125 mutation callsites.
+ *
+ * @example
+ *   onError: mutationErrorToast("Failed to delete repository"),
+ */
+export const mutationErrorToast = (label: string) =>
+  (err: unknown) => {
+    toast.error(toUserMessage(err, label));
+  };


### PR DESCRIPTION
## Summary

Closes #354.

Adds a `mutationErrorToast(label)` helper to `src/lib/error-utils.ts` and refactors ~120 mutation `onError` callsites across 36 files from:

```ts
onError: (err: unknown) => {
  toast.error(toUserMessage(err, "Failed to <action>"));
},
```

to:

```ts
onError: mutationErrorToast("Failed to <action>"),
```

Net **−145 LOC**. User-visible toast strings unchanged. 7 callsites with non-trivial onError logic (state side effects, branching on `isPasswordReuseError`, etc.) intentionally left as inline.

## Why

After PR #207 standardized error handling, this pattern repeats ~125 times. Centralizing it:
- Removes ~375 lines of boilerplate
- One place to add HTTP status prefixes (#355), truncation (#356), telemetry hooks
- Removes duplicated `import { toast } from "sonner"` / `import { toUserMessage } from "..."` from 35+ files

## Review process

- **R1 build** — SWE agent did the refactor (3 logical commits: helper+tests, refactor, test mocks). 4 R1 reviewers (Senior SE, Test, prod-parity, Completeness) all ship; only finding was missing CHANGELOG. Fixed.
- **R2 simplifier** — skipped (this PR *is* a simplification).
- **R3 fresh-eyes** — verdict ship grade A. Verified: helper signature compatible with TanStack onError, closures isolated per `mutationErrorToast(label)` call, all 3 test mocks updated, build clean, 2017/2017 tests pass.

## Test plan

- [x] `npm test` — 2017/2017 pass (7 new helper tests; 33 existing files updated)
- [x] `npm run lint` — 0 errors
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds
- [x] Coverage on changed lines: 82% (above 80% gate; thin margin noted by Test reviewer)
- [x] 7 skipped callsites verified to have non-trivial onError logic that doesn't fit the helper signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)