### PR TITLE
feat(ci-oidc): admin UI for CI OIDC provider and identity mapping management

### DIFF
--- a/src/app/(app)/(admin)/settings/sso/ci/__tests__/page.test.tsx
+++ b/src/app/(app)/(admin)/settings/sso/ci/__tests__/page.test.tsx
@@ -1,0 +1,541 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, cleanup, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import type {
+  CiOidcProvider,
+  CiOidcIdentityMapping,
+} from "@/types/ci-oidc";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockCiOidcApi = {
+  list: vi.fn(),
+  get: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  enableProvider: vi.fn(),
+  disableProvider: vi.fn(),
+  listMappings: vi.fn(),
+  getMapping: vi.fn(),
+  createMapping: vi.fn(),
+  updateMapping: vi.fn(),
+  deleteMapping: vi.fn(),
+  enableMapping: vi.fn(),
+  disableMapping: vi.fn(),
+};
+
+vi.mock("@/lib/api/ci-oidc", () => ({
+  ciOidcApi: mockCiOidcApi,
+}));
+
+const mockUseRepositories = vi.fn();
+vi.mock("@/hooks/use-repositories", () => ({
+  useRepositories: (...args: unknown[]) => mockUseRepositories(...args),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/lib/error-utils", () => ({
+  mutationErrorToast: () => () => {},
+}));
+
+// Mock UI primitives for predictable jsdom rendering
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div role="dialog">{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/select", () => {
+  const Select = ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value?: string;
+    onValueChange?: (v: string) => void;
+    children: React.ReactNode;
+  }) => (
+    <select value={value ?? ""} onChange={(e) => onValueChange?.(e.target.value)}>
+      {children}
+    </select>
+  );
+  return {
+    Select,
+    SelectTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    SelectValue: () => null,
+    SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
+      <option value={value}>{children}</option>
+    ),
+  };
+});
+
+vi.mock("@/components/ui/checkbox", () => ({
+  Checkbox: ({
+    checked,
+    onCheckedChange,
+  }: {
+    checked?: boolean;
+    onCheckedChange?: (v: boolean) => void;
+  }) => (
+    <input
+      type="checkbox"
+      checked={checked ?? false}
+      onChange={(e) => onCheckedChange?.(e.target.checked)}
+    />
+  ),
+}));
+
+vi.mock("@/components/ui/collapsible", () => ({
+  Collapsible: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CollapsibleTrigger: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CollapsibleContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/common/confirm-dialog", () => ({
+  ConfirmDialog: ({
+    open,
+    onConfirm,
+    title,
+  }: {
+    open: boolean;
+    onConfirm: () => void;
+    title: string;
+  }) =>
+    open ? (
+      <div data-testid="confirm-dialog">
+        <span>{title}</span>
+        <button onClick={onConfirm}>Confirm Delete</button>
+      </div>
+    ) : null,
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const MOCK_PROVIDER: CiOidcProvider = {
+  id: "p1",
+  name: "GitLab Prod",
+  provider_type: "gitlab",
+  issuer_url: "https://gitlab.com",
+  audience: "artifact-keeper",
+  is_enabled: true,
+  mapping_count: 1,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+const MOCK_MAPPING: CiOidcIdentityMapping = {
+  id: "m1",
+  provider_id: "p1",
+  name: "Prod Deployment",
+  priority: 10,
+  claim_filters: { namespace_path: "org/project" },
+  allowed_repo_ids: ["r1"],
+  is_enabled: true,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+const MOCK_REPOSITORIES = {
+  items: [
+    { id: "r1", key: "docker-local", name: "Docker Local" },
+    { id: "r2", key: "maven-local", name: "Maven Local" },
+  ],
+  pagination: { page: 1, per_page: 500, total: 2, total_pages: 1 },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function newQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+let CiOidcPage: React.ComponentType;
+
+async function renderPage() {
+  const qc = newQueryClient();
+  return render(
+    <QueryClientProvider client={qc}>
+      <CiOidcPage />
+    </QueryClientProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("CiOidcPage", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockCiOidcApi.list.mockResolvedValue([MOCK_PROVIDER]);
+    mockCiOidcApi.listMappings.mockResolvedValue([MOCK_MAPPING]);
+    mockUseRepositories.mockReturnValue({
+      data: MOCK_REPOSITORIES,
+      isLoading: false,
+    });
+
+    const mod = await import("../page");
+    CiOidcPage = mod.default;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders page title and list of configured providers", async () => {
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("CI / CD OIDC Providers")).toBeTruthy();
+      expect(screen.getByText("GitLab Prod")).toBeTruthy();
+      expect(screen.getByText("https://gitlab.com")).toBeTruthy();
+    });
+  });
+
+  it("opens create provider dialog and submits new provider", async () => {
+    const user = userEvent.setup();
+    mockCiOidcApi.create.mockResolvedValue({ ...MOCK_PROVIDER, id: "p2", name: "GitHub Actions" });
+
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("GitLab Prod")).toBeTruthy();
+    });
+
+    const addBtn = screen.getByRole("button", { name: /Add Provider/i });
+    await user.click(addBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Add CI OIDC Provider")).toBeTruthy();
+    });
+
+    const nameInput = screen.getByLabelText(/^Name$/i);
+    const issuerInput = screen.getByLabelText(/Issuer URL/i);
+
+    await user.type(nameInput, "GitHub Actions");
+    await user.type(issuerInput, "https://token.actions.githubusercontent.com");
+
+    const submitBtn = screen.getByRole("button", { name: /Create Provider/i });
+    await user.click(submitBtn);
+
+    await waitFor(() => {
+      expect(mockCiOidcApi.create).toHaveBeenCalled();
+      expect(mockCiOidcApi.create.mock.calls[0][0]).toEqual({
+        name: "GitHub Actions",
+        provider_type: "generic",
+        issuer_url: "https://token.actions.githubusercontent.com",
+        audience: "artifact-keeper",
+      });
+    });
+  });
+
+  it("opens edit provider dialog and updates provider settings", async () => {
+    const user = userEvent.setup();
+    mockCiOidcApi.update.mockResolvedValue({ ...MOCK_PROVIDER, name: "GitLab Updated" });
+
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("GitLab Prod")).toBeTruthy();
+    });
+
+    // Find the pencil icon button for editing provider
+    const editBtns = screen.getAllByRole("button");
+    const editBtn = editBtns.find((b) => b.querySelector(".lucide-pencil"));
+    expect(editBtn).toBeTruthy();
+    await user.click(editBtn!);
+
+    await waitFor(() => {
+      expect(screen.getByText("Edit CI OIDC Provider")).toBeTruthy();
+    });
+
+    const nameInput = screen.getByLabelText(/^Name$/i);
+    await user.clear(nameInput);
+    await user.type(nameInput, "GitLab Updated");
+
+    const saveBtn = screen.getByRole("button", { name: /Save Changes/i });
+    await user.click(saveBtn);
+
+    await waitFor(() => {
+      expect(mockCiOidcApi.update).toHaveBeenCalled();
+      expect(mockCiOidcApi.update.mock.calls[0][0]).toBe("p1");
+      expect(mockCiOidcApi.update.mock.calls[0][1]).toEqual({
+        name: "GitLab Updated",
+        provider_type: "gitlab",
+        issuer_url: "https://gitlab.com",
+        audience: "artifact-keeper",
+      });
+    });
+  });
+
+  it("deletes a provider when confirmed", async () => {
+    const user = userEvent.setup();
+    mockCiOidcApi.delete.mockResolvedValue(undefined);
+
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("GitLab Prod")).toBeTruthy();
+    });
+
+    const trashBtns = screen.getAllByRole("button");
+    const trashBtn = trashBtns.find((b) => b.querySelector(".lucide-trash-2"));
+    expect(trashBtn).toBeTruthy();
+    await user.click(trashBtn!);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("confirm-dialog")).toBeTruthy();
+    });
+
+    const confirmBtn = screen.getByRole("button", { name: /Confirm Delete/i });
+    await user.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(mockCiOidcApi.delete).toHaveBeenCalled();
+      expect(mockCiOidcApi.delete.mock.calls[0][0]).toBe("p1");
+    });
+  });
+
+  it("toggles provider active state", async () => {
+    const user = userEvent.setup();
+    mockCiOidcApi.disableProvider.mockResolvedValue(undefined);
+
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("GitLab Prod")).toBeTruthy();
+    });
+
+    const toggleBtn = screen.getAllByRole("button").find((b) => b.querySelector(".lucide-toggle-right"));
+    expect(toggleBtn).toBeTruthy();
+    await user.click(toggleBtn!);
+
+    await waitFor(() => {
+      expect(mockCiOidcApi.disableProvider).toHaveBeenCalled();
+      expect(mockCiOidcApi.disableProvider.mock.calls[0][0]).toBe("p1");
+    });
+  });
+
+  it("renders mappings and allows creating a new mapping", async () => {
+    const user = userEvent.setup();
+    mockCiOidcApi.createMapping.mockResolvedValue({ ...MOCK_MAPPING, id: "m2", name: "New Mapping" });
+
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Prod Deployment")).toBeTruthy();
+    });
+
+    const addMappingBtn = screen.getByRole("button", { name: /Add Mapping/i });
+    await user.click(addMappingBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Add Identity Mapping")).toBeTruthy();
+    });
+
+    const nameInput = screen.getByLabelText(/^Name$/i);
+    await user.type(nameInput, "New Mapping");
+
+    const saveBtn = screen.getByRole("button", { name: /Create Mapping/i });
+    await user.click(saveBtn);
+
+    await waitFor(() => {
+      expect(mockCiOidcApi.createMapping).toHaveBeenCalled();
+      expect(mockCiOidcApi.createMapping.mock.calls[0][0]).toBe("p1");
+      expect(mockCiOidcApi.createMapping.mock.calls[0][1]).toEqual({
+        name: "New Mapping",
+        priority: 100,
+        claim_filters: { namespace_path: "my-org/my-group", ref_protected: "true" },
+        allowed_repo_ids: null,
+        is_enabled: true,
+      });
+    });
+  });
+
+  it("validates claim_filters JSON in mapping dialog", async () => {
+    const user = userEvent.setup();
+
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Prod Deployment")).toBeTruthy();
+    });
+
+    const addMappingBtn = screen.getByRole("button", { name: /Add Mapping/i });
+    await user.click(addMappingBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Add Identity Mapping")).toBeTruthy();
+    });
+
+    const nameInput = screen.getByLabelText(/^Name$/i);
+    await user.type(nameInput, "Invalid Test");
+
+    // Enter invalid JSON
+    const jsonArea = screen.getByLabelText(/Claim Filters/i);
+    await user.clear(jsonArea);
+    await user.type(jsonArea, "{{ invalid json");
+
+    const saveBtn = screen.getByRole("button", { name: /Create Mapping/i });
+    await user.click(saveBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Invalid JSON — please fix claim_filters before saving.")).toBeTruthy();
+      expect(mockCiOidcApi.createMapping).not.toHaveBeenCalled();
+    });
+  });
+
+  it("rejects a priority below 1 in mapping dialog", async () => {
+    const user = userEvent.setup();
+
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Prod Deployment")).toBeTruthy();
+    });
+
+    const addMappingBtn = screen.getByRole("button", { name: /Add Mapping/i });
+    await user.click(addMappingBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Add Identity Mapping")).toBeTruthy();
+    });
+
+    const nameInput = screen.getByLabelText(/^Name$/i);
+    await user.type(nameInput, "Invalid Test");
+
+    // Set priority to 0 via the underlying input value.
+    const priorityInput = screen.getByLabelText(/Priority/i);
+    fireEvent.change(priorityInput, { target: { value: "0" } });
+
+    const saveBtn = screen.getByRole("button", { name: /Create Mapping/i });
+    await user.click(saveBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Priority must be a positive integer (>= 1).")).toBeTruthy();
+      expect(mockCiOidcApi.createMapping).not.toHaveBeenCalled();
+    });
+  });
+
+  it("edits mapping and sends allowed_repo_ids: [] when switching from selected to all repos (bug fix verification)", async () => {
+    const user = userEvent.setup();
+    mockCiOidcApi.updateMapping.mockResolvedValue({ ...MOCK_MAPPING, allowed_repo_ids: null });
+
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Prod Deployment")).toBeTruthy();
+    });
+
+    // Find the edit button inside MappingsPanel table
+    const editBtns = screen.getAllByRole("button");
+    const editMappingBtn = editBtns.find(
+      (b) => b.querySelector(".lucide-pencil") && b.closest("table"),
+    );
+    expect(editMappingBtn).toBeTruthy();
+    await user.click(editMappingBtn!);
+
+    await waitFor(() => {
+      expect(screen.getByText("Edit Identity Mapping")).toBeTruthy();
+    });
+
+    // Switch repo scope mode from "selected" to "all"
+    const selects = screen.getAllByRole("combobox");
+    const repoScopeSelect = selects[selects.length - 1];
+    await user.selectOptions(repoScopeSelect, "all");
+
+    const saveBtn = screen.getByRole("button", { name: /Save Changes/i });
+    await user.click(saveBtn);
+
+    await waitFor(() => {
+      expect(mockCiOidcApi.updateMapping).toHaveBeenCalled();
+      expect(mockCiOidcApi.updateMapping.mock.calls[0][0]).toBe("p1");
+      expect(mockCiOidcApi.updateMapping.mock.calls[0][1]).toBe("m1");
+      expect(mockCiOidcApi.updateMapping.mock.calls[0][2]).toEqual(
+        expect.objectContaining({
+          allowed_repo_ids: [],
+        }),
+      );
+    });
+  });
+
+  it("toggles and deletes identity mapping", async () => {
+    const user = userEvent.setup();
+    mockCiOidcApi.disableMapping.mockResolvedValue(undefined);
+    mockCiOidcApi.deleteMapping.mockResolvedValue(undefined);
+
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Prod Deployment")).toBeTruthy();
+    });
+
+    // Find toggle button inside mappings table
+    const mappingRow = screen.getByText("Prod Deployment").closest("tr");
+    const toggleMappingBtn = mappingRow?.querySelector(".lucide-toggle-right")?.closest("button");
+    expect(toggleMappingBtn).toBeTruthy();
+    await user.click(toggleMappingBtn!);
+
+    await waitFor(() => {
+      expect(mockCiOidcApi.disableMapping).toHaveBeenCalled();
+      expect(mockCiOidcApi.disableMapping.mock.calls[0][0]).toBe("p1");
+      expect(mockCiOidcApi.disableMapping.mock.calls[0][1]).toBe("m1");
+    });
+
+    // Delete mapping
+    const deleteMappingBtn = mappingRow?.querySelector(".lucide-trash-2")?.closest("button");
+    expect(deleteMappingBtn).toBeTruthy();
+    await user.click(deleteMappingBtn!);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("confirm-dialog")).toBeTruthy();
+    });
+
+    const confirmBtn = screen.getByRole("button", { name: /Confirm Delete/i });
+    await user.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(mockCiOidcApi.deleteMapping).toHaveBeenCalled();
+      expect(mockCiOidcApi.deleteMapping.mock.calls[0][0]).toBe("p1");
+      expect(mockCiOidcApi.deleteMapping.mock.calls[0][1]).toBe("m1");
+    });
+  });
+
+  it("shows empty state when no providers exist", async () => {
+    mockCiOidcApi.list.mockResolvedValue([]);
+
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("No CI OIDC providers configured yet.")).toBeTruthy();
+    });
+  });
+});

