### PR TITLE
fix(repositories): always render secondary name line for consistent card heights

### DIFF
--- a/src/app/(app)/repositories/_components/repo-list-item.tsx
+++ b/src/app/(app)/repositories/_components/repo-list-item.tsx
@@ -40,9 +40,9 @@ export function RepoListItem({ repo, isSelected, onSelect, onEdit, onDelete, art
               <span className="text-sm font-medium truncate">{repo.key}</span>
               {!repo.is_public && <Lock className="size-3 shrink-0 text-muted-foreground" />}
             </div>
-            {repo.name !== repo.key && (
-              <p className="text-xs text-muted-foreground truncate">{repo.name}</p>
-            )}
+            <p className="text-xs text-muted-foreground truncate" aria-hidden={repo.name === repo.key}>
+              {repo.name}
+            </p>
             <div className="flex items-center gap-1.5 mt-0.5">
               <span className="text-[11px] font-medium uppercase text-muted-foreground">
                 {repo.format}


### PR DESCRIPTION
## Summary

Repo list cards drifted in height depending on whether `name === key`. When the user accepted the auto-derived lowercase key (the common case), the muted secondary `name` paragraph was conditionally omitted, leaving that card visually shorter than neighbours where the user had customised name or key. The result is a slightly ragged list.

Fix: always render the secondary name line so every card has the same height regardless of how name/key relate. Set `aria-hidden` on the line when the text equals the primary `key` so screen readers don't announce the same string twice.

```tsx
// before
{repo.name !== repo.key && (
  <p className="text-xs text-muted-foreground truncate">{repo.name}</p>
)}

// after
<p className="text-xs text-muted-foreground truncate" aria-hidden={repo.name === repo.key}>
  {repo.name}
</p>
```

## Test Checklist
- [ ] Unit tests added/updated *(N/A — no dedicated test file for `repo-list-item.tsx`; `repositories-content.test.tsx` mocks it out. A Playwright E2E asserting equal card heights would be the right home for a regression test if you'd like one added in a follow-up.)*
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests (`npm test` → 2118/2118 pass; `npm run lint` → 0 errors)

## UI Changes
- [ ] Playwright E2E spec covers the change
- [x] Responsive layout verified (mobile + desktop) — same flex column at all widths; only whether the row renders changes
- [x] Dark mode verified — uses existing `text-muted-foreground` token; no new colour
- [x] Accessibility checked (keyboard navigation, screen reader) — `aria-hidden` on the redundant line prevents screen readers from announcing the same string twice when `name === key`
- [ ] N/A - no UI changes

## Trade-off note

When `name === key` the secondary line shows the same string in muted text (slight visual redundancy). Accepting this in exchange for uniform card heights is a deliberate UX choice. If a designer would rather not duplicate the text, the alternative is to apply `min-height` on the inner column instead — but that requires committing to a specific pixel value that's brittle across font scaling. Happy to switch approaches if you'd prefer the min-height shape.