--- a/src/app/(app)/(admin)/settings/sso/ci/page.tsx
+++ b/src/app/(app)/(admin)/settings/sso/ci/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {
@@ -19,6 +19,7 @@ import {
 } from "lucide-react";
 
 import { ciOidcApi } from "@/lib/api/ci-oidc";
+import { repositoriesApi } from "@/lib/api/repositories";
 import { mutationErrorToast } from "@/lib/error-utils";
 import type {
   CiOidcProvider,
@@ -30,6 +31,7 @@ import type {
   CreateCiOidcMappingRequest,
   UpdateCiOidcMappingRequest,
 } from "@/types/ci-oidc";
+import type { Repository } from "@/types";
 
 import { PageHeader } from "@/components/common/page-header";
 import { StatusBadge } from "@/components/common/status-badge";
@@ -42,6 +44,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Card,
   CardContent,
@@ -135,8 +138,8 @@ const BLANK_MAPPING_FORM = {
   name: "",
   priority: "100",
   claim_filters_raw: "",
-  role_id: "",
-  allowed_repo_ids_raw: "",
+  repo_scope_mode: "all" as "all" | "selected",
+  selected_repo_ids: [] as string[],
   is_enabled: true,
 };
 type MappingForm = typeof BLANK_MAPPING_FORM;
@@ -146,8 +149,8 @@ function mappingFormFromRow(m: CiOidcIdentityMapping): MappingForm {
     name: m.name,
     priority: String(m.priority),
     claim_filters_raw: JSON.stringify(m.claim_filters, null, 2),
-    role_id: m.role_id ?? "",
-    allowed_repo_ids_raw: m.allowed_repo_ids ? m.allowed_repo_ids.join("\n") : "",
+    repo_scope_mode: m.allowed_repo_ids === null ? "all" : "selected",
+    selected_repo_ids: m.allowed_repo_ids ?? [],
     is_enabled: m.is_enabled,
   };
 }
@@ -166,14 +169,6 @@ function parseClaimFilters(raw: string): ClaimFilters | undefined {
   }
 }
 
-function parseRepoIds(raw: string): string[] | null {
-  const ids = raw
-    .split(/[\n,]+/)
-    .map((s) => s.trim())
-    .filter(Boolean);
-  return ids.length ? ids : null;
-}
-
 function claimFilterSummary(filters: ClaimFilters): string {
   const keys = Object.keys(filters);
   if (!keys.length) return "No filters (any JWT accepted)";
@@ -183,6 +178,15 @@ function claimFilterSummary(filters: ClaimFilters): string {
       return Array.isArray(v) ? `${k} ∈ [${v.join(", ")}]` : `${k} = ${v}`;
     })
     .join(", ");
+}
+
+function repoScopeSummary(
+  allowedRepoIds: CiOidcIdentityMapping["allowed_repo_ids"],
+): string {
+  if (allowedRepoIds === null) return "All repositories";
+  if (allowedRepoIds.length === 0) return "No repositories";
+  if (allowedRepoIds.length === 1) return "1 repository";
+  return `${allowedRepoIds.length} repositories`;
 }
 
 // ---------------------------------------------------------------------------
@@ -202,9 +206,21 @@ function MappingsPanel({ provider }: MappingsPanelProps) {
     queryFn: () => ciOidcApi.listMappings(provider.id),
   });
 
+  const { data: repositoriesPage, isLoading: isLoadingRepositories } = useQuery({
+    queryKey: ["repositories", "ci-oidc-picker"],
+    queryFn: () => repositoriesApi.list({ page: 1, per_page: 500 }),
+  });
+  const repositories = useMemo(
+    () => [...(repositoriesPage?.items ?? [])].sort((a, b) => a.key.localeCompare(b.key)),
+    [repositoriesPage?.items],
+  );
+
   const [dialogOpen, setDialogOpen] = useState(false);
-  const [editTarget, setEditTarget] = useState<CiOidcIdentityMapping | null>(null);
-  const [deleteTarget, setDeleteTarget] = useState<CiOidcIdentityMapping | null>(null);
+  const [editTarget, setEditTarget] = useState<CiOidcIdentityMapping | null>(
+    null,
+  );
+  const [deleteTarget, setDeleteTarget] =
+    useState<CiOidcIdentityMapping | null>(null);
   const [form, setForm] = useState<MappingForm>(BLANK_MAPPING_FORM);
   const [filtersError, setFiltersError] = useState<string | null>(null);
 
@@ -225,8 +241,13 @@ function MappingsPanel({ provider }: MappingsPanelProps) {
   });
 
   const updateMutation = useMutation({
-    mutationFn: ({ id, req }: { id: string; req: UpdateCiOidcMappingRequest }) =>
-      ciOidcApi.updateMapping(provider.id, id, req),
+    mutationFn: ({
+      id,
+      req,
+    }: {
+      id: string;
+      req: UpdateCiOidcMappingRequest;
+    }) => ciOidcApi.updateMapping(provider.id, id, req),
     onSuccess: () => {
       invalidate();
       toast.success("Mapping updated");
@@ -276,9 +297,35 @@ function MappingsPanel({ provider }: MappingsPanelProps) {
     setDialogOpen(true);
   }
 
-  function setField<K extends keyof MappingForm>(key: K, value: MappingForm[K]) {
+  function setField<K extends keyof MappingForm>(
+    key: K,
+    value: MappingForm[K],
+  ) {
     setForm((prev) => ({ ...prev, [key]: value }));
   }
+
+  function toggleRepoSelection(repoId: string, checked: boolean) {
+    setForm((prev) => {
+      if (checked) {
+        if (prev.selected_repo_ids.includes(repoId)) return prev;
+        return {
+          ...prev,
+          selected_repo_ids: [...prev.selected_repo_ids, repoId],
+        };
+      }
+      return {
+        ...prev,
+        selected_repo_ids: prev.selected_repo_ids.filter((id) => id !== repoId),
+      };
+    });
+  }
+
+  const selectedRepositories = useMemo(() => {
+    const byId = new Map<string, Repository>(
+      repositories.map((repo) => [repo.id, repo]),
+    );
+    return form.selected_repo_ids.map((id) => byId.get(id)).filter(Boolean) as Repository[];
+  }, [form.selected_repo_ids, repositories]);
 
   function handleSubmit() {
     setFiltersError(null);
@@ -297,8 +344,8 @@ function MappingsPanel({ provider }: MappingsPanelProps) {
       name: form.name,
       priority,
       claim_filters: filters,
-      role_id: form.role_id.trim() || null,
-      allowed_repo_ids: parseRepoIds(form.allowed_repo_ids_raw),
+      allowed_repo_ids:
+        form.repo_scope_mode === "all" ? null : form.selected_repo_ids,
       is_enabled: form.is_enabled,
     };
 
@@ -335,7 +382,7 @@ function MappingsPanel({ provider }: MappingsPanelProps) {
               <TableHead className="pl-6 w-16">Priority</TableHead>
               <TableHead>Name</TableHead>
               <TableHead>Claim Filters</TableHead>
-              <TableHead>Role</TableHead>
+              <TableHead>Repository Scope</TableHead>
               <TableHead>Status</TableHead>
               <TableHead className="text-right pr-6">Actions</TableHead>
             </TableRow>
@@ -352,12 +399,8 @@ function MappingsPanel({ provider }: MappingsPanelProps) {
                 <TableCell className="max-w-[280px] text-xs text-muted-foreground truncate">
                   {claimFilterSummary(m.claim_filters)}
                 </TableCell>
-                <TableCell className="text-xs font-mono text-muted-foreground">
-                  {m.role_id ? (
-                    m.role_id.slice(0, 8) + "…"
-                  ) : (
-                    <span className="italic">none</span>
-                  )}
+                <TableCell className="text-xs text-muted-foreground">
+                  {repoScopeSummary(m.allowed_repo_ids)}
                 </TableCell>
                 <TableCell>
                   <StatusBadge
@@ -372,7 +415,10 @@ function MappingsPanel({ provider }: MappingsPanelProps) {
                       size="icon"
                       className="size-7"
                       onClick={() =>
-                        toggleMutation.mutate({ id: m.id, enabled: !m.is_enabled })
+                        toggleMutation.mutate({
+                          id: m.id,
+                          enabled: !m.is_enabled,
+                        })
                       }
                     >
                       {m.is_enabled ? (
@@ -454,7 +500,9 @@ function MappingsPanel({ provider }: MappingsPanelProps) {
             <div className="space-y-1.5">
               <Label htmlFor="m-filters">
                 Claim Filters{" "}
-                <span className="text-muted-foreground font-normal">(JSON)</span>
+                <span className="text-muted-foreground font-normal">
+                  (JSON)
+                </span>
               </Label>
               <Textarea
                 id="m-filters"
@@ -475,42 +523,82 @@ function MappingsPanel({ provider }: MappingsPanelProps) {
               </p>
             </div>
 
-            <div className="space-y-1.5">
-              <Label htmlFor="m-role">
-                Role ID{" "}
-                <span className="text-muted-foreground font-normal">
-                  (optional UUID)
-                </span>
-              </Label>
-              <Input
-                id="m-role"
-                className="font-mono text-xs"
-                placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-                value={form.role_id}
-                onChange={(e) => setField("role_id", e.target.value)}
-              />
-              <p className="text-xs text-muted-foreground">
-                AK Role to assign to the service account for this mapping. Find
-                Role UUIDs under{" "}
-                <span className="font-medium">Users → Roles</span>.
-              </p>
-            </div>
+            <div className="space-y-2">
+              <Label>Repository Access Scope</Label>
+              <Select
+                value={form.repo_scope_mode}
+                onValueChange={(value) =>
+                  setField("repo_scope_mode", value as MappingForm["repo_scope_mode"])
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All repositories</SelectItem>
+                  <SelectItem value="selected">Selected repositories only</SelectItem>
+                </SelectContent>
+              </Select>
 
-            <div className="space-y-1.5">
-              <Label htmlFor="m-repos">
-                Allowed Repository IDs{" "}
-                <span className="text-muted-foreground font-normal">
-                  (optional, one UUID per line)
-                </span>
-              </Label>
-              <Textarea
-                id="m-repos"
-                rows={3}
-                className="font-mono text-xs"
-                placeholder="Leave empty to allow access to all repositories."
-                value={form.allowed_repo_ids_raw}
-                onChange={(e) => setField("allowed_repo_ids_raw", e.target.value)}
-              />
+              {form.repo_scope_mode === "selected" && (
+                <div className="space-y-2 rounded-md border p-3">
+                  {isLoadingRepositories ? (
+                    <div className="space-y-2">
+                      <Skeleton className="h-6 w-full" />
+                      <Skeleton className="h-6 w-full" />
+                    </div>
+                  ) : repositories.length === 0 ? (
+                    <p className="text-xs text-muted-foreground">
+                      No repositories found.
+                    </p>
+                  ) : (
+                    <>
+                      <div className="max-h-44 overflow-y-auto space-y-1 pr-1">
+                        {repositories.map((repo) => {
+                          const checked = form.selected_repo_ids.includes(repo.id);
+                          return (
+                            <label
+                              key={repo.id}
+                              className="flex items-start gap-2 rounded p-1.5 hover:bg-muted cursor-pointer"
+                            >
+                              <Checkbox
+                                checked={checked}
+                                onCheckedChange={(value) =>
+                                  toggleRepoSelection(repo.id, value === true)
+                                }
+                                className="mt-0.5"
+                              />
+                              <span className="min-w-0">
+                                <span className="block text-sm font-medium truncate">
+                                  {repo.name}
+                                </span>
+                                <span className="block text-xs text-muted-foreground font-mono truncate">
+                                  {repo.key}
+                                </span>
+                              </span>
+                            </label>
+                          );
+                        })}
+                      </div>
+
+                      {selectedRepositories.length > 0 && (
+                        <div className="flex flex-wrap gap-1 pt-1">
+                          {selectedRepositories.map((repo) => (
+                            <Badge key={repo.id} variant="secondary" className="text-xs">
+                              {repo.key}
+                            </Badge>
+                          ))}
+                        </div>
+                      )}
+
+                      <p className="text-xs text-muted-foreground">
+                        Pick the repositories this mapping may publish to.
+                        Leaving all unchecked will deny repository access.
+                      </p>
+                    </>
+                  )}
+                </div>
+              )}
             </div>
           </div>
 
@@ -572,8 +660,13 @@ export default function CiOidcPage() {
   });
 
   const updateMutation = useMutation({
-    mutationFn: ({ id, data }: { id: string; data: UpdateCiOidcProviderRequest }) =>
-      ciOidcApi.update(id, data),
+    mutationFn: ({
+      id,
+      data,
+    }: {
+      id: string;
+      data: UpdateCiOidcProviderRequest;
+    }) => ciOidcApi.update(id, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["ci-oidc"] });
       toast.success("CI OIDC provider updated");
@@ -617,7 +710,10 @@ export default function CiOidcPage() {
     setDialogOpen(true);
   }
 
-  function setField<K extends keyof ProviderForm>(key: K, value: ProviderForm[K]) {
+  function setField<K extends keyof ProviderForm>(
+    key: K,
+    value: ProviderForm[K],
+  ) {
     setForm((prev) => ({ ...prev, [key]: value }));
   }
 
@@ -665,7 +761,11 @@ export default function CiOidcPage() {
         <ShieldCheck className="size-4" />
         <AlertTitle>Identity Mapping model</AlertTitle>
         <AlertDescription>
-          Each provider holds priority-ordered <strong>Identity Mappings</strong>. When a pipeline posts its CI JWT, the first enabled mapping whose claim filters all match wins — the pipeline authenticates as a stable service account with the mapping&apos;s assigned role. No static secrets required.
+          Each provider holds priority-ordered{" "}
+          <strong>Identity Mappings</strong>. When a pipeline posts its CI JWT,
+          the first enabled mapping whose claim filters all match wins — the
+          pipeline authenticates as a stable service account. No static secrets
+          required.
         </AlertDescription>
       </Alert>
 
@@ -717,7 +817,8 @@ export default function CiOidcPage() {
 
                       <div className="flex items-center gap-1.5 min-w-[100px] text-sm text-muted-foreground shrink-0">
                         <ProviderTypeIcon type={p.provider_type} />
-                        {PROVIDER_TYPE_LABELS[p.provider_type] ?? p.provider_type}
+                        {PROVIDER_TYPE_LABELS[p.provider_type] ??
+                          p.provider_type}
                       </div>
 
                       <div className="flex-1 min-w-0">

--- a/src/app/(app)/(admin)/settings/sso/ci/page.tsx
+++ b/src/app/(app)/(admin)/settings/sso/ci/page.tsx
@@ -1,0 +1,913 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+  Plus,
+  Pencil,
+  Trash2,
+  ToggleLeft,
+  ToggleRight,
+  Loader2,
+  GitBranch,
+  Cpu,
+  ChevronDown,
+  ChevronRight,
+  Filter,
+  ShieldCheck,
+} from "lucide-react";
+
+import { ciOidcApi } from "@/lib/api/ci-oidc";
+import { mutationErrorToast } from "@/lib/error-utils";
+import type {
+  CiOidcProvider,
+  CiOidcIdentityMapping,
+  CiOidcProviderType,
+  ClaimFilters,
+  CreateCiOidcProviderRequest,
+  UpdateCiOidcProviderRequest,
+  CreateCiOidcMappingRequest,
+  UpdateCiOidcMappingRequest,
+} from "@/types/ci-oidc";
+
+import { PageHeader } from "@/components/common/page-header";
+import { StatusBadge } from "@/components/common/status-badge";
+import { ConfirmDialog } from "@/components/common/confirm-dialog";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+
+// ---------------------------------------------------------------------------
+// Provider type helpers
+// ---------------------------------------------------------------------------
+
+const PROVIDER_TYPE_LABELS: Record<CiOidcProviderType, string> = {
+  gitlab: "GitLab",
+  github: "GitHub Actions",
+  generic: "Generic OIDC",
+};
+
+const DEFAULT_ISSUER: Record<CiOidcProviderType, string> = {
+  gitlab: "https://gitlab.com",
+  github: "https://token.actions.githubusercontent.com",
+  generic: "",
+};
+
+const CLAIM_PLACEHOLDER: Record<CiOidcProviderType, string> = {
+  gitlab: `{\n  "namespace_path": "my-org/my-group",\n  "ref_protected": "true"\n}`,
+  github: `{\n  "repository": "my-org/my-repo",\n  "ref": "refs/heads/main"\n}`,
+  generic: `{\n  "sub": "system:serviceaccount:prod"\n}`,
+};
+
+function ProviderTypeIcon({ type }: { type: string }) {
+  if (type === "gitlab" || type === "github")
+    return <GitBranch className="size-4" />;
+  return <Cpu className="size-4" />;
+}
+
+// ---------------------------------------------------------------------------
+// Provider form
+// ---------------------------------------------------------------------------
+
+const BLANK_PROVIDER_FORM = {
+  name: "",
+  provider_type: "generic" as CiOidcProviderType,
+  issuer_url: "",
+  audience: "artifact-keeper",
+};
+type ProviderForm = typeof BLANK_PROVIDER_FORM;
+
+function providerFormFromRow(p: CiOidcProvider): ProviderForm {
+  return {
+    name: p.name,
+    provider_type: p.provider_type,
+    issuer_url: p.issuer_url,
+    audience: p.audience,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mapping form
+// ---------------------------------------------------------------------------
+
+const BLANK_MAPPING_FORM = {
+  name: "",
+  priority: "100",
+  claim_filters_raw: "",
+  role_id: "",
+  allowed_repo_ids_raw: "",
+  is_enabled: true,
+};
+type MappingForm = typeof BLANK_MAPPING_FORM;
+
+function mappingFormFromRow(m: CiOidcIdentityMapping): MappingForm {
+  return {
+    name: m.name,
+    priority: String(m.priority),
+    claim_filters_raw: JSON.stringify(m.claim_filters, null, 2),
+    role_id: m.role_id ?? "",
+    allowed_repo_ids_raw: m.allowed_repo_ids ? m.allowed_repo_ids.join("\n") : "",
+    is_enabled: m.is_enabled,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parseClaimFilters(raw: string): ClaimFilters | undefined {
+  const t = raw.trim();
+  if (!t) return {};
+  try {
+    return JSON.parse(t) as ClaimFilters;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseRepoIds(raw: string): string[] | null {
+  const ids = raw
+    .split(/[\n,]+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return ids.length ? ids : null;
+}
+
+function claimFilterSummary(filters: ClaimFilters): string {
+  const keys = Object.keys(filters);
+  if (!keys.length) return "No filters (any JWT accepted)";
+  return keys
+    .map((k) => {
+      const v = filters[k];
+      return Array.isArray(v) ? `${k} ∈ [${v.join(", ")}]` : `${k} = ${v}`;
+    })
+    .join(", ");
+}
+
+// ---------------------------------------------------------------------------
+// Mappings sub-panel
+// ---------------------------------------------------------------------------
+
+interface MappingsPanelProps {
+  provider: CiOidcProvider;
+}
+
+function MappingsPanel({ provider }: MappingsPanelProps) {
+  const queryClient = useQueryClient();
+  const qKey = ["ci-oidc-mappings", provider.id];
+
+  const { data: mappings, isLoading } = useQuery({
+    queryKey: qKey,
+    queryFn: () => ciOidcApi.listMappings(provider.id),
+  });
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<CiOidcIdentityMapping | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<CiOidcIdentityMapping | null>(null);
+  const [form, setForm] = useState<MappingForm>(BLANK_MAPPING_FORM);
+  const [filtersError, setFiltersError] = useState<string | null>(null);
+
+  function invalidate() {
+    queryClient.invalidateQueries({ queryKey: qKey });
+    queryClient.invalidateQueries({ queryKey: ["ci-oidc"] });
+  }
+
+  const createMutation = useMutation({
+    mutationFn: (req: CreateCiOidcMappingRequest) =>
+      ciOidcApi.createMapping(provider.id, req),
+    onSuccess: () => {
+      invalidate();
+      toast.success("Mapping created");
+      closeDialog();
+    },
+    onError: mutationErrorToast("Failed to create mapping"),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, req }: { id: string; req: UpdateCiOidcMappingRequest }) =>
+      ciOidcApi.updateMapping(provider.id, id, req),
+    onSuccess: () => {
+      invalidate();
+      toast.success("Mapping updated");
+      closeDialog();
+    },
+    onError: mutationErrorToast("Failed to update mapping"),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => ciOidcApi.deleteMapping(provider.id, id),
+    onSuccess: () => {
+      invalidate();
+      toast.success("Mapping deleted");
+      setDeleteTarget(null);
+    },
+    onError: mutationErrorToast("Failed to delete mapping"),
+  });
+
+  const toggleMutation = useMutation({
+    mutationFn: ({ id, enabled }: { id: string; enabled: boolean }) =>
+      ciOidcApi.toggleMapping(provider.id, id, { enabled }),
+    onSuccess: () => invalidate(),
+    onError: mutationErrorToast("Failed to toggle mapping"),
+  });
+
+  function closeDialog() {
+    setDialogOpen(false);
+    setEditTarget(null);
+    setForm(BLANK_MAPPING_FORM);
+    setFiltersError(null);
+  }
+
+  function openCreate() {
+    setEditTarget(null);
+    setForm({
+      ...BLANK_MAPPING_FORM,
+      claim_filters_raw: CLAIM_PLACEHOLDER[provider.provider_type] ?? "",
+    });
+    setFiltersError(null);
+    setDialogOpen(true);
+  }
+
+  function openEdit(m: CiOidcIdentityMapping) {
+    setEditTarget(m);
+    setForm(mappingFormFromRow(m));
+    setFiltersError(null);
+    setDialogOpen(true);
+  }
+
+  function setField<K extends keyof MappingForm>(key: K, value: MappingForm[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  }
+
+  function handleSubmit() {
+    setFiltersError(null);
+    const filters = parseClaimFilters(form.claim_filters_raw);
+    if (filters === undefined) {
+      setFiltersError("Invalid JSON — please fix claim_filters before saving.");
+      return;
+    }
+    const priority = parseInt(form.priority, 10);
+    if (isNaN(priority)) {
+      setFiltersError("Priority must be a number.");
+      return;
+    }
+
+    const payload = {
+      name: form.name,
+      priority,
+      claim_filters: filters,
+      role_id: form.role_id.trim() || null,
+      allowed_repo_ids: parseRepoIds(form.allowed_repo_ids_raw),
+      is_enabled: form.is_enabled,
+    };
+
+    if (editTarget) {
+      updateMutation.mutate({ id: editTarget.id, req: payload });
+    } else {
+      createMutation.mutate(payload as CreateCiOidcMappingRequest);
+    }
+  }
+
+  const isSaving = createMutation.isPending || updateMutation.isPending;
+
+  return (
+    <div className="border-t bg-muted/30">
+      <div className="px-6 py-3 flex items-center justify-between">
+        <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+          Identity Mappings
+        </span>
+        <Button size="sm" variant="outline" onClick={openCreate}>
+          <Plus className="size-3.5 mr-1" />
+          Add Mapping
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <div className="px-6 pb-4 space-y-2">
+          <Skeleton className="h-8 w-full" />
+          <Skeleton className="h-8 w-full" />
+        </div>
+      ) : mappings && mappings.length > 0 ? (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="pl-6 w-16">Priority</TableHead>
+              <TableHead>Name</TableHead>
+              <TableHead>Claim Filters</TableHead>
+              <TableHead>Role</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead className="text-right pr-6">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {mappings.map((m) => (
+              <TableRow key={m.id}>
+                <TableCell className="pl-6">
+                  <Badge variant="outline" className="font-mono text-xs">
+                    {m.priority}
+                  </Badge>
+                </TableCell>
+                <TableCell className="font-medium">{m.name}</TableCell>
+                <TableCell className="max-w-[280px] text-xs text-muted-foreground truncate">
+                  {claimFilterSummary(m.claim_filters)}
+                </TableCell>
+                <TableCell className="text-xs font-mono text-muted-foreground">
+                  {m.role_id ? (
+                    m.role_id.slice(0, 8) + "…"
+                  ) : (
+                    <span className="italic">none</span>
+                  )}
+                </TableCell>
+                <TableCell>
+                  <StatusBadge
+                    status={m.is_enabled ? "Active" : "Disabled"}
+                    color={m.is_enabled ? "green" : "default"}
+                  />
+                </TableCell>
+                <TableCell className="text-right pr-6">
+                  <div className="flex items-center justify-end gap-1">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="size-7"
+                      onClick={() =>
+                        toggleMutation.mutate({ id: m.id, enabled: !m.is_enabled })
+                      }
+                    >
+                      {m.is_enabled ? (
+                        <ToggleRight className="size-3.5 text-emerald-600" />
+                      ) : (
+                        <ToggleLeft className="size-3.5 text-muted-foreground" />
+                      )}
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="size-7"
+                      onClick={() => openEdit(m)}
+                    >
+                      <Pencil className="size-3.5" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="size-7 text-destructive hover:text-destructive"
+                      onClick={() => setDeleteTarget(m)}
+                    >
+                      <Trash2 className="size-3.5" />
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      ) : (
+        <div className="px-6 pb-6 text-center text-sm text-muted-foreground">
+          <Filter className="size-6 mx-auto mb-2 text-muted-foreground/40" />
+          No identity mappings yet. Add one to allow pipelines to authenticate.
+        </div>
+      )}
+
+      {/* Mapping Create/Edit Dialog */}
+      <Dialog open={dialogOpen} onOpenChange={(open) => !open && closeDialog()}>
+        <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>
+              {editTarget ? "Edit Identity Mapping" : "Add Identity Mapping"}
+            </DialogTitle>
+            <DialogDescription>
+              Mappings are evaluated in priority order (lowest number first).
+              The first enabled mapping whose claim filters all match the CI JWT
+              wins.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="m-name">Name</Label>
+              <Input
+                id="m-name"
+                placeholder="e.g. Production deploy jobs"
+                value={form.name}
+                onChange={(e) => setField("name", e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="m-priority">Priority</Label>
+              <Input
+                id="m-priority"
+                type="number"
+                min={1}
+                placeholder="100"
+                value={form.priority}
+                onChange={(e) => setField("priority", e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                Lower = evaluated first. Use 10, 20, 30 … to leave room for
+                reordering.
+              </p>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="m-filters">
+                Claim Filters{" "}
+                <span className="text-muted-foreground font-normal">(JSON)</span>
+              </Label>
+              <Textarea
+                id="m-filters"
+                rows={5}
+                className="font-mono text-xs"
+                placeholder={CLAIM_PLACEHOLDER[provider.provider_type]}
+                value={form.claim_filters_raw}
+                onChange={(e) => setField("claim_filters_raw", e.target.value)}
+              />
+              {filtersError && (
+                <p className="text-xs text-destructive">{filtersError}</p>
+              )}
+              <p className="text-xs text-muted-foreground">
+                Every key must match the CI JWT. Array values use any-of
+                semantics:{" "}
+                <code className="text-xs">{`"namespace_path": ["group-a", "group-b"]`}</code>
+                . Empty object matches any valid JWT.
+              </p>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="m-role">
+                Role ID{" "}
+                <span className="text-muted-foreground font-normal">
+                  (optional UUID)
+                </span>
+              </Label>
+              <Input
+                id="m-role"
+                className="font-mono text-xs"
+                placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+                value={form.role_id}
+                onChange={(e) => setField("role_id", e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                AK Role to assign to the service account for this mapping. Find
+                Role UUIDs under{" "}
+                <span className="font-medium">Users → Roles</span>.
+              </p>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="m-repos">
+                Allowed Repository IDs{" "}
+                <span className="text-muted-foreground font-normal">
+                  (optional, one UUID per line)
+                </span>
+              </Label>
+              <Textarea
+                id="m-repos"
+                rows={3}
+                className="font-mono text-xs"
+                placeholder="Leave empty to allow access to all repositories."
+                value={form.allowed_repo_ids_raw}
+                onChange={(e) => setField("allowed_repo_ids_raw", e.target.value)}
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={closeDialog}>
+              Cancel
+            </Button>
+            <Button onClick={handleSubmit} disabled={isSaving || !form.name}>
+              {isSaving && <Loader2 className="size-4 mr-1.5 animate-spin" />}
+              {editTarget ? "Save Changes" : "Create Mapping"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmDialog
+        open={!!deleteTarget}
+        title="Delete Identity Mapping"
+        description={`Remove "${deleteTarget?.name}"? Pipelines that matched this mapping will no longer be able to authenticate.`}
+        confirmText="Delete"
+        danger
+        onConfirm={() => {
+          if (deleteTarget) deleteMutation.mutate(deleteTarget.id);
+        }}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export default function CiOidcPage() {
+  const queryClient = useQueryClient();
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<CiOidcProvider | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<CiOidcProvider | null>(null);
+  const [form, setForm] = useState<ProviderForm>(BLANK_PROVIDER_FORM);
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+
+  const { data: providers, isLoading } = useQuery({
+    queryKey: ["ci-oidc"],
+    queryFn: ciOidcApi.list,
+  });
+
+  const createMutation = useMutation({
+    mutationFn: ciOidcApi.create,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["ci-oidc"] });
+      toast.success("CI OIDC provider created");
+      closeDialog();
+    },
+    onError: mutationErrorToast("Failed to create CI OIDC provider"),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateCiOidcProviderRequest }) =>
+      ciOidcApi.update(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["ci-oidc"] });
+      toast.success("CI OIDC provider updated");
+      closeDialog();
+    },
+    onError: mutationErrorToast("Failed to update CI OIDC provider"),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: ciOidcApi.delete,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["ci-oidc"] });
+      toast.success("CI OIDC provider deleted");
+      setDeleteTarget(null);
+    },
+    onError: mutationErrorToast("Failed to delete CI OIDC provider"),
+  });
+
+  const toggleMutation = useMutation({
+    mutationFn: ({ id, enabled }: { id: string; enabled: boolean }) =>
+      ciOidcApi.toggle(id, { enabled }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["ci-oidc"] }),
+    onError: mutationErrorToast("Failed to toggle CI OIDC provider"),
+  });
+
+  function closeDialog() {
+    setDialogOpen(false);
+    setEditTarget(null);
+    setForm(BLANK_PROVIDER_FORM);
+  }
+
+  function openCreate() {
+    setEditTarget(null);
+    setForm(BLANK_PROVIDER_FORM);
+    setDialogOpen(true);
+  }
+
+  function openEdit(p: CiOidcProvider) {
+    setEditTarget(p);
+    setForm(providerFormFromRow(p));
+    setDialogOpen(true);
+  }
+
+  function setField<K extends keyof ProviderForm>(key: K, value: ProviderForm[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  }
+
+  function handleProviderTypeChange(t: CiOidcProviderType) {
+    setForm((prev) => ({
+      ...prev,
+      provider_type: t,
+      issuer_url: prev.issuer_url || DEFAULT_ISSUER[t],
+    }));
+  }
+
+  function handleSubmit() {
+    const payload = {
+      name: form.name,
+      provider_type: form.provider_type,
+      issuer_url: form.issuer_url,
+      audience: form.audience || "artifact-keeper",
+    };
+    if (editTarget) {
+      updateMutation.mutate({ id: editTarget.id, data: payload });
+    } else {
+      createMutation.mutate(payload as CreateCiOidcProviderRequest);
+    }
+  }
+
+  function toggleExpanded(id: string) {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  const isSaving = createMutation.isPending || updateMutation.isPending;
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="CI / CD OIDC Providers"
+        description="Allow CI pipelines to authenticate without static API tokens using priority-ordered identity mappings."
+      />
+
+      <Alert>
+        <ShieldCheck className="size-4" />
+        <AlertTitle>Identity Mapping model</AlertTitle>
+        <AlertDescription>
+          Each provider holds priority-ordered <strong>Identity Mappings</strong>. When a pipeline posts its CI JWT, the first enabled mapping whose claim filters all match wins — the pipeline authenticates as a stable service account with the mapping&apos;s assigned role. No static secrets required.
+        </AlertDescription>
+      </Alert>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <div>
+            <CardTitle className="text-base">Configured Providers</CardTitle>
+            <CardDescription>
+              Expand a provider row to manage its identity mappings.
+            </CardDescription>
+          </div>
+          <Button size="sm" onClick={openCreate}>
+            <Plus className="size-4 mr-1.5" />
+            Add Provider
+          </Button>
+        </CardHeader>
+
+        <CardContent className="p-0">
+          {isLoading ? (
+            <div className="px-6 pb-6 space-y-2">
+              {[0, 1, 2].map((i) => (
+                <Skeleton key={i} className="h-12 w-full" />
+              ))}
+            </div>
+          ) : providers && providers.length > 0 ? (
+            <div className="divide-y">
+              {providers.map((p) => {
+                const expanded = expandedIds.has(p.id);
+                return (
+                  <Collapsible
+                    key={p.id}
+                    open={expanded}
+                    onOpenChange={() => toggleExpanded(p.id)}
+                  >
+                    <div className="flex items-center gap-3 px-6 py-3">
+                      <CollapsibleTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="size-7 shrink-0"
+                        >
+                          {expanded ? (
+                            <ChevronDown className="size-4" />
+                          ) : (
+                            <ChevronRight className="size-4" />
+                          )}
+                        </Button>
+                      </CollapsibleTrigger>
+
+                      <div className="flex items-center gap-1.5 min-w-[100px] text-sm text-muted-foreground shrink-0">
+                        <ProviderTypeIcon type={p.provider_type} />
+                        {PROVIDER_TYPE_LABELS[p.provider_type] ?? p.provider_type}
+                      </div>
+
+                      <div className="flex-1 min-w-0">
+                        <p className="font-medium text-sm truncate">{p.name}</p>
+                        <p className="text-xs text-muted-foreground font-mono truncate">
+                          {p.issuer_url}
+                        </p>
+                      </div>
+
+                      <Badge variant="secondary" className="text-xs shrink-0">
+                        {p.mapping_count} mapping
+                        {p.mapping_count !== 1 ? "s" : ""}
+                      </Badge>
+
+                      <StatusBadge
+                        status={p.is_enabled ? "Active" : "Disabled"}
+                        color={p.is_enabled ? "green" : "default"}
+                      />
+
+                      <div className="flex items-center gap-1 shrink-0">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="size-8"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            toggleMutation.mutate({
+                              id: p.id,
+                              enabled: !p.is_enabled,
+                            });
+                          }}
+                        >
+                          {p.is_enabled ? (
+                            <ToggleRight className="size-4 text-emerald-600" />
+                          ) : (
+                            <ToggleLeft className="size-4 text-muted-foreground" />
+                          )}
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="size-8"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            openEdit(p);
+                          }}
+                        >
+                          <Pencil className="size-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="size-8 text-destructive hover:text-destructive"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setDeleteTarget(p);
+                          }}
+                        >
+                          <Trash2 className="size-4" />
+                        </Button>
+                      </div>
+                    </div>
+
+                    <CollapsibleContent>
+                      <MappingsPanel provider={p} />
+                    </CollapsibleContent>
+                  </Collapsible>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="flex flex-col items-center justify-center py-12 text-center px-6">
+              <Cpu className="size-10 text-muted-foreground/50 mb-3" />
+              <p className="text-sm text-muted-foreground">
+                No CI OIDC providers configured yet.
+              </p>
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-4"
+                onClick={openCreate}
+              >
+                <Plus className="size-4 mr-1.5" />
+                Add Provider
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Provider Create / Edit Dialog */}
+      <Dialog open={dialogOpen} onOpenChange={(open) => !open && closeDialog()}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              {editTarget ? "Edit CI OIDC Provider" : "Add CI OIDC Provider"}
+            </DialogTitle>
+            <DialogDescription>
+              {editTarget
+                ? "Update provider settings. Identity mappings are managed by expanding the provider row."
+                : "Register a CI/CD identity provider. After creation, expand the row to add identity mappings."}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="ci-name">Name</Label>
+              <Input
+                id="ci-name"
+                placeholder="e.g. GitLab Production"
+                value={form.name}
+                onChange={(e) => setField("name", e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="ci-type">Provider Type</Label>
+              <Select
+                value={form.provider_type}
+                onValueChange={(v) =>
+                  handleProviderTypeChange(v as CiOidcProviderType)
+                }
+              >
+                <SelectTrigger id="ci-type">
+                  <SelectValue placeholder="Select type" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="gitlab">GitLab</SelectItem>
+                  <SelectItem value="github">GitHub Actions</SelectItem>
+                  <SelectItem value="generic">Generic OIDC</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="ci-issuer">Issuer URL</Label>
+              <Input
+                id="ci-issuer"
+                placeholder="https://gitlab.com"
+                value={form.issuer_url}
+                onChange={(e) => setField("issuer_url", e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                Must match the <code>iss</code> claim in the CI JWT exactly.
+              </p>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="ci-audience">Audience</Label>
+              <Input
+                id="ci-audience"
+                placeholder="artifact-keeper"
+                value={form.audience}
+                onChange={(e) => setField("audience", e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                The <code>aud</code> claim the CI JWT must contain.
+              </p>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={closeDialog}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleSubmit}
+              disabled={isSaving || !form.name || !form.issuer_url}
+            >
+              {isSaving && <Loader2 className="size-4 mr-1.5 animate-spin" />}
+              {editTarget ? "Save Changes" : "Create Provider"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Provider Delete Confirm */}
+      <ConfirmDialog
+        open={!!deleteTarget}
+        title="Delete CI OIDC Provider"
+        description={`This will permanently remove "${deleteTarget?.name}" and all its identity mappings. Pipelines using this provider will stop working.`}
+        confirmText="Delete"
+        danger
+        onConfirm={() => {
+          if (deleteTarget) deleteMutation.mutate(deleteTarget.id);
+        }}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+      />
+    </div>
+  );
+}

--- a/src/app/(app)/(admin)/settings/sso/ci/page.tsx
+++ b/src/app/(app)/(admin)/settings/sso/ci/page.tsx
@@ -19,7 +19,8 @@ import {
 } from "lucide-react";
 
 import { ciOidcApi } from "@/lib/api/ci-oidc";
-import { repositoriesApi } from "@/lib/api/repositories";
+import { useRepositories } from "@/hooks/use-repositories";
+import { QUERY_KEYS } from "@/lib/query-keys";
 import { mutationErrorToast } from "@/lib/error-utils";
 import type {
   CiOidcProvider,
@@ -35,6 +36,7 @@ import type { Repository } from "@/types";
 
 import { PageHeader } from "@/components/common/page-header";
 import { StatusBadge } from "@/components/common/status-badge";
+import { ListTruncationNotice } from "@/components/common/list-truncation-notice";
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
 
 import { Button } from "@/components/ui/button";
@@ -85,7 +87,7 @@ import {
 // Provider type helpers
 // ---------------------------------------------------------------------------
 
-const PROVIDER_TYPE_LABELS: Record<CiOidcProviderType, string> = {
+const PROVIDER_TYPE_LABELS: Record<string, string> = {
   gitlab: "GitLab",
   github: "GitHub Actions",
   generic: "Generic OIDC",
@@ -97,7 +99,7 @@ const DEFAULT_ISSUER: Record<CiOidcProviderType, string> = {
   generic: "",
 };
 
-const CLAIM_PLACEHOLDER: Record<CiOidcProviderType, string> = {
+const CLAIM_PLACEHOLDER: Record<string, string> = {
   gitlab: `{\n  "namespace_path": "my-org/my-group",\n  "ref_protected": "true"\n}`,
   github: `{\n  "repository": "my-org/my-repo",\n  "ref": "refs/heads/main"\n}`,
   generic: `{\n  "sub": "system:serviceaccount:prod"\n}`,
@@ -124,7 +126,7 @@ type ProviderForm = typeof BLANK_PROVIDER_FORM;
 function providerFormFromRow(p: CiOidcProvider): ProviderForm {
   return {
     name: p.name,
-    provider_type: p.provider_type,
+    provider_type: p.provider_type as CiOidcProviderType,
     issuer_url: p.issuer_url,
     audience: p.audience,
   };
@@ -159,17 +161,21 @@ function mappingFormFromRow(m: CiOidcIdentityMapping): MappingForm {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function parseClaimFilters(raw: string): ClaimFilters | undefined {
+export function parseClaimFilters(raw: string): ClaimFilters | undefined {
   const t = raw.trim();
   if (!t) return {};
   try {
-    return JSON.parse(t) as ClaimFilters;
+    const parsed = JSON.parse(t);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return undefined;
+    }
+    return parsed as ClaimFilters;
   } catch {
     return undefined;
   }
 }
 
-function claimFilterSummary(filters: ClaimFilters): string {
+export function claimFilterSummary(filters: ClaimFilters): string {
   const keys = Object.keys(filters);
   if (!keys.length) return "No filters (any JWT accepted)";
   return keys
@@ -180,7 +186,7 @@ function claimFilterSummary(filters: ClaimFilters): string {
     .join(", ");
 }
 
-function repoScopeSummary(
+export function repoScopeSummary(
   allowedRepoIds: CiOidcIdentityMapping["allowed_repo_ids"],
 ): string {
   if (allowedRepoIds === null) return "All repositories";
@@ -199,21 +205,20 @@ interface MappingsPanelProps {
 
 function MappingsPanel({ provider }: MappingsPanelProps) {
   const queryClient = useQueryClient();
-  const qKey = ["ci-oidc-mappings", provider.id];
+  const qKey = [...QUERY_KEYS.CI_OIDC_MAPPINGS, provider.id];
 
   const { data: mappings, isLoading } = useQuery({
     queryKey: qKey,
     queryFn: () => ciOidcApi.listMappings(provider.id),
   });
 
-  const { data: repositoriesPage, isLoading: isLoadingRepositories } = useQuery({
-    queryKey: ["repositories", "ci-oidc-picker"],
-    queryFn: () => repositoriesApi.list({ page: 1, per_page: 500 }),
-  });
+  const { data: repositoriesPage, isLoading: isLoadingRepositories } =
+    useRepositories({ page: 1, per_page: 500 });
   const repositories = useMemo(
     () => [...(repositoriesPage?.items ?? [])].sort((a, b) => a.key.localeCompare(b.key)),
     [repositoriesPage?.items],
   );
+  const totalRepos = repositoriesPage?.pagination.total ?? 0;
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<CiOidcIdentityMapping | null>(
@@ -226,7 +231,7 @@ function MappingsPanel({ provider }: MappingsPanelProps) {
 
   function invalidate() {
     queryClient.invalidateQueries({ queryKey: qKey });
-    queryClient.invalidateQueries({ queryKey: ["ci-oidc"] });
+    queryClient.invalidateQueries({ queryKey: QUERY_KEYS.CI_OIDC });
   }
 
   const createMutation = useMutation({
@@ -268,7 +273,9 @@ function MappingsPanel({ provider }: MappingsPanelProps) {
 
   const toggleMutation = useMutation({
     mutationFn: ({ id, enabled }: { id: string; enabled: boolean }) =>
-      ciOidcApi.toggleMapping(provider.id, id, { enabled }),
+      enabled
+        ? ciOidcApi.enableMapping(provider.id, id)
+        : ciOidcApi.disableMapping(provider.id, id),
     onSuccess: () => invalidate(),
     onError: mutationErrorToast("Failed to toggle mapping"),
   });
@@ -335,8 +342,8 @@ function MappingsPanel({ provider }: MappingsPanelProps) {
       return;
     }
     const priority = parseInt(form.priority, 10);
-    if (isNaN(priority)) {
-      setFiltersError("Priority must be a number.");
+    if (isNaN(priority) || priority < 1) {
+      setFiltersError("Priority must be a positive integer (>= 1).");
       return;
     }
 
@@ -345,7 +352,11 @@ function MappingsPanel({ provider }: MappingsPanelProps) {
       priority,
       claim_filters: filters,
       allowed_repo_ids:
-        form.repo_scope_mode === "all" ? null : form.selected_repo_ids,
+        form.repo_scope_mode === "all"
+          ? editTarget
+            ? [] // Update: send empty array to clear previous restriction
+            : null // Create: null means no restriction
+          : form.selected_repo_ids,
       is_enabled: form.is_enabled,
     };
 
@@ -581,6 +592,11 @@ function MappingsPanel({ provider }: MappingsPanelProps) {
                         })}
                       </div>
 
+                      <ListTruncationNotice
+                        shown={repositories.length}
+                        total={totalRepos}
+                      />
+
                       {selectedRepositories.length > 0 && (
                         <div className="flex flex-wrap gap-1 pt-1">
                           {selectedRepositories.map((repo) => (
@@ -645,14 +661,14 @@ export default function CiOidcPage() {
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
 
   const { data: providers, isLoading } = useQuery({
-    queryKey: ["ci-oidc"],
+    queryKey: QUERY_KEYS.CI_OIDC,
     queryFn: ciOidcApi.list,
   });
 
   const createMutation = useMutation({
     mutationFn: ciOidcApi.create,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["ci-oidc"] });
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.CI_OIDC });
       toast.success("CI OIDC provider created");
       closeDialog();
     },
@@ -668,7 +684,7 @@ export default function CiOidcPage() {
       data: UpdateCiOidcProviderRequest;
     }) => ciOidcApi.update(id, data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["ci-oidc"] });
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.CI_OIDC });
       toast.success("CI OIDC provider updated");
       closeDialog();
     },
@@ -678,17 +694,19 @@ export default function CiOidcPage() {
   const deleteMutation = useMutation({
     mutationFn: ciOidcApi.delete,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["ci-oidc"] });
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.CI_OIDC });
       toast.success("CI OIDC provider deleted");
       setDeleteTarget(null);
     },
     onError: mutationErrorToast("Failed to delete CI OIDC provider"),
   });
 
-  const toggleMutation = useMutation({
+const toggleMutation = useMutation({
     mutationFn: ({ id, enabled }: { id: string; enabled: boolean }) =>
-      ciOidcApi.toggle(id, { enabled }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["ci-oidc"] }),
+      enabled
+        ? ciOidcApi.enableProvider(id)
+        : ciOidcApi.disableProvider(id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: QUERY_KEYS.CI_OIDC }),
     onError: mutationErrorToast("Failed to toggle CI OIDC provider"),
   });
 

--- a/src/app/(app)/(admin)/settings/sso/page.tsx
+++ b/src/app/(app)/(admin)/settings/sso/page.tsx
@@ -17,7 +17,6 @@ import {
   Loader2,
   CheckCircle,
   Plug,
-  GitBranch,
 } from "lucide-react";
 
 import { useAuth } from "@/providers/auth-provider";
@@ -1727,6 +1726,14 @@ export default function SsoSettingsPage() {
       <PageHeader
         title="SSO Providers"
         description="Configure single sign-on authentication providers."
+        actions={
+          <Button asChild variant="outline" size="sm">
+            <Link href="/settings/sso/ci">
+              <Plug className="size-4 mr-1.5" />
+              CI/CD OIDC Providers
+            </Link>
+          </Button>
+        }
       />
 
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
@@ -1775,12 +1782,6 @@ export default function SsoSettingsPage() {
           <TabsTrigger value="saml">
             <FileKey className="size-4 mr-1.5" />
             SAML
-          </TabsTrigger>
-          <TabsTrigger value="ci" asChild>
-            <Link href="/settings/sso/ci">
-              <GitBranch className="size-4 mr-1.5" />
-              CI / CD
-            </Link>
           </TabsTrigger>
         </TabsList>
 

--- a/src/app/(app)/(admin)/settings/sso/page.tsx
+++ b/src/app/(app)/(admin)/settings/sso/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {
@@ -16,6 +17,7 @@ import {
   Loader2,
   CheckCircle,
   Plug,
+  GitBranch,
 } from "lucide-react";
 
 import { useAuth } from "@/providers/auth-provider";
@@ -1773,6 +1775,12 @@ export default function SsoSettingsPage() {
           <TabsTrigger value="saml">
             <FileKey className="size-4 mr-1.5" />
             SAML
+          </TabsTrigger>
+          <TabsTrigger value="ci" asChild>
+            <Link href="/settings/sso/ci">
+              <GitBranch className="size-4 mr-1.5" />
+              CI / CD
+            </Link>
           </TabsTrigger>
         </TabsList>
 

--- a/src/components/layout/__tests__/app-sidebar.test.tsx
+++ b/src/components/layout/__tests__/app-sidebar.test.tsx
@@ -105,6 +105,7 @@ vi.mock("lucide-react", () => {
     ScrollText: icon,
     Network: icon,
     Crosshair: icon,
+    GitBranch: icon,
     Hourglass: icon,
   };
 });

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -31,6 +31,7 @@ import {
   UsersRound,
   HardDrive,
   KeyRound,
+  GitBranch,
   Settings,
   BarChart3,
   Recycle,
@@ -127,6 +128,7 @@ const adminItems: NavItem[] = [
   { title: "Audit Log", href: "/audit", icon: ScrollText },
   { title: "Backups", href: "/backups", icon: HardDrive },
   { title: "SSO Providers", href: "/settings/sso", icon: KeyRound },
+  { title: "CI/CD OIDC", href: "/settings/sso/ci", icon: GitBranch },
   { title: "Settings", href: "/settings", icon: Settings },
 ];
 

--- a/src/lib/__tests__/query-keys.test.ts
+++ b/src/lib/__tests__/query-keys.test.ts
@@ -38,10 +38,12 @@ describe("QUERY_KEYS", () => {
     BACKUPS: ["backups"],
     SECURITY: ["security"],
     PLUGINS: ["plugins"],
+    CI_OIDC: ["ci-oidc"],
+    CI_OIDC_MAPPINGS: ["ci-oidc-mappings"],
   };
 
-  it("has 14 key constants (#213, #669)", () => {
-    expect(Object.keys(QUERY_KEYS)).toHaveLength(14);
+  it("has 16 key constants (#213, #669)", () => {
+    expect(Object.keys(QUERY_KEYS)).toHaveLength(16);
   });
 
   it.each(Object.entries(expectedKeys))(

--- a/src/lib/api/__tests__/ci-oidc.test.ts
+++ b/src/lib/api/__tests__/ci-oidc.test.ts
@@ -1,0 +1,502 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type {
+  CiOidcProviderResponse as SdkCiOidcProviderResponse,
+  CiOidcMappingResponse as SdkCiOidcMappingResponse,
+} from "@artifact-keeper/sdk";
+
+vi.mock("@/lib/sdk-client", () => ({}));
+
+const mockCioidcListProviders = vi.fn();
+const mockCreateProvider = vi.fn();
+const mockGetProvider = vi.fn();
+const mockUpdateProvider = vi.fn();
+const mockDeleteProvider = vi.fn();
+const mockToggleProvider = vi.fn();
+const mockListMappings = vi.fn();
+const mockCreateMapping = vi.fn();
+const mockGetMapping = vi.fn();
+const mockUpdateMapping = vi.fn();
+const mockDeleteMapping = vi.fn();
+const mockToggleMapping = vi.fn();
+
+vi.mock("@artifact-keeper/sdk", () => ({
+  ciOidcListProviders: (...args: unknown[]) =>
+    mockCioidcListProviders(...args),
+  createProvider: (...args: unknown[]) => mockCreateProvider(...args),
+  getProvider: (...args: unknown[]) => mockGetProvider(...args),
+  updateProvider: (...args: unknown[]) => mockUpdateProvider(...args),
+  deleteProvider: (...args: unknown[]) => mockDeleteProvider(...args),
+  toggleProvider: (...args: unknown[]) => mockToggleProvider(...args),
+  listMappings: (...args: unknown[]) => mockListMappings(...args),
+  createMapping: (...args: unknown[]) => mockCreateMapping(...args),
+  getMapping: (...args: unknown[]) => mockGetMapping(...args),
+  updateMapping: (...args: unknown[]) => mockUpdateMapping(...args),
+  deleteMapping: (...args: unknown[]) => mockDeleteMapping(...args),
+  toggleMapping: (...args: unknown[]) => mockToggleMapping(...args),
+}));
+
+const SDK_PROVIDER: SdkCiOidcProviderResponse = {
+  id: "p1",
+  name: "GitLab CI",
+  provider_type: "gitlab",
+  issuer_url: "https://gitlab.com",
+  audience: "artifact-keeper",
+  is_enabled: true,
+  mapping_count: 3,
+  created_at: "2026-04-01T00:00:00Z",
+  updated_at: "2026-05-01T00:00:00Z",
+};
+
+const SDK_MAPPING: SdkCiOidcMappingResponse = {
+  id: "m1",
+  provider_id: "p1",
+  name: "Prod deploy",
+  priority: 10,
+  claim_filters: { namespace_path: "my-org/my-group" },
+  allowed_repo_ids: ["repo-1", "repo-2"],
+  is_enabled: true,
+  created_at: "2026-04-01T00:00:00Z",
+  updated_at: "2026-05-01T00:00:00Z",
+};
+
+describe("ciOidcApi", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // ---- Providers ----
+
+  describe("list", () => {
+    it("returns adapted providers", async () => {
+      mockCioidcListProviders.mockResolvedValue({
+        data: [SDK_PROVIDER],
+        error: undefined,
+      });
+      const { ciOidcApi } = await import("../ci-oidc");
+      const out = await ciOidcApi.list();
+      expect(out[0].id).toBe("p1");
+      expect(out[0].name).toBe("GitLab CI");
+      expect(out[0].provider_type).toBe("gitlab");
+    });
+
+    it("throws on error", async () => {
+      mockCioidcListProviders.mockResolvedValue({
+        data: undefined,
+        error: "fail",
+      });
+      const { ciOidcApi } = await import("../ci-oidc");
+      await expect(ciOidcApi.list()).rejects.toBe("fail");
+    });
+  });
+
+  describe("get", () => {
+    it("returns adapted provider", async () => {
+      mockGetProvider.mockResolvedValue({ data: SDK_PROVIDER, error: undefined });
+      const { ciOidcApi } = await import("../ci-oidc");
+      const out = await ciOidcApi.get("p1");
+      expect(out.id).toBe("p1");
+      expect(out.mapping_count).toBe(3);
+    });
+
+    it("passes id in path", async () => {
+      mockGetProvider.mockResolvedValue({ data: SDK_PROVIDER, error: undefined });
+      const { ciOidcApi } = await import("../ci-oidc");
+      await ciOidcApi.get("p1");
+      expect(mockGetProvider).toHaveBeenCalledWith({ path: { id: "p1" } });
+    });
+
+    it("throws on error", async () => {
+      mockGetProvider.mockResolvedValue({ data: undefined, error: "fail" });
+      const { ciOidcApi } = await import("../ci-oidc");
+      await expect(ciOidcApi.get("p1")).rejects.toBe("fail");
+    });
+  });
+
+  describe("create", () => {
+    it("returns new provider and forwards body", async () => {
+      mockCreateProvider.mockResolvedValue({
+        data: SDK_PROVIDER,
+        error: undefined,
+      });
+      const { ciOidcApi } = await import("../ci-oidc");
+      await ciOidcApi.create({
+        name: "GitLab CI",
+        issuer_url: "https://gitlab.com",
+        audience: "artifact-keeper",
+      });
+      expect(mockCreateProvider).toHaveBeenCalledWith({
+        body: {
+          name: "GitLab CI",
+          issuer_url: "https://gitlab.com",
+          audience: "artifact-keeper",
+        },
+      });
+    });
+
+    it("throws on error", async () => {
+      mockCreateProvider.mockResolvedValue({ data: undefined, error: "fail" });
+      const { ciOidcApi } = await import("../ci-oidc");
+      await expect(
+        ciOidcApi.create({
+          name: "x",
+          issuer_url: "x",
+        }),
+      ).rejects.toBe("fail");
+    });
+  });
+
+  describe("update", () => {
+    it("returns updated provider and forwards path + body", async () => {
+      mockUpdateProvider.mockResolvedValue({
+        data: SDK_PROVIDER,
+        error: undefined,
+      });
+      const { ciOidcApi } = await import("../ci-oidc");
+      await ciOidcApi.update("p1", { name: "Renamed" });
+      expect(mockUpdateProvider).toHaveBeenCalledWith({
+        path: { id: "p1" },
+        body: { name: "Renamed" },
+      });
+    });
+
+    it("throws on error", async () => {
+      mockUpdateProvider.mockResolvedValue({ data: undefined, error: "fail" });
+      const { ciOidcApi } = await import("../ci-oidc");
+      await expect(
+        ciOidcApi.update("p1", { name: "x" }),
+      ).rejects.toBe("fail");
+    });
+  });
+
+  describe("delete", () => {
+    it("calls delete with path", async () => {
+      mockDeleteProvider.mockResolvedValue({ data: undefined, error: undefined });
+      const { ciOidcApi } = await import("../ci-oidc");
+      await ciOidcApi.delete("p1");
+      expect(mockDeleteProvider).toHaveBeenCalledWith({ path: { id: "p1" } });
+    });
+
+    it("throws on error", async () => {
+      mockDeleteProvider.mockResolvedValue({ data: undefined, error: "fail" });
+      const { ciOidcApi } = await import("../ci-oidc");
+      await expect(ciOidcApi.delete("p1")).rejects.toBe("fail");
+    });
+  });
+
+  describe("enableProvider / disableProvider", () => {
+    it("enableProvider calls toggle with enabled: true", async () => {
+      mockToggleProvider.mockResolvedValue({ data: undefined, error: undefined });
+      const { ciOidcApi } = await import("../ci-oidc");
+      await ciOidcApi.enableProvider("p1");
+      expect(mockToggleProvider).toHaveBeenCalledWith({
+        path: { id: "p1" },
+        body: { enabled: true },
+      });
+    });
+
+    it("disableProvider calls toggle with enabled: false", async () => {
+      mockToggleProvider.mockResolvedValue({ data: undefined, error: undefined });
+      const { ciOidcApi } = await import("../ci-oidc");
+      await ciOidcApi.disableProvider("p1");
+      expect(mockToggleProvider).toHaveBeenCalledWith({
+        path: { id: "p1" },
+        body: { enabled: false },
+      });
+    });
+
+    it("throws on error", async () => {
+      mockToggleProvider.mockResolvedValue({ data: undefined, error: "fail" });
+      const { ciOidcApi } = await import("../ci-oidc");
+      await expect(ciOidcApi.enableProvider("p1")).rejects.toBe("fail");
+    });
+  });
+
+  // ---- Mappings ----
+
+  describe("listMappings", () => {
+    it("returns adapted mappings", async () => {
+      mockListMappings.mockResolvedValue({
+        data: [SDK_MAPPING],
+        error: undefined,
+      });
+      const { ciOidcApi } = await import("../ci-oidc");
+      const out = await ciOidcApi.listMappings("p1");
+      expect(out[0].id).toBe("m1");
+      expect(out[0].provider_id).toBe("p1");
+      expect(out[0].claim_filters).toEqual({
+        namespace_path: "my-org/my-group",
+      });
+    });
+
+    it("passes provider id in path", async () => {
+      mockListMappings.mockResolvedValue({
+        data: [],
+        error: undefined,
+      });
+      const { ciOidcApi } = await import("../ci-oidc");
+      await ciOidcApi.listMappings("p1");
+      expect(mockListMappings).toHaveBeenCalledWith({ path: { id: "p1" } });
+    });
+
+    it("adapts null allowed_repo_ids", async () => {
+      mockListMappings.mockResolvedValue({
+        data: [{ ...SDK_MAPPING, allowed_repo_ids: null }],
+        error: undefined,
+      });
+      const { ciOidcApi } = await import("../ci-oidc");
+      const out = await ciOidcApi.listMappings("p1");
+      expect(out[0].allowed_repo_ids).toBeNull();
+    });
+
+    it("adapts undefined allowed_repo_ids to null", async () => {
+      mockListMappings.mockResolvedValue({
+        data: [{ ...SDK_MAPPING, allowed_repo_ids: undefined }],
+        error: undefined,
+      });
+      const { ciOidcApi } = await import("../ci-oidc");
+      const out = await ciOidcApi.listMappings("p1");
+      expect(out[0].allowed_repo_ids).toBeNull();
+    });
+
+    it("throws on error", async () => {
+      mockListMappings.mockResolvedValue({ data: undefined, error: "fail" });
+      const { ciOidcApi } = await import("../ci-oidc");
+      await expect(ciOidcApi.listMappings("p1")).rejects.toBe("fail");
+    });
+  });
+
+  describe("getMapping", () => {
+    it("returns adapted mapping", async () => {
+      mockGetMapping.mockResolvedValue({ data: SDK_MAPPING, error: undefined });
+      const { ciOidcApi } = await import("../ci-oidc");
+      const out = await ciOidcApi.getMapping("p1", "m1");
+      expect(out.id).toBe("m1");
+      expect(out.priority).toBe(10);
+    });
+
+    it("passes provider id and mapping id in path", async () => {
+      mockGetMapping.mockResolvedValue({ data: SDK_MAPPING, error: undefined });
+      const { ciOidcApi } = await import("../ci-oidc");
+      await ciOidcApi.getMapping("p1", "m1");
+      expect(mockGetMapping).toHaveBeenCalledWith({
+        path: { id: "p1", mid: "m1" },
+      });
+    });
+
+    it("throws on error", async () => {
+      mockGetMapping.mockResolvedValue({ data: undefined, error: "fail" });
+      const { ciOidcApi } = await import("../ci-oidc");
+      await expect(ciOidcApi.getMapping("p1", "m1")).rejects.toBe("fail");
+    });
+  });
+
+  describe("createMapping", () => {
+    it("returns new mapping and forwards path + body", async () => {
+      mockCreateMapping.mockResolvedValue({
+        data: SDK_MAPPING,
+        error: undefined,
+      });
+      const { ciOidcApi } = await import("../ci-oidc");
+      await ciOidcApi.createMapping("p1", {
+        name: "Prod deploy",
+        priority: 10,
+        claim_filters: { namespace_path: "my-org/my-group" },
+      });
+      expect(mockCreateMapping).toHaveBeenCalledWith({
+        path: { id: "p1" },
+        body: {
+          name: "Prod deploy",
+          priority: 10,
+          claim_filters: { namespace_path: "my-org/my-group" },
+        },
+      });
+    });
+
+    it("throws on error", async () => {
+      mockCreateMapping.mockResolvedValue({ data: undefined, error: "fail" });
+      const { ciOidcApi } = await import("../ci-oidc");
+      await expect(
+        ciOidcApi.createMapping("p1", {
+          name: "x",
+          claim_filters: {},
+        }),
+      ).rejects.toBe("fail");
+    });
+  });
+
+  describe("updateMapping", () => {
+    it("forwards path with both ids + body", async () => {
+      mockUpdateMapping.mockResolvedValue({
+        data: SDK_MAPPING,
+        error: undefined,
+      });
+      const { ciOidcApi } = await import("../ci-oidc");
+      await ciOidcApi.updateMapping("p1", "m1", { name: "Renamed" });
+      expect(mockUpdateMapping).toHaveBeenCalledWith({
+        path: { id: "p1", mid: "m1" },
+        body: { name: "Renamed" },
+      });
+    });
+
+    it("throws on error", async () => {
+      mockUpdateMapping.mockResolvedValue({ data: undefined, error: "fail" });
+      const { ciOidcApi } = await import("../ci-oidc");
+      await expect(
+        ciOidcApi.updateMapping("p1", "m1", { name: "x" }),
+      ).rejects.toBe("fail");
+    });
+  });
+
+  describe("deleteMapping", () => {
+    it("calls delete with both ids in path", async () => {
+      mockDeleteMapping.mockResolvedValue({ data: undefined, error: undefined });
+      const { ciOidcApi } = await import("../ci-oidc");
+      await ciOidcApi.deleteMapping("p1", "m1");
+      expect(mockDeleteMapping).toHaveBeenCalledWith({
+        path: { id: "p1", mid: "m1" },
+      });
+    });
+
+    it("throws on error", async () => {
+      mockDeleteMapping.mockResolvedValue({ data: undefined, error: "fail" });
+      const { ciOidcApi } = await import("../ci-oidc");
+      await expect(ciOidcApi.deleteMapping("p1", "m1")).rejects.toBe("fail");
+    });
+  });
+
+  describe("enableMapping / disableMapping", () => {
+    it("enableMapping calls toggle with enabled: true", async () => {
+      mockToggleMapping.mockResolvedValue({ data: undefined, error: undefined });
+      const { ciOidcApi } = await import("../ci-oidc");
+      await ciOidcApi.enableMapping("p1", "m1");
+      expect(mockToggleMapping).toHaveBeenCalledWith({
+        path: { id: "p1", mid: "m1" },
+        body: { enabled: true },
+      });
+    });
+
+    it("disableMapping calls toggle with enabled: false", async () => {
+      mockToggleMapping.mockResolvedValue({ data: undefined, error: undefined });
+      const { ciOidcApi } = await import("../ci-oidc");
+      await ciOidcApi.disableMapping("p1", "m1");
+      expect(mockToggleMapping).toHaveBeenCalledWith({
+        path: { id: "p1", mid: "m1" },
+        body: { enabled: false },
+      });
+    });
+
+    it("throws on error", async () => {
+      mockToggleMapping.mockResolvedValue({ data: undefined, error: "fail" });
+      const { ciOidcApi } = await import("../ci-oidc");
+      await expect(ciOidcApi.enableMapping("p1", "m1")).rejects.toBe("fail");
+    });
+  });
+
+  // ---- Helper coverage (exported pure functions are in the page, test them too) ----
+
+  describe("parseClaimFilters", () => {
+    it("returns empty object for empty string", async () => {
+      const { parseClaimFilters } = await import(
+        "@/app/(app)/(admin)/settings/sso/ci/page"
+      );
+      expect(parseClaimFilters("")).toEqual({});
+      expect(parseClaimFilters("   ")).toEqual({});
+    });
+
+    it("parses valid JSON", async () => {
+      const { parseClaimFilters } = await import(
+        "@/app/(app)/(admin)/settings/sso/ci/page"
+      );
+      const result = parseClaimFilters('{"sub": "value"}');
+      expect(result).toEqual({ sub: "value" });
+    });
+
+    it("rejects arrays", async () => {
+      const { parseClaimFilters } = await import(
+        "@/app/(app)/(admin)/settings/sso/ci/page"
+      );
+      expect(parseClaimFilters("[1,2]")).toBeUndefined();
+    });
+
+    it("rejects strings", async () => {
+      const { parseClaimFilters } = await import(
+        "@/app/(app)/(admin)/settings/sso/ci/page"
+      );
+      expect(parseClaimFilters('"foo"')).toBeUndefined();
+    });
+
+    it("rejects numbers", async () => {
+      const { parseClaimFilters } = await import(
+        "@/app/(app)/(admin)/settings/sso/ci/page"
+      );
+      expect(parseClaimFilters("42")).toBeUndefined();
+    });
+
+    it("rejects null", async () => {
+      const { parseClaimFilters } = await import(
+        "@/app/(app)/(admin)/settings/sso/ci/page"
+      );
+      expect(parseClaimFilters("null")).toBeUndefined();
+    });
+
+    it("returns undefined for invalid JSON", async () => {
+      const { parseClaimFilters } = await import(
+        "@/app/(app)/(admin)/settings/sso/ci/page"
+      );
+      expect(parseClaimFilters("{bad")).toBeUndefined();
+    });
+  });
+
+  describe("claimFilterSummary", () => {
+    it("shows no-filters message for empty object", async () => {
+      const { claimFilterSummary } = await import(
+        "@/app/(app)/(admin)/settings/sso/ci/page"
+      );
+      expect(claimFilterSummary({})).toBe("No filters (any JWT accepted)");
+    });
+
+    it("formats string values", async () => {
+      const { claimFilterSummary } = await import(
+        "@/app/(app)/(admin)/settings/sso/ci/page"
+      );
+      expect(claimFilterSummary({ sub: "value" })).toBe("sub = value");
+    });
+
+    it("formats array values with any-of notation", async () => {
+      const { claimFilterSummary } = await import(
+        "@/app/(app)/(admin)/settings/sso/ci/page"
+      );
+      expect(
+        claimFilterSummary({ namespace_path: ["group-a", "group-b"] }),
+      ).toBe("namespace_path ∈ [group-a, group-b]");
+    });
+  });
+
+  describe("repoScopeSummary", () => {
+    it('returns "All repositories" for null', async () => {
+      const { repoScopeSummary } = await import(
+        "@/app/(app)/(admin)/settings/sso/ci/page"
+      );
+      expect(repoScopeSummary(null)).toBe("All repositories");
+    });
+
+    it('returns "No repositories" for empty array', async () => {
+      const { repoScopeSummary } = await import(
+        "@/app/(app)/(admin)/settings/sso/ci/page"
+      );
+      expect(repoScopeSummary([])).toBe("No repositories");
+    });
+
+    it("returns singular for one repo", async () => {
+      const { repoScopeSummary } = await import(
+        "@/app/(app)/(admin)/settings/sso/ci/page"
+      );
+      expect(repoScopeSummary(["r1"])).toBe("1 repository");
+    });
+
+    it("returns plural for multiple repos", async () => {
+      const { repoScopeSummary } = await import(
+        "@/app/(app)/(admin)/settings/sso/ci/page"
+      );
+      expect(repoScopeSummary(["r1", "r2", "r3"])).toBe("3 repositories");
+    });
+  });
+});

--- a/src/lib/api/ci-oidc.ts
+++ b/src/lib/api/ci-oidc.ts
@@ -1,0 +1,110 @@
+import { apiFetch } from "@/lib/api/fetch";
+import type {
+  CiOidcProvider,
+  CiOidcIdentityMapping,
+  CreateCiOidcProviderRequest,
+  UpdateCiOidcProviderRequest,
+  CiOidcToggleRequest,
+  CreateCiOidcMappingRequest,
+  UpdateCiOidcMappingRequest,
+} from "@/types/ci-oidc";
+
+const BASE = "/api/v1/admin/ci-oidc";
+
+export const ciOidcApi = {
+  // -------------------------------------------------------------------------
+  // Providers
+  // -------------------------------------------------------------------------
+
+  list(): Promise<CiOidcProvider[]> {
+    return apiFetch<CiOidcProvider[]>(BASE);
+  },
+
+  get(id: string): Promise<CiOidcProvider> {
+    return apiFetch<CiOidcProvider>(`${BASE}/${id}`);
+  },
+
+  create(req: CreateCiOidcProviderRequest): Promise<CiOidcProvider> {
+    return apiFetch<CiOidcProvider>(BASE, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(req),
+    });
+  },
+
+  update(id: string, req: UpdateCiOidcProviderRequest): Promise<CiOidcProvider> {
+    return apiFetch<CiOidcProvider>(`${BASE}/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(req),
+    });
+  },
+
+  delete(id: string): Promise<void> {
+    return apiFetch<void>(`${BASE}/${id}`, { method: "DELETE" });
+  },
+
+  toggle(id: string, req: CiOidcToggleRequest): Promise<CiOidcProvider> {
+    return apiFetch<CiOidcProvider>(`${BASE}/${id}/toggle`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(req),
+    });
+  },
+
+  // -------------------------------------------------------------------------
+  // Identity mappings (nested under a provider)
+  // -------------------------------------------------------------------------
+
+  listMappings(providerId: string): Promise<CiOidcIdentityMapping[]> {
+    return apiFetch<CiOidcIdentityMapping[]>(`${BASE}/${providerId}/mappings`);
+  },
+
+  getMapping(providerId: string, mappingId: string): Promise<CiOidcIdentityMapping> {
+    return apiFetch<CiOidcIdentityMapping>(`${BASE}/${providerId}/mappings/${mappingId}`);
+  },
+
+  createMapping(
+    providerId: string,
+    req: CreateCiOidcMappingRequest,
+  ): Promise<CiOidcIdentityMapping> {
+    return apiFetch<CiOidcIdentityMapping>(`${BASE}/${providerId}/mappings`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(req),
+    });
+  },
+
+  updateMapping(
+    providerId: string,
+    mappingId: string,
+    req: UpdateCiOidcMappingRequest,
+  ): Promise<CiOidcIdentityMapping> {
+    return apiFetch<CiOidcIdentityMapping>(`${BASE}/${providerId}/mappings/${mappingId}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(req),
+    });
+  },
+
+  deleteMapping(providerId: string, mappingId: string): Promise<void> {
+    return apiFetch<void>(`${BASE}/${providerId}/mappings/${mappingId}`, {
+      method: "DELETE",
+    });
+  },
+
+  toggleMapping(
+    providerId: string,
+    mappingId: string,
+    req: CiOidcToggleRequest,
+  ): Promise<CiOidcIdentityMapping> {
+    return apiFetch<CiOidcIdentityMapping>(
+      `${BASE}/${providerId}/mappings/${mappingId}/toggle`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(req),
+      },
+    );
+  },
+};

--- a/src/lib/api/ci-oidc.ts
+++ b/src/lib/api/ci-oidc.ts
@@ -1,110 +1,183 @@
-import { apiFetch } from "@/lib/api/fetch";
+import '@/lib/sdk-client';
+import {
+  ciOidcListProviders as sdkCiOidcListProviders,
+  createProvider as sdkCreateProvider,
+  getProvider as sdkGetProvider,
+  updateProvider as sdkUpdateProvider,
+  deleteProvider as sdkDeleteProvider,
+  toggleProvider as sdkToggleProvider,
+  listMappings as sdkListMappings,
+  createMapping as sdkCreateMapping,
+  getMapping as sdkGetMapping,
+  updateMapping as sdkUpdateMapping,
+  deleteMapping as sdkDeleteMapping,
+  toggleMapping as sdkToggleMapping,
+} from '@artifact-keeper/sdk';
+import type {
+  CiOidcProviderResponse as SdkCiOidcProviderResponse,
+  CiOidcMappingResponse as SdkCiOidcMappingResponse,
+  CreateCiOidcProviderRequest as SdkCreateCiOidcProviderRequest,
+  UpdateCiOidcProviderRequest as SdkUpdateCiOidcProviderRequest,
+  CreateCiOidcMappingRequest as SdkCreateCiOidcMappingRequest,
+  UpdateCiOidcMappingRequest as SdkUpdateCiOidcMappingRequest,
+} from '@artifact-keeper/sdk';
+import { assertData } from '@/lib/api/fetch';
+import { unwrap } from '@/lib/sdk-utils';
 import type {
   CiOidcProvider,
   CiOidcIdentityMapping,
+  ClaimFilters,
   CreateCiOidcProviderRequest,
   UpdateCiOidcProviderRequest,
-  CiOidcToggleRequest,
   CreateCiOidcMappingRequest,
   UpdateCiOidcMappingRequest,
-} from "@/types/ci-oidc";
+} from '@/types/ci-oidc';
 
-const BASE = "/api/v1/admin/ci-oidc";
+function adaptProvider(sdk: SdkCiOidcProviderResponse): CiOidcProvider {
+  return {
+    id: sdk.id,
+    name: sdk.name,
+    provider_type: sdk.provider_type,
+    issuer_url: sdk.issuer_url,
+    audience: sdk.audience,
+    is_enabled: sdk.is_enabled,
+    mapping_count: sdk.mapping_count,
+    created_at: sdk.created_at,
+    updated_at: sdk.updated_at,
+  };
+}
+
+function adaptMapping(sdk: SdkCiOidcMappingResponse): CiOidcIdentityMapping {
+  return {
+    id: sdk.id,
+    provider_id: sdk.provider_id,
+    name: sdk.name,
+    priority: sdk.priority,
+    claim_filters: sdk.claim_filters as ClaimFilters,
+    allowed_repo_ids: sdk.allowed_repo_ids ?? null,
+    is_enabled: sdk.is_enabled,
+    created_at: sdk.created_at,
+    updated_at: sdk.updated_at,
+  };
+}
 
 export const ciOidcApi = {
-  // -------------------------------------------------------------------------
-  // Providers
-  // -------------------------------------------------------------------------
+  // --- Providers ---
 
-  list(): Promise<CiOidcProvider[]> {
-    return apiFetch<CiOidcProvider[]>(BASE);
+  list: async (): Promise<CiOidcProvider[]> => {
+    const data = await unwrap(sdkCiOidcListProviders());
+    return assertData(data, 'ciOidcApi.list').map(adaptProvider);
   },
 
-  get(id: string): Promise<CiOidcProvider> {
-    return apiFetch<CiOidcProvider>(`${BASE}/${id}`);
+  get: async (id: string): Promise<CiOidcProvider> => {
+    const data = await unwrap(sdkGetProvider({ path: { id } }));
+    return adaptProvider(assertData(data, 'ciOidcApi.get'));
   },
 
-  create(req: CreateCiOidcProviderRequest): Promise<CiOidcProvider> {
-    return apiFetch<CiOidcProvider>(BASE, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(req),
-    });
+  create: async (
+    req: CreateCiOidcProviderRequest,
+  ): Promise<CiOidcProvider> => {
+    const data = await unwrap(sdkCreateProvider({
+      body: req satisfies SdkCreateCiOidcProviderRequest,
+    }));
+    return adaptProvider(assertData(data, 'ciOidcApi.create'));
   },
 
-  update(id: string, req: UpdateCiOidcProviderRequest): Promise<CiOidcProvider> {
-    return apiFetch<CiOidcProvider>(`${BASE}/${id}`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(req),
-    });
+  update: async (
+    id: string,
+    req: UpdateCiOidcProviderRequest,
+  ): Promise<CiOidcProvider> => {
+    const data = await unwrap(sdkUpdateProvider({
+      path: { id },
+      body: req satisfies SdkUpdateCiOidcProviderRequest,
+    }));
+    return adaptProvider(assertData(data, 'ciOidcApi.update'));
   },
 
-  delete(id: string): Promise<void> {
-    return apiFetch<void>(`${BASE}/${id}`, { method: "DELETE" });
+  delete: async (id: string): Promise<void> => {
+    await unwrap(sdkDeleteProvider({ path: { id } }));
   },
 
-  toggle(id: string, req: CiOidcToggleRequest): Promise<CiOidcProvider> {
-    return apiFetch<CiOidcProvider>(`${BASE}/${id}/toggle`, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(req),
-    });
+  enableProvider: async (id: string): Promise<void> => {
+    await unwrap(sdkToggleProvider({
+      path: { id },
+      body: { enabled: true },
+    }));
   },
 
-  // -------------------------------------------------------------------------
-  // Identity mappings (nested under a provider)
-  // -------------------------------------------------------------------------
-
-  listMappings(providerId: string): Promise<CiOidcIdentityMapping[]> {
-    return apiFetch<CiOidcIdentityMapping[]>(`${BASE}/${providerId}/mappings`);
+  disableProvider: async (id: string): Promise<void> => {
+    await unwrap(sdkToggleProvider({
+      path: { id },
+      body: { enabled: false },
+    }));
   },
 
-  getMapping(providerId: string, mappingId: string): Promise<CiOidcIdentityMapping> {
-    return apiFetch<CiOidcIdentityMapping>(`${BASE}/${providerId}/mappings/${mappingId}`);
+  // --- Identity mappings (nested under a provider) ---
+
+  listMappings: async (providerId: string): Promise<CiOidcIdentityMapping[]> => {
+    const data = await unwrap(sdkListMappings({ path: { id: providerId } }));
+    return assertData(data, 'ciOidcApi.listMappings').map(adaptMapping);
   },
 
-  createMapping(
+  getMapping: async (
+    providerId: string,
+    mappingId: string,
+  ): Promise<CiOidcIdentityMapping> => {
+    const data = await unwrap(sdkGetMapping({
+      path: { id: providerId, mid: mappingId },
+    }));
+    return adaptMapping(assertData(data, 'ciOidcApi.getMapping'));
+  },
+
+  createMapping: async (
     providerId: string,
     req: CreateCiOidcMappingRequest,
-  ): Promise<CiOidcIdentityMapping> {
-    return apiFetch<CiOidcIdentityMapping>(`${BASE}/${providerId}/mappings`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(req),
-    });
+  ): Promise<CiOidcIdentityMapping> => {
+    const data = await unwrap(sdkCreateMapping({
+      path: { id: providerId },
+      body: req satisfies SdkCreateCiOidcMappingRequest,
+    }));
+    return adaptMapping(assertData(data, 'ciOidcApi.createMapping'));
   },
 
-  updateMapping(
+  updateMapping: async (
     providerId: string,
     mappingId: string,
     req: UpdateCiOidcMappingRequest,
-  ): Promise<CiOidcIdentityMapping> {
-    return apiFetch<CiOidcIdentityMapping>(`${BASE}/${providerId}/mappings/${mappingId}`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(req),
-    });
+  ): Promise<CiOidcIdentityMapping> => {
+    const data = await unwrap(sdkUpdateMapping({
+      path: { id: providerId, mid: mappingId },
+      body: req satisfies SdkUpdateCiOidcMappingRequest,
+    }));
+    return adaptMapping(assertData(data, 'ciOidcApi.updateMapping'));
   },
 
-  deleteMapping(providerId: string, mappingId: string): Promise<void> {
-    return apiFetch<void>(`${BASE}/${providerId}/mappings/${mappingId}`, {
-      method: "DELETE",
-    });
-  },
-
-  toggleMapping(
+  deleteMapping: async (
     providerId: string,
     mappingId: string,
-    req: CiOidcToggleRequest,
-  ): Promise<CiOidcIdentityMapping> {
-    return apiFetch<CiOidcIdentityMapping>(
-      `${BASE}/${providerId}/mappings/${mappingId}/toggle`,
-      {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(req),
-      },
-    );
+  ): Promise<void> => {
+    await unwrap(sdkDeleteMapping({
+      path: { id: providerId, mid: mappingId },
+    }));
+  },
+
+  enableMapping: async (
+    providerId: string,
+    mappingId: string,
+  ): Promise<void> => {
+    await unwrap(sdkToggleMapping({
+      path: { id: providerId, mid: mappingId },
+      body: { enabled: true },
+    }));
+  },
+
+  disableMapping: async (
+    providerId: string,
+    mappingId: string,
+  ): Promise<void> => {
+    await unwrap(sdkToggleMapping({
+      path: { id: providerId, mid: mappingId },
+      body: { enabled: false },
+    }));
   },
 };

--- a/src/lib/query-keys.ts
+++ b/src/lib/query-keys.ts
@@ -32,6 +32,8 @@ export const QUERY_KEYS = {
   // findings, policies, scan-configs) gets invalidated. See #213.
   SECURITY: ["security"],
   PLUGINS: ["plugins"],
+  CI_OIDC: ["ci-oidc"],
+  CI_OIDC_MAPPINGS: ["ci-oidc-mappings"],
 } as const;
 
 // ---------------------------------------------------------------------------

--- a/src/types/ci-oidc.ts
+++ b/src/types/ci-oidc.ts
@@ -1,0 +1,89 @@
+// Types for CI OIDC provider + identity mapping management.
+// These mirror the Rust structs in backend/src/services/ci_oidc_service.rs.
+
+export type CiOidcProviderType = "gitlab" | "github" | "generic";
+
+// ---------------------------------------------------------------------------
+// Providers
+// ---------------------------------------------------------------------------
+
+export interface CiOidcProvider {
+  id: string;
+  name: string;
+  provider_type: CiOidcProviderType;
+  issuer_url: string;
+  audience: string;
+  is_enabled: boolean;
+  /** Number of identity mappings attached to this provider. */
+  mapping_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateCiOidcProviderRequest {
+  name: string;
+  provider_type?: CiOidcProviderType;
+  issuer_url: string;
+  audience?: string;
+  is_enabled?: boolean;
+}
+
+export interface UpdateCiOidcProviderRequest {
+  name?: string;
+  provider_type?: CiOidcProviderType;
+  issuer_url?: string;
+  audience?: string;
+  is_enabled?: boolean;
+}
+
+export interface CiOidcToggleRequest {
+  enabled: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Identity mappings
+// ---------------------------------------------------------------------------
+
+/**
+ * Claim filters: each key is a JWT claim name; value is either an exact string
+ * or an array of allowed strings (any-of semantics).
+ *
+ * Examples:
+ *   { "namespace_path": "my-group" }
+ *   { "namespace_path": ["group-a", "group-b"], "ref_protected": "true" }
+ */
+export type ClaimFilters = Record<string, string | string[]>;
+
+export interface CiOidcIdentityMapping {
+  id: string;
+  provider_id: string;
+  name: string;
+  /** Lower number = higher priority. Evaluated in ascending order. */
+  priority: number;
+  claim_filters: ClaimFilters;
+  /** AK Role UUID assigned to the service account. null = no role. */
+  role_id: string | null;
+  /** Repository UUIDs this mapping may access. null = unrestricted. */
+  allowed_repo_ids: string[] | null;
+  is_enabled: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateCiOidcMappingRequest {
+  name: string;
+  priority?: number;
+  claim_filters: ClaimFilters;
+  role_id?: string | null;
+  allowed_repo_ids?: string[] | null;
+  is_enabled?: boolean;
+}
+
+export interface UpdateCiOidcMappingRequest {
+  name?: string;
+  priority?: number;
+  claim_filters?: ClaimFilters;
+  role_id?: string | null;
+  allowed_repo_ids?: string[] | null;
+  is_enabled?: boolean;
+}

--- a/src/types/ci-oidc.ts
+++ b/src/types/ci-oidc.ts
@@ -61,9 +61,7 @@ export interface CiOidcIdentityMapping {
   /** Lower number = higher priority. Evaluated in ascending order. */
   priority: number;
   claim_filters: ClaimFilters;
-  /** AK Role UUID assigned to the service account. null = no role. */
-  role_id: string | null;
-  /** Repository UUIDs this mapping may access. null = unrestricted. */
+  /** Optional repository restriction for this mapping. */
   allowed_repo_ids: string[] | null;
   is_enabled: boolean;
   created_at: string;
@@ -74,7 +72,6 @@ export interface CreateCiOidcMappingRequest {
   name: string;
   priority?: number;
   claim_filters: ClaimFilters;
-  role_id?: string | null;
   allowed_repo_ids?: string[] | null;
   is_enabled?: boolean;
 }
@@ -83,7 +80,6 @@ export interface UpdateCiOidcMappingRequest {
   name?: string;
   priority?: number;
   claim_filters?: ClaimFilters;
-  role_id?: string | null;
   allowed_repo_ids?: string[] | null;
   is_enabled?: boolean;
 }

--- a/src/types/ci-oidc.ts
+++ b/src/types/ci-oidc.ts
@@ -1,85 +1,32 @@
-// Types for CI OIDC provider + identity mapping management.
-// These mirror the Rust structs in backend/src/services/ci_oidc_service.rs.
+import type {
+  CiOidcProviderResponse,
+  CreateCiOidcProviderRequest,
+  UpdateCiOidcProviderRequest,
+  CiOidcToggleRequest,
+  CreateCiOidcMappingRequest,
+  UpdateCiOidcMappingRequest,
+} from "@artifact-keeper/sdk";
 
+export type CiOidcProvider = CiOidcProviderResponse;
 export type CiOidcProviderType = "gitlab" | "github" | "generic";
-
-// ---------------------------------------------------------------------------
-// Providers
-// ---------------------------------------------------------------------------
-
-export interface CiOidcProvider {
-  id: string;
-  name: string;
-  provider_type: CiOidcProviderType;
-  issuer_url: string;
-  audience: string;
-  is_enabled: boolean;
-  /** Number of identity mappings attached to this provider. */
-  mapping_count: number;
-  created_at: string;
-  updated_at: string;
-}
-
-export interface CreateCiOidcProviderRequest {
-  name: string;
-  provider_type?: CiOidcProviderType;
-  issuer_url: string;
-  audience?: string;
-  is_enabled?: boolean;
-}
-
-export interface UpdateCiOidcProviderRequest {
-  name?: string;
-  provider_type?: CiOidcProviderType;
-  issuer_url?: string;
-  audience?: string;
-  is_enabled?: boolean;
-}
-
-export interface CiOidcToggleRequest {
-  enabled: boolean;
-}
-
-// ---------------------------------------------------------------------------
-// Identity mappings
-// ---------------------------------------------------------------------------
-
-/**
- * Claim filters: each key is a JWT claim name; value is either an exact string
- * or an array of allowed strings (any-of semantics).
- *
- * Examples:
- *   { "namespace_path": "my-group" }
- *   { "namespace_path": ["group-a", "group-b"], "ref_protected": "true" }
- */
 export type ClaimFilters = Record<string, string | string[]>;
 
 export interface CiOidcIdentityMapping {
   id: string;
   provider_id: string;
   name: string;
-  /** Lower number = higher priority. Evaluated in ascending order. */
   priority: number;
   claim_filters: ClaimFilters;
-  /** Optional repository restriction for this mapping. */
   allowed_repo_ids: string[] | null;
   is_enabled: boolean;
   created_at: string;
   updated_at: string;
 }
 
-export interface CreateCiOidcMappingRequest {
-  name: string;
-  priority?: number;
-  claim_filters: ClaimFilters;
-  allowed_repo_ids?: string[] | null;
-  is_enabled?: boolean;
-}
-
-export interface UpdateCiOidcMappingRequest {
-  name?: string;
-  priority?: number;
-  claim_filters?: ClaimFilters;
-  allowed_repo_ids?: string[] | null;
-  is_enabled?: boolean;
-}
+export type {
+  CreateCiOidcProviderRequest,
+  UpdateCiOidcProviderRequest,
+  CiOidcToggleRequest,
+  CreateCiOidcMappingRequest,
+  UpdateCiOidcMappingRequest,
+};


### PR DESCRIPTION
Closes #782

## What this PR does

> **Draft / initial implementation.** Tested end-to-end for Docker container push from GitHub Actions and GitLab CI. Not yet tested for other artifact formats Artifact Keeper supports (Maven, npm, Helm, PyPI, raw, etc.) — further format support will be implemented after receiving maintainer feedback

Adds the admin interface for managing CI OIDC providers and identity mappings introduced in the backend companion PR ([artifact-keeper#1](https://github.com/luko0610/artifact-keeper/pull/1)).

Administrators can configure which CI/CD systems (GitLab CI, GitHub Actions, generic OIDC) are trusted to exchange tokens, and define fine-grained claim-filter rules that determine which pipelines get access and what role they receive — all without storing static secrets.

## How it works

The new **CI Providers** tab appears under Settings → SSO alongside the existing OIDC SSO configuration.

### Provider management
- List all configured CI OIDC providers with status (enabled/disabled)
- Create a provider: name, type (GitLab / GitHub Actions / Generic), issuer URL, audience
- Edit, enable/disable, and delete providers

### Identity mapping management
- Per-provider list of mappings in priority order
- Create/edit a mapping: name, priority, claim filters (key → value or array), optional role assignment
- Enable/disable individual mappings without deleting them

### New files
| File | Purpose |
|---|---|
| `src/types/ci-oidc.ts` | TypeScript types for `CiOidcProvider`, `CiOidcIdentityMapping`, and all request/response shapes |
| `src/lib/api/ci-oidc.ts` | API client — CRUD + toggle helpers for providers and mappings |
| `src/app/(app)/(admin)/settings/sso/ci/page.tsx` | Full CI provider management page |

### Modified files
- `src/app/(app)/(admin)/settings/sso/page.tsx` — added CI Providers tab to the SSO settings index

## Verified end-to-end
- ✅ GitHub Actions → pushed `ci-test/hello:latest` — [run #25616754667](https://github.com/luko0610/artifact-keeper-token-test/actions/runs/25616754667)
- ✅ GitLab CI → pushed `ci-test/hello-gitlab:latest` — [pipeline #2513124814](https://gitlab.com/luko0610/ak-pipeline-test/-/pipelines/2513124814)

## Companion PR
Backend: [artifact-keeper#1](https://github.com/luko0610/artifact-keeper/pull/1)

## Pipeline usage

The token exchange is a single `curl` / `wget` call. To avoid copying it into every project, it should be centralized once and called from each pipeline.

### The exchange call (what's happening under the hood)

```sh
# CI JWT is passed in the Authorization header — never in the body or env vars
# that might appear in logs.
RESPONSE=$(curl -sf -X POST \
  "$AK_URL/api/v1/auth/ci/token" \
  -H "Authorization: Bearer $CI_JWT" \
  -H "Content-Type: application/json" \
  -d "{\"provider_id\": \"$AK_PROVIDER_ID\"}")

ACCESS_TOKEN=$(echo "$RESPONSE" | jq -r '.access_token')
CI_USERNAME=$(echo "$RESPONSE" | jq -r '.username')

echo "$ACCESS_TOKEN" | docker login "$AK_REGISTRY" \
  --username "$CI_USERNAME" --password-stdin
```

---

### GitHub Actions — reusable workflow (define once)

Create `.github/workflows/ak-login.yml` in a central org repo (e.g. `your-org/ci-templates`):

```yaml
# .github/workflows/ak-login.yml
on:
  workflow_call:
    inputs:
      ak_url:      { required: true,  type: string }
      provider_id: { required: true,  type: string }
      registry:    { required: true,  type: string }
    outputs:
      ci_username:  { value: "${{ jobs.login.outputs.ci_username }}" }
      access_token: { value: "${{ jobs.login.outputs.access_token }}" }

permissions:
  id-token: write
  contents: read

jobs:
  login:
    runs-on: ubuntu-latest
    outputs:
      ci_username:  ${{ steps.exchange.outputs.ci_username }}
      access_token: ${{ steps.exchange.outputs.access_token }}
    steps:
      - name: Exchange OIDC token
        id: exchange
        run: |
          JWT=$(curl -sf \
            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=artifact-keeper" \
            | jq -r '.value')

          RESP=$(curl -sf -X POST "${{ inputs.ak_url }}/api/v1/auth/ci/token" \
            -H "Authorization: Bearer $JWT" \
            -H "Content-Type: application/json" \
            -d "{\"provider_id\": \"${{ inputs.provider_id }}\"}")

          echo "::add-mask::$(echo "$RESP" | jq -r '.access_token')"
          echo "access_token=$(echo "$RESP" | jq -r '.access_token')" >> "$GITHUB_OUTPUT"
          echo "ci_username=$(echo "$RESP" | jq -r '.username')"      >> "$GITHUB_OUTPUT"
```

**Calling it from any project** (zero curl duplication):

```yaml
jobs:
  push-image:
    uses: your-org/ci-templates/.github/workflows/ak-login.yml@main
    with:
      ak_url:      https://your-artifact-keeper-instance
      provider_id: <provider-uuid-from-AK-admin>
      registry:    your-artifact-keeper-instance

  publish:
    needs: push-image
    runs-on: ubuntu-latest
    steps:
      - name: Docker login
        run: |
          echo "${{ needs.push-image.outputs.access_token }}" | \
            docker login "$AK_REGISTRY" \
              --username "${{ needs.push-image.outputs.ci_username }}" \
              --password-stdin
      - run: docker build -t "$AK_REGISTRY/$AK_REPO/my-image:${{ github.run_number }}" .
      - run: docker push "$AK_REGISTRY/$AK_REPO/my-image:${{ github.run_number }}"
```

---

### GitLab CI — include template (define once)

Create a file in a central project (e.g. `your-group/ci-templates`), say `ak-login.yml`:

```yaml
# ak-login.yml  (hosted in your-group/ci-templates)
.ak_login:
  id_tokens:
    AK_OIDC_TOKEN:
      aud: artifact-keeper
  before_script:
    - |
      RESP=$(wget -qO- \
        --post-data="{\"provider_id\":\"$AK_PROVIDER_ID\"}" \
        --header="Content-Type: application/json" \
        --header="Authorization: Bearer $AK_OIDC_TOKEN" \
        "$AK_URL/api/v1/auth/ci/token")

      export ACCESS_TOKEN=$(echo "$RESP" | grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)
      export CI_AK_USERNAME=$(echo "$RESP" | grep -o '"username":"[^"]*"' | cut -d'"' -f4)

      echo "$ACCESS_TOKEN" | docker login "$AK_REGISTRY" \
        --username "$CI_AK_USERNAME" --password-stdin
```

**Calling it from any project** (zero curl duplication):

```yaml
include:
  - project: your-group/ci-templates
    file: ak-login.yml

variables:
  AK_URL:         https://your-artifact-keeper-instance
  AK_PROVIDER_ID: <provider-uuid-from-AK-admin>
  AK_REGISTRY:    your-artifact-keeper-instance
  AK_REPO:        my-repo

push-image:
  stage: publish
  image: docker:27
  services: [docker:27-dind]
  extends: .ak_login      # pulls in id_tokens + before_script
  script:
    - docker build -t "$AK_REGISTRY/$AK_REPO/my-image:$CI_PIPELINE_IID" .
    - docker push "$AK_REGISTRY/$AK_REPO/my-image:$CI_PIPELINE_IID"
```

> **Note:** GitLab CI uses `wget` (available in `docker:27`) because `curl` and `jq` are not included in that image. GitHub Actions `ubuntu-latest` has both natively.