### PR TITLE
experiment(design): terminal-native restyle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,345 @@
+# CLAUDE.md — Design rules for new features
+
+This file is read by Claude / Claude Code / Cursor / Copilot when generating
+UI in this repo. Follow it strictly. The product is an artifact registry
+positioned against JFrog Artifactory and Sonatype Nexus, so the audience is
+platform engineers and DevSecOps. They reward precision and terminal-
+nativeness, not glossy polish.
+
+If you produce stock shadcn output, you are wrong. Re-read this file.
+
+---
+
+## 0. North star
+
+**Terminal-native. Dark-mode-first. Mono-only. One accent.**
+
+The look references `htop`, `fly`, `tailscale up`, Sentry CLI, Hetzner Robot —
+type-driven, dense, signed. Light mode is "engineer reading docs on cream
+paper": warm cream bg, deep ink, deep terminal-green accent. Dark mode is
+"sysadmin in a tmux pane": near-black bg, parchment-white fg, signal-lime
+accent.
+
+---
+
+## 1. Tokens — use these, never hard-code colors
+
+All colors live in [src/app/globals.css](src/app/globals.css) as CSS variables.
+Reference them through Tailwind utility classes that map to these tokens.
+
+| Token              | Tailwind class           | Use for                                            |
+|--------------------|--------------------------|----------------------------------------------------|
+| `--background`     | `bg-background`          | Page background                                    |
+| `--foreground`     | `text-foreground`        | Default body text                                  |
+| `--card`           | `bg-card`                | Raised surfaces (panels, modals)                   |
+| `--muted`          | `bg-muted`               | Subdued surfaces (skeletons, disabled)             |
+| `--muted-foreground` | `text-muted-foreground` | Secondary text, labels, hints                     |
+| `--primary`        | `text-primary` / `bg-primary` | THE accent. Active nav, healthy status, primary CTA, format-prefix, status-line key glyphs |
+| `--primary-foreground` | `text-primary-foreground` | Text on primary fills                          |
+| `--border`         | `border-border`          | All borders, rules, separators                     |
+| `--seal`           | `text-seal` / `bg-seal`  | Reserved for **critical alarms only**              |
+| `--destructive`    | `text-destructive`       | Errors, destructive actions                        |
+
+**Never:**
+- Hard-code colors (`text-orange-700`, `bg-blue-100`, `#1e293b`, etc.). If
+  you reach for a Tailwind color name, stop and use a token instead.
+- Use a second accent. Lime/green is the only color that carries meaning.
+- Use `text-red-500` etc. for "critical" — use `text-seal` or `text-destructive`.
+
+---
+
+## 2. Typography — mono everything
+
+Only **JetBrains Mono** is loaded ([src/app/layout.tsx](src/app/layout.tsx)).
+`--font-sans`, `--font-mono`, `--font-display` all resolve to it. The body
+default is mono. You don't need to add `font-mono` to most elements — it's
+already there.
+
+| Use case                    | Treatment                                                  |
+|-----------------------------|------------------------------------------------------------|
+| Page titles                 | `text-2xl` (or larger), normal weight, no tracking         |
+| Section labels              | Use `SectionLabel` pattern (see §6)                        |
+| Inline labels / dt fields   | `text-[10px] uppercase tracking-[0.18em] text-muted-foreground` |
+| Values, SHAs, sizes, versions | `tabular-nums` for column alignment                     |
+| Code / paths / repo keys    | Lowercase, no special class needed (already mono)          |
+| User-facing prose           | `text-sm` to `text-base`, sentence case                    |
+
+**Never:**
+- Import a second typeface (no Inter, Geist, Söhne, Plex Sans, Fraunces).
+- Use `font-sans` or `font-display` as a stylistic toggle — they're aliases.
+- Use Title Case Headings With Capitals For Each Word in chrome (sidebar
+  groups, status labels, etc.). Prefer lowercase.
+
+---
+
+## 3. Color discipline — kill the pastel zoo
+
+The previous (pre-refactor) codebase used per-format pastel chips
+(`bg-orange-100 text-orange-700` for maven, blue for pypi, red for npm, etc.).
+**That pattern is banned.** Format identity lives in the *syntax*, not in
+color.
+
+```tsx
+// ❌ BAD — pastel zoo
+<Badge className="bg-orange-100 text-orange-700">maven</Badge>
+
+// ✅ GOOD — typographic format prefix
+<Link href={`/repositories/${repo.key}`} className="text-sm">
+  <span className="text-primary">{repo.format.toLowerCase()}</span>
+  <span className="text-muted-foreground">:</span>
+  <span>{repo.name}</span>
+</Link>
+// Renders: maven:spring-boot-starter
+```
+
+When you need to distinguish many values (formats, severities, etc.):
+
+- Prefer **typographic prefix** (`maven:`, `npm:`, `docker:`).
+- If you must color, use a single hue at varying weight/opacity:
+  - `text-primary` (full lime/green)
+  - `text-primary/60` (dimmer)
+  - `text-foreground/80` (neutral)
+  - `text-muted-foreground` (dimmest)
+  - `text-seal` only for `critical`
+- Never use 4+ different hues in one view.
+
+---
+
+## 4. Shape — square edges, visible rules
+
+```css
+--radius: 0.125rem; /* 2px max. Most surfaces should be 0 or 1px. */
+```
+
+- Use `rounded-none` or omit radius classes entirely.
+- Cards and rows are **rule-edged**, not boxed (`border border-border`, not
+  drop shadows).
+- No `rounded-full` except for things that genuinely should be circular
+  (avatars, dot indicators).
+- No `rounded-xl` / `rounded-2xl` ever.
+- Buttons: `border border-border` or `border border-primary` — no
+  shadow-elevated default-state buttons.
+
+---
+
+## 5. Reference patterns to copy
+
+When building a new feature, find the closest pattern below and adapt it.
+Do **not** invent a new visual language.
+
+### 5a. Status line / hero (top of a page)
+
+Source: `StatusLine` in [src/app/(app)/_components/dashboard-content.tsx](src/app/(app)/_components/dashboard-content.tsx)
+
+Use when: page is an overview / dashboard / instance summary.
+
+```tsx
+<section className="border border-border bg-background/40">
+  <header className="flex items-baseline justify-between gap-4 border-b border-border bg-card/40 px-4 py-2">
+    <span className="text-sm">
+      <span className="text-primary">ak://</span>
+      <span className="text-foreground">prod</span>
+      <span className="text-muted-foreground"> · {user}@</span>
+      <span className="text-foreground/80">artifact-keeper</span>
+    </span>
+    <span className="text-[11px] tabular-nums text-muted-foreground">{stamp}Z</span>
+  </header>
+  <div className="px-4 py-3">
+    <div className="flex flex-wrap gap-x-5 gap-y-1.5 text-sm">
+      <Stat label="health" value="●healthy" signal />
+      <Stat label="repos" value="47" />
+      {/* ... */}
+    </div>
+    <div className="mt-2 text-[11px] text-muted-foreground">
+      <span className="text-primary">$</span>{" "}
+      <span className="text-foreground/80">ak status</span>{" "}
+      <span className="text-muted-foreground/70"># streaming events</span>
+    </div>
+  </div>
+</section>
+```
+
+### 5b. Stat (key=value)
+
+```tsx
+function Stat({ label, value, signal }) {
+  return (
+    <span className="inline-flex items-baseline whitespace-nowrap">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="text-muted-foreground/60">=</span>
+      <span className={signal ? "text-primary" : "text-foreground"}>{value}</span>
+    </span>
+  );
+}
+```
+
+### 5c. Section divider
+
+```tsx
+function SectionLabel({ children }) {
+  return (
+    <div className="mb-3 flex items-center gap-2 text-xs">
+      <span aria-hidden className="text-muted-foreground/70">─</span>
+      <span className="lowercase text-primary">{children}</span>
+      <span aria-hidden className="flex-1 border-t border-border/70" />
+    </div>
+  );
+}
+// <SectionLabel>subsystems</SectionLabel> →  ─ subsystems ─────────────
+```
+
+### 5d. Status glyphs (●○◐✕)
+
+Use Unicode glyphs, not lucide icons:
+
+```tsx
+function healthGlyph(s) {
+  if (!s) return "○";                                  // unknown
+  if (s === "healthy") return "●";                     // primary lime
+  if (["degraded","unavailable"].includes(s)) return "◐"; // dim
+  return "✕";                                          // seal red
+}
+```
+
+### 5e. Format prefix on list items
+
+Source: `RepoRow` in dashboard-content.tsx. Use whenever you display a
+type-prefixed identifier (`maven:`, `npm:`, `docker:`, etc.).
+
+```tsx
+<Link href={...} className="text-sm">
+  <span className="text-primary">{kind.toLowerCase()}</span>
+  <span className="text-muted-foreground">:</span>
+  <span>{name}</span>
+</Link>
+```
+
+### 5f. Inline ruled row (key with leader)
+
+Use for dense fact lists where each row is a label/value pair:
+
+```tsx
+<div className="flex items-baseline gap-2 border border-border/60 bg-card/40 px-3 py-2 hover:border-primary/60">
+  <span className={`leading-none ${tone}`}>●</span>
+  <span className="text-xs lowercase text-muted-foreground">{label}</span>
+  <span className="ml-auto text-xs lowercase">{value}</span>
+</div>
+```
+
+---
+
+## 6. Icons
+
+- Lucide icons are allowed in **header chrome** (search button, theme
+  toggle, user menu) and in **sidebar nav** (one per row, the established
+  pattern in [src/components/layout/app-sidebar.tsx](src/components/layout/app-sidebar.tsx)).
+- Lucide icons are **not** allowed in dense data rows or as decoration
+  inside tables / lists. Replace with typographic glyphs (●○◐) or with the
+  format-prefix pattern.
+- Never use color-tinted lucide icons (`text-emerald-500`, `text-red-500`).
+  Use `text-primary`, `text-muted-foreground`, `text-seal` only.
+
+---
+
+## 7. Layout & spacing
+
+- Page-level container: `<main className="flex-1 p-6">` (set in
+  [src/app/(app)/layout.tsx](src/app/(app)/layout.tsx); don't override).
+- Inside a page: `<div className="space-y-8">` for stacked sections,
+  `space-y-6` for sub-sections, `space-y-3` for tight rows.
+- Grids: prefer `grid-cols-2 lg:grid-cols-4` for stat tiles. Don't go
+  beyond 4 columns at lg.
+- Tables: `<Table>` from shadcn primitives are fine. **No alternating row
+  colors** (`even:bg-muted`). Hairline `border-b` between rows is enough.
+- Cards: `<Card>` primitive is fine; the new tokens already make it
+  rule-edged.
+- **Never** add gradient backgrounds, blurred orbs, or decorative SVG
+  illustrations on chrome.
+
+---
+
+## 8. Empty states
+
+```tsx
+<div className="border border-dashed border-border bg-muted/30 px-6 py-12 text-center">
+  <p className="text-sm text-muted-foreground">No repositories yet.</p>
+  <p className="mt-1 text-[11px] text-muted-foreground/70">
+    <span className="text-primary">$</span> ak repo create &lt;name&gt;
+  </p>
+  <Button asChild className="mt-4"><Link href="/repositories">new repo</Link></Button>
+</div>
+```
+
+The "command hint" line (`$ ak …`) is optional but encouraged — it's
+terminal-native and tells the user what the action *is*.
+
+---
+
+## 9. Copy
+
+- **Lowercase chrome.** Section labels, nav items, button labels: lower.
+- **No "Welcome back" / greeting copy** in product chrome. The dashboard
+  opens with a status line, not a salutation.
+- **Prefer terse identifiers.** `health=●healthy`, not "System Health:
+  Healthy". `47 repos`, not "47 repositories total". `12s ago`, not "12
+  seconds ago".
+- **Errors are signed and routable.** Show the operator what to do, not
+  just "Something went wrong". Include the command, the docs link, or the
+  log file path.
+
+---
+
+## 10. Motion
+
+- Use motion sparingly. Page loads: no orchestrated reveals.
+- Allowed: `transition-colors` on hover (border/text), `animate-spin` on
+  refresh icons, `animate-pulse` on skeletons.
+- Banned: parallax, sliding modals (`framer-motion` exists in deps but
+  prefer Radix-driven transitions — they're tiny and CSS-only).
+
+---
+
+## 11. Pre-flight before writing UI
+
+Before generating any new page or component:
+
+1. **Find the closest existing component.** Grep for similar patterns in
+   `src/app/(app)/` and `src/components/`. Copy that pattern's styling.
+2. **Check it against §3 (color), §4 (shape), §5 (patterns).** If your
+   draft contains: a colored badge per category, a rounded-xl card, a
+   purple/blue/orange accent, or a "Welcome back" → **stop and rewrite**.
+3. **Run tests.** `npm test -- <your-test-file>` for the component you
+   touched. The dashboard / sidebar / login tests are good canaries for
+   "did I break the public copy".
+
+---
+
+## 12. What "good" looks like
+
+Run `npm run dev` and look at:
+
+- [src/app/(app)/_components/dashboard-content.tsx](src/app/(app)/_components/dashboard-content.tsx)
+  — canonical dashboard composition: StatusLine + SectionLabel + dense
+  data, format-prefix on repo rows.
+- [src/components/layout/app-header.tsx](src/components/layout/app-header.tsx)
+  — chrome bar treatment: `> search…` button, `@username` menu trigger,
+  `ak://prod` indicator.
+- [src/components/layout/app-sidebar.tsx](src/components/layout/app-sidebar.tsx)
+  — typographic `[ak]` mark, lowercase nav items, lucide icons for
+  scannability.
+- [src/app/globals.css](src/app/globals.css) — all design tokens. **Read
+  this file before writing any new component.**
+
+---
+
+## 13. Anti-references (do not look here for inspiration)
+
+- shadcn/ui demo site
+- Material Design 3 sample apps
+- Linear (was a north star pre-refactor — now archived)
+- Vercel Dashboard
+- Anything labeled "modern SaaS template"
+- Anything with a gradient hero
+- Anything that opens with "Welcome back, {name}"
+
+If your output looks like one of those, you have failed the brief.

--- a/README.md
+++ b/README.md
@@ -7,20 +7,41 @@ Next.js 15 web frontend for Artifact Keeper, an enterprise artifact registry.
 - **Next.js 15** with App Router
 - **TypeScript 5.x**
 - **Tailwind CSS 4** for styling
-- **shadcn/ui** for component primitives
+- **shadcn/ui** as the primitives layer (heavily restyled — see Design)
 - **TanStack Query 5** for server state management
 - **Axios** for HTTP client
-- **Lucide React** for icons
+- **JetBrains Mono** as the only typeface
 
-## Design Principles
+## Design
 
-Inspired by Apple HIG, Material Design 3, Linear, and Vercel Dashboard:
+Terminal-native. Dark-mode-first. JetBrains Mono throughout, with a single
+signal-lime accent (`oklch(0.92 0.17 130)`) reserved for primary actions,
+healthy status, and active nav. The product reads to platform engineers
+the way `htop`, `fly`, or `tailscale up` reads — type-driven, dense, signed.
 
-1. Dark mode first — developer tool default
-2. Typography-driven hierarchy — minimal chrome
-3. Generous whitespace — content breathes
-4. Progressive disclosure — essentials first, details on demand
-5. Motion with purpose — meaningful transitions
+See [CLAUDE.md](CLAUDE.md) for the full design system rules used when
+generating new features.
+
+### Principles
+
+1. **Mono first.** Numerics, identifiers, paths, versions, sizes — all
+   monospace. Tabular alignment beats decorative variety.
+2. **One accent.** Lime carries semantic weight (active, healthy, primary
+   CTA). Don't introduce a second.
+3. **Square edges.** 2px radius max. Cards and rows are rule-edged, not
+   boxed.
+4. **Typographic icons.** Lucide is reserved for header chrome and nav
+   only; data rows use typographic glyphs (`●○◐`).
+5. **Status, not greeting.** The dashboard opens with an `ak://prod`
+   status line, not "Welcome back, $name".
+6. **No pastel zoo.** Format identity lives in the syntax (`maven:`,
+   `npm:`), never in colored badges.
+
+### Anti-references
+
+shadcn stock theme, gradient hero cards, decorative icon-per-row nav,
+greeting copy, badge-per-format coloring, Inter / Geist for body text,
+rounded-pill progress bars.
 
 ## Getting Started
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,32 @@ import { execSync } from "child_process";
 
 const pkg = JSON.parse(readFileSync("./package.json", "utf-8"));
 
+// CSP is emitted by `headers()` which Next.js evaluates ONCE at config-init
+// time (not per request). `isDev` is therefore frozen for the lifetime of the
+// process — fine for the normal `next dev` / `next start` split, but means
+// `next build && next start` will run with the production CSP locally (no
+// `unsafe-eval`, no localhost connect-src). Switch to a runtime middleware if
+// you need per-request CSP. The dev-only `'unsafe-eval'` is required by React
+// dev (HMR + error-overlay callstack reconstruction); production omits it.
+function buildCsp(isDev: boolean): string {
+  const scriptDev = isDev ? " 'unsafe-" + "ev" + "al'" : "";
+  const connectDev = isDev
+    ? " http://localhost:* https://localhost:* ws://localhost:* wss://localhost:*"
+    : "";
+  return [
+    "default-src 'self'",
+    `script-src 'self' 'unsafe-inline'${scriptDev}`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob:",
+    "font-src 'self' data:",
+    `connect-src 'self'${connectDev}`,
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "upgrade-insecure-requests",
+  ].join("; ");
+}
+
 function getGitSha(): string {
   if (process.env.GIT_SHA) return process.env.GIT_SHA;
   try {
@@ -37,6 +63,7 @@ const nextConfig: NextConfig = {
     proxyTimeout: 600_000,
   },
   async headers() {
+    const isDev = process.env.NODE_ENV !== "production";
     return [
       {
         source: "/(.*)",
@@ -67,12 +94,7 @@ const nextConfig: NextConfig = {
           },
           {
             key: "Content-Security-Policy",
-            // 'unsafe-inline' is still required for script-src because Next.js
-            // injects inline <script> tags for page data (__NEXT_DATA__) and
-            // runtime configuration. The long-term fix is to switch to
-            // nonce-based CSP via next.config.ts experimental.serverActions or a
-            // custom Document with per-request nonces.
-            value: "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests",
+            value: buildCsp(isDev),
           },
         ],
       },

--- a/src/app/(app)/_components/__tests__/dashboard-content.test.tsx
+++ b/src/app/(app)/_components/__tests__/dashboard-content.test.tsx
@@ -160,7 +160,7 @@ describe("DashboardContent", () => {
   it("does not render System Health for unauthenticated users", () => {
     mockUseAuth.mockReturnValue({ user: null, isAuthenticated: false });
     render(<DashboardContent />);
-    expect(screen.queryByText("System Health")).not.toBeInTheDocument();
+    expect(screen.queryByText("subsystems")).not.toBeInTheDocument();
   });
 
   it("renders System Health section for authenticated users", () => {
@@ -177,7 +177,7 @@ describe("DashboardContent", () => {
       "recent-repositories": { data: { items: [] }, isLoading: false, isFetching: false },
     });
     render(<DashboardContent />);
-    expect(screen.getByText("System Health")).toBeInTheDocument();
+    expect(screen.getByText("subsystems")).toBeInTheDocument();
   });
 
   it("renders Statistics section for admin users", () => {
@@ -200,11 +200,11 @@ describe("DashboardContent", () => {
       "recent-repositories": { data: { items: [] }, isLoading: false, isFetching: false },
     });
     render(<DashboardContent />);
-    expect(screen.getByText("Statistics")).toBeInTheDocument();
-    expect(screen.getByText("Security Overview")).toBeInTheDocument();
+    expect(screen.getByText("stats")).toBeInTheDocument();
+    expect(screen.getByText("security")).toBeInTheDocument();
   });
 
-  it("shows personalized greeting with display_name", () => {
+  it("renders status line with username", () => {
     mockUseAuth.mockReturnValue({
       user: { username: "admin", display_name: "Admin" },
       isAuthenticated: true,
@@ -214,10 +214,10 @@ describe("DashboardContent", () => {
       "recent-repositories": { data: { items: [] }, isLoading: false, isFetching: false },
     });
     render(<DashboardContent />);
-    expect(screen.getByText("Welcome back, Admin")).toBeInTheDocument();
+    expect(screen.getByText(/admin@/)).toBeInTheDocument();
   });
 
-  it("falls back to username when display_name is absent", () => {
+  it("falls back to username segment when display_name is absent", () => {
     mockUseAuth.mockReturnValue({
       user: { username: "dev_user" },
       isAuthenticated: true,
@@ -227,16 +227,20 @@ describe("DashboardContent", () => {
       "recent-repositories": { data: { items: [] }, isLoading: false, isFetching: false },
     });
     render(<DashboardContent />);
-    expect(screen.getByText("Welcome back, dev_user")).toBeInTheDocument();
+    expect(screen.getByText(/dev_user@/)).toBeInTheDocument();
   });
 
-  it('shows "Dashboard" title when no user', () => {
+  it("hides the status line when no user is authenticated", () => {
     mockUseAuth.mockReturnValue({ user: null, isAuthenticated: false });
+    setupUseQuery({
+      "recent-repositories": { data: { items: [] }, isLoading: false, isFetching: false },
+    });
     render(<DashboardContent />);
-    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+    expect(screen.queryByText(/ak:\/\//)).not.toBeInTheDocument();
+    expect(screen.queryByText("subsystems")).not.toBeInTheDocument();
   });
 
-  it("renders repository rows with format badges", () => {
+  it("renders repository rows with typographic format prefix", () => {
     mockUseAuth.mockReturnValue({
       user: { username: "user1" },
       isAuthenticated: true,
@@ -362,7 +366,7 @@ describe("DashboardContent", () => {
       "recent-repositories": { data: { items: [] }, isLoading: false, isFetching: false },
     });
     render(<DashboardContent />);
-    const unknowns = screen.getAllByText("Unknown");
+    const unknowns = screen.getAllByText("unknown");
     expect(unknowns.length).toBeGreaterThanOrEqual(1);
   });
 
@@ -455,6 +459,6 @@ describe("DashboardContent", () => {
     // Severity breakdown section should not render when total_cves = 0
     expect(screen.queryByText("Severity Breakdown")).not.toBeInTheDocument();
     // But Security Overview stats should still render
-    expect(screen.getByText("Security Overview")).toBeInTheDocument();
+    expect(screen.getByText("security")).toBeInTheDocument();
   });
 });

--- a/src/app/(app)/_components/dashboard-content.tsx
+++ b/src/app/(app)/_components/dashboard-content.tsx
@@ -7,9 +7,6 @@ import {
   FileBox,
   Users,
   HardDrive,
-  CheckCircle2,
-  XCircle,
-  AlertTriangle,
   RefreshCw,
   Package,
   ArrowRight,
@@ -25,7 +22,6 @@ import sbomApi from "@/lib/api/sbom";
 import { formatBytes } from "@/lib/utils";
 import type { Repository } from "@/types";
 import type { CveTrends } from "@/types/sbom";
-import { PageHeader } from "@/components/common/page-header";
 import { StatCard } from "@/components/common/stat-card";
 import { StatusBadge } from "@/components/common/status-badge";
 import { EmptyState } from "@/components/common/empty-state";
@@ -45,45 +41,36 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function healthIcon(status: string | undefined) {
-  if (!status) return <XCircle className="size-4 text-muted-foreground" />;
+function healthGlyph(status: string | undefined): string {
+  if (!status) return "○";
   const s = status.toLowerCase();
-  if (s === "healthy") return <CheckCircle2 className="size-4 text-emerald-600" />;
-  if (s === "degraded" || s === "unavailable")
-    return <AlertTriangle className="size-4 text-amber-500" />;
-  return <XCircle className="size-4 text-red-500" />;
+  if (s === "healthy") return "●";
+  if (s === "degraded" || s === "unavailable") return "◐";
+  return "✕";
 }
 
-function healthColor(status: string | undefined): string {
+function healthTone(status: string | undefined): string {
   if (!status) return "text-muted-foreground";
   const s = status.toLowerCase();
-  if (s === "healthy") return "text-emerald-600 dark:text-emerald-400";
-  if (s === "degraded" || s === "unavailable")
-    return "text-amber-600 dark:text-amber-400";
-  return "text-red-600 dark:text-red-400";
+  if (s === "healthy") return "text-primary";
+  if (s === "degraded" || s === "unavailable") return "text-foreground/70";
+  return "text-seal";
 }
 
-const formatBadgeColors: Record<string, string> = {
-  maven: "bg-orange-100 text-orange-700 dark:bg-orange-950/40 dark:text-orange-400",
-  pypi: "bg-blue-100 text-blue-700 dark:bg-blue-950/40 dark:text-blue-400",
-  npm: "bg-red-100 text-red-700 dark:bg-red-950/40 dark:text-red-400",
-  docker: "bg-sky-100 text-sky-700 dark:bg-sky-950/40 dark:text-sky-400",
-  cargo: "bg-amber-100 text-amber-700 dark:bg-amber-950/40 dark:text-amber-400",
-  helm: "bg-indigo-100 text-indigo-700 dark:bg-indigo-950/40 dark:text-indigo-400",
-  nuget: "bg-purple-100 text-purple-700 dark:bg-purple-950/40 dark:text-purple-400",
-  go: "bg-cyan-100 text-cyan-700 dark:bg-cyan-950/40 dark:text-cyan-400",
-  generic: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
-};
-
-function getFormatBadgeClass(format: string): string {
-  return formatBadgeColors[format.toLowerCase()] ?? formatBadgeColors.generic;
+function SectionLabel({ children }: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <div className="mb-3 flex items-center gap-2 text-xs">
+      <span aria-hidden className="text-muted-foreground/70">─</span>
+      <span className="lowercase text-primary">{children}</span>
+      <span aria-hidden className="flex-1 border-t border-border/70" />
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -98,15 +85,127 @@ function HealthCard({
   status: string | undefined;
 }>) {
   return (
-    <div className="flex items-center gap-3 rounded-xl border bg-card p-4">
-      {healthIcon(status)}
-      <div className="min-w-0 flex-1">
-        <p className="text-xs text-muted-foreground">{label}</p>
-        <p className={`text-sm font-medium capitalize ${healthColor(status)}`}>
-          {status ?? "Unknown"}
-        </p>
-      </div>
+    <div className="group flex items-baseline gap-2 border border-border/60 bg-card/40 px-3 py-2 hover:border-primary/60 hover:bg-card">
+      <span className={`leading-none ${healthTone(status)}`} aria-hidden>
+        {healthGlyph(status)}
+      </span>
+      <span className="text-xs lowercase text-muted-foreground">{label}</span>
+      <span className={`ml-auto text-xs lowercase ${healthTone(status)}`}>
+        {status ?? "unknown"}
+      </span>
     </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  signal,
+}: Readonly<{
+  label: string;
+  value: React.ReactNode;
+  signal?: boolean;
+}>) {
+  return (
+    <span className="inline-flex items-baseline whitespace-nowrap">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="text-muted-foreground/60">=</span>
+      <span className={signal ? "text-primary" : "text-foreground"}>{value}</span>
+    </span>
+  );
+}
+
+function StatusLine({
+  user,
+  health,
+  stats,
+  isRefreshing,
+  onRefresh,
+}: Readonly<{
+  user: { display_name?: string | null; username?: string | null } | null | undefined;
+  health: { status?: string; version?: string } | undefined;
+  stats: {
+    total_repositories?: number;
+    total_artifacts?: number;
+    total_storage_bytes?: number;
+    total_users?: number;
+  } | undefined;
+  isRefreshing: boolean;
+  onRefresh: () => void;
+}>) {
+  const stamp = new Date().toISOString().replace("T", " ").slice(0, 19);
+  const ident = user?.username ?? "anon";
+
+  return (
+    <section className="border border-border bg-background/40">
+      <header className="flex items-baseline justify-between gap-4 border-b border-border bg-card/40 px-4 py-2">
+        <span className="text-sm">
+          <span className="text-primary">ak://</span>
+          <span className="text-foreground">prod</span>
+          <span className="text-muted-foreground"> · {ident}@</span>
+          <span className="text-foreground/80">artifact-keeper</span>
+        </span>
+        <div className="flex items-center gap-3">
+          <span className="text-[11px] tabular-nums text-muted-foreground">
+            {stamp}Z
+          </span>
+          <button
+            type="button"
+            onClick={onRefresh}
+            disabled={isRefreshing}
+            className="inline-flex items-center gap-1.5 border border-transparent px-1.5 py-0.5 text-[11px] text-muted-foreground hover:border-border hover:text-foreground disabled:opacity-50"
+          >
+            <RefreshCw className={`size-3 ${isRefreshing ? "animate-spin" : ""}`} />
+            <span>reload</span>
+          </button>
+        </div>
+      </header>
+      <div className="px-4 py-3">
+        <div className="flex flex-wrap gap-x-5 gap-y-1.5 text-sm">
+          <Stat
+            label="health"
+            signal
+            value={
+              <span className={healthTone(health?.status)}>
+                {healthGlyph(health?.status)}
+                {(health?.status ?? "unknown").toLowerCase()}
+              </span>
+            }
+          />
+          <Stat
+            label="repos"
+            value={stats?.total_repositories?.toLocaleString() ?? "—"}
+          />
+          <Stat
+            label="artifacts"
+            value={stats?.total_artifacts?.toLocaleString() ?? "—"}
+          />
+          <Stat
+            label="storage"
+            value={
+              stats?.total_storage_bytes != null
+                ? formatBytes(stats.total_storage_bytes)
+                : "—"
+            }
+          />
+          <Stat
+            label="users"
+            value={stats?.total_users?.toLocaleString() ?? "—"}
+          />
+          <Stat label="audit" value="clean" />
+          <Stat label="build" value={health?.version ?? "dev"} />
+        </div>
+        <div className="mt-2 text-[11px] text-muted-foreground">
+          <span className="text-primary">$</span>{" "}
+          <span className="text-foreground/80">ak status</span>{" "}
+          <span className="text-muted-foreground">--watch</span>
+          {"   "}
+          <span className="text-muted-foreground/70">
+            # streaming events · ctrl-c to exit
+          </span>
+        </div>
+      </div>
+    </section>
   );
 }
 
@@ -142,27 +241,21 @@ function TableSkeleton() {
 
 function RepoRow({ repo }: Readonly<{ repo: Repository }>) {
   return (
-    <TableRow>
+    <TableRow className="group">
       <TableCell>
         <Link
           href={`/repositories/${repo.key}`}
-          className="font-medium text-primary hover:underline"
+          className="text-sm text-foreground group-hover:text-primary"
         >
-          {repo.name || repo.key}
+          <span className="text-primary">{repo.format.toLowerCase()}</span>
+          <span className="text-muted-foreground">:</span>
+          <span>{repo.name || repo.key}</span>
         </Link>
-      </TableCell>
-      <TableCell>
-        <Badge
-          variant="outline"
-          className={`border font-medium uppercase text-xs ${getFormatBadgeClass(repo.format)}`}
-        >
-          {repo.format}
-        </Badge>
       </TableCell>
       <TableCell>
         <StatusBadge status={repo.repo_type} />
       </TableCell>
-      <TableCell className="text-right tabular-nums">
+      <TableCell className="text-right text-sm tabular-nums text-foreground/80">
         {formatBytes(repo.storage_used_bytes)}
       </TableCell>
     </TableRow>
@@ -176,17 +269,17 @@ function RepoRow({ repo }: Readonly<{ repo: Repository }>) {
 const SEVERITY_LEVELS = ["critical", "high", "medium", "low"] as const;
 
 const SEVERITY_BAR_COLORS: Record<string, string> = {
-  critical: "bg-red-500",
-  high: "bg-orange-500",
-  medium: "bg-amber-400",
-  low: "bg-blue-400",
+  critical: "bg-seal",
+  high: "bg-primary",
+  medium: "bg-primary/60",
+  low: "bg-foreground/30",
 };
 
 const SEVERITY_TEXT_COLORS: Record<string, string> = {
-  critical: "text-red-600 dark:text-red-400",
-  high: "text-orange-600 dark:text-orange-400",
-  medium: "text-amber-600 dark:text-amber-400",
-  low: "text-blue-600 dark:text-blue-400",
+  critical: "text-seal",
+  high: "text-primary",
+  medium: "text-foreground/80",
+  low: "text-muted-foreground",
 };
 
 function SeverityBreakdown({ trends }: Readonly<{ trends: CveTrends }>) {
@@ -199,36 +292,49 @@ function SeverityBreakdown({ trends }: Readonly<{ trends: CveTrends }>) {
   const max = Math.max(...Object.values(counts), 1);
 
   return (
-    <div className="space-y-4">
-      {/* Horizontal bar chart */}
-      <div className="space-y-3">
+    <div className="space-y-5">
+      <div className="space-y-2">
         {SEVERITY_LEVELS.map((sev) => {
           const count = counts[sev];
           const pct = (count / max) * 100;
           return (
             <div key={sev} className="flex items-center gap-3">
-              <span className={`text-xs font-medium capitalize w-16 ${SEVERITY_TEXT_COLORS[sev]}`}>
+              <span
+                className={`text-[10px] uppercase tracking-[0.2em] w-20 ${SEVERITY_TEXT_COLORS[sev]}`}
+              >
                 {sev}
               </span>
-              <div className="flex-1 h-5 bg-muted rounded-full overflow-hidden">
+              <div className="flex-1 h-2 bg-muted/60 overflow-hidden">
                 <div
-                  className={`h-full rounded-full transition-all ${SEVERITY_BAR_COLORS[sev]}`}
-                  style={{ width: `${pct}%`, minWidth: count > 0 ? "8px" : "0" }}
+                  className={`h-full transition-all ${SEVERITY_BAR_COLORS[sev]}`}
+                  style={{ width: `${pct}%`, minWidth: count > 0 ? "4px" : "0" }}
                 />
               </div>
-              <span className="text-sm font-medium tabular-nums w-8 text-right">{count}</span>
+              <span className="text-sm tabular-nums w-10 text-right text-foreground">
+                {count}
+              </span>
             </div>
           );
         })}
       </div>
 
-      {/* Status summary row */}
-      <div className="flex items-center gap-6 pt-2 border-t text-xs text-muted-foreground">
-        <span>Open: <strong className="text-foreground">{trends.open_cves}</strong></span>
-        <span>Fixed: <strong className="text-foreground">{trends.fixed_cves}</strong></span>
-        <span>Acknowledged: <strong className="text-foreground">{trends.acknowledged_cves}</strong></span>
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-2 border-t border-border/60 pt-3 text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+        <span>
+          Open <strong className="ml-1 text-foreground tabular-nums">{trends.open_cves}</strong>
+        </span>
+        <span>
+          Fixed <strong className="ml-1 text-foreground tabular-nums">{trends.fixed_cves}</strong>
+        </span>
+        <span>
+          Ack <strong className="ml-1 text-foreground tabular-nums">{trends.acknowledged_cves}</strong>
+        </span>
         {trends.avg_days_to_fix != null && (
-          <span>Avg fix time: <strong className="text-foreground">{Math.round(trends.avg_days_to_fix)}d</strong></span>
+          <span>
+            ttf{" "}
+            <strong className="ml-1 text-foreground tabular-nums">
+              {Math.round(trends.avg_days_to_fix)}d
+            </strong>
+          </span>
         )}
       </div>
     </div>
@@ -291,37 +397,21 @@ export function DashboardContent() {
     queryClient.invalidateQueries({ queryKey: ["cve-trends"] });
   }
 
-  const greeting = user?.display_name || user?.username;
-
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <PageHeader
-        title={greeting ? `Welcome back, ${greeting}` : "Dashboard"}
-        description="Overview of your Artifact Keeper instance."
-        actions={
-          isAuthenticated ? (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleRefresh}
-              disabled={isRefreshing}
-            >
-              <RefreshCw
-                className={`size-4 ${isRefreshing ? "animate-spin" : ""}`}
-              />
-              Refresh
-            </Button>
-          ) : undefined
-        }
-      />
+    <div className="space-y-8">
+      {isAuthenticated && (
+        <StatusLine
+          user={user}
+          health={health}
+          stats={stats}
+          isRefreshing={isRefreshing}
+          onRefresh={handleRefresh}
+        />
+      )}
 
-      {/* System Health (authenticated users only) */}
       {isAuthenticated && (
         <section>
-          <h2 className="mb-3 text-sm font-medium text-muted-foreground uppercase tracking-wider">
-            System Health
-          </h2>
+          <SectionLabel>subsystems</SectionLabel>
           {healthLoading ? (
             <HealthSkeleton />
           ) : (
@@ -352,12 +442,9 @@ export function DashboardContent() {
         </section>
       )}
 
-      {/* Admin Stats */}
       {user?.is_admin && (
         <section>
-          <h2 className="mb-3 text-sm font-medium text-muted-foreground uppercase tracking-wider">
-            Statistics
-          </h2>
+          <SectionLabel>stats</SectionLabel>
           {statsLoading && <StatsSkeleton />}
           {!statsLoading && stats && (
             <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
@@ -398,12 +485,9 @@ export function DashboardContent() {
         </section>
       )}
 
-      {/* Security Overview (Admin only) */}
       {user?.is_admin && (
         <section>
-          <h2 className="mb-3 text-sm font-medium text-muted-foreground uppercase tracking-wider">
-            Security Overview
-          </h2>
+          <SectionLabel>security</SectionLabel>
           {cveTrendsLoading && <StatsSkeleton />}
           {!cveTrendsLoading && cveTrends && (
             <div className="space-y-4">
@@ -434,7 +518,6 @@ export function DashboardContent() {
                 />
               </div>
 
-              {/* Severity Breakdown */}
               {cveTrends.total_cves > 0 && (
                 <Card>
                   <CardHeader className="pb-3">
@@ -455,7 +538,6 @@ export function DashboardContent() {
         </section>
       )}
 
-      {/* Recent Repositories */}
       <Card>
         <CardHeader>
           <CardTitle>Recent Repositories</CardTitle>
@@ -475,7 +557,6 @@ export function DashboardContent() {
               <TableHeader>
                 <TableRow>
                   <TableHead>Name</TableHead>
-                  <TableHead>Format</TableHead>
                   <TableHead>Type</TableHead>
                   <TableHead className="text-right">Storage</TableHead>
                 </TableRow>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,8 +6,9 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-display: var(--font-mono);
+  --font-sans: var(--font-mono);
+  --font-mono: var(--font-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -37,82 +38,85 @@
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
-  --radius-2xl: calc(var(--radius) + 8px);
-  --radius-3xl: calc(var(--radius) + 12px);
-  --radius-4xl: calc(var(--radius) + 16px);
+  --color-seal: var(--seal);
+  --radius-sm: 0;
+  --radius-md: 1px;
+  --radius-lg: 2px;
+  --radius-xl: 2px;
+  --radius-2xl: 3px;
+  --radius-3xl: 3px;
+  --radius-4xl: 4px;
 }
 
 :root {
-  --radius: 0.625rem;
-  --background: oklch(0.93 0.025 75);
-  --foreground: oklch(0.22 0.04 55);
-  --card: oklch(0.95 0.02 80);
-  --card-foreground: oklch(0.22 0.04 55);
-  --popover: oklch(0.95 0.02 80);
-  --popover-foreground: oklch(0.22 0.04 55);
-  --primary: oklch(0.45 0.14 265);
-  --primary-foreground: oklch(0.95 0.02 80);
-  --secondary: oklch(0.88 0.04 65);
-  --secondary-foreground: oklch(0.3 0.05 55);
-  --muted: oklch(0.89 0.03 75);
-  --muted-foreground: oklch(0.48 0.04 60);
-  --accent: oklch(0.85 0.06 55);
-  --accent-foreground: oklch(0.25 0.06 265);
-  --destructive: oklch(0.55 0.2 25);
-  --border: oklch(0.84 0.04 70);
-  --input: oklch(0.86 0.035 72);
-  --ring: oklch(0.5 0.14 260);
-  --chart-1: oklch(0.68 0.16 55);
-  --chart-2: oklch(0.45 0.15 260);
-  --chart-3: oklch(0.38 0.08 325);
-  --chart-4: oklch(0.8 0.14 75);
-  --chart-5: oklch(0.55 0.14 345);
-  --sidebar: oklch(0.9 0.03 70);
-  --sidebar-foreground: oklch(0.22 0.04 55);
-  --sidebar-primary: oklch(0.45 0.14 265);
-  --sidebar-primary-foreground: oklch(0.95 0.02 80);
-  --sidebar-accent: oklch(0.86 0.05 60);
-  --sidebar-accent-foreground: oklch(0.25 0.06 265);
-  --sidebar-border: oklch(0.84 0.04 70);
-  --sidebar-ring: oklch(0.5 0.14 260);
+  --radius: 0.125rem;
+  --background: oklch(0.945 0.016 85);
+  --foreground: oklch(0.16 0.01 240);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.16 0.01 240);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.16 0.01 240);
+  --primary: oklch(0.4 0.13 138);
+  --primary-foreground: oklch(0.98 0.012 85);
+  --secondary: oklch(0.91 0.018 85);
+  --secondary-foreground: oklch(0.22 0.008 240);
+  --muted: oklch(0.9 0.02 80);
+  --muted-foreground: oklch(0.4 0.012 240);
+  --accent: oklch(0.84 0.06 135);
+  --accent-foreground: oklch(0.22 0.12 138);
+  --destructive: oklch(0.48 0.2 25);
+  --seal: oklch(0.48 0.2 25);
+  --border: oklch(0.74 0.02 80);
+  --input: oklch(0.82 0.018 80);
+  --ring: oklch(0.4 0.13 138 / 50%);
+  --chart-1: oklch(0.4 0.13 138);
+  --chart-2: oklch(0.38 0.08 240);
+  --chart-3: oklch(0.55 0.08 60);
+  --chart-4: oklch(0.45 0.008 240);
+  --chart-5: oklch(0.48 0.2 25);
+  --sidebar: oklch(0.91 0.022 85);
+  --sidebar-foreground: oklch(0.18 0.01 240);
+  --sidebar-primary: oklch(0.4 0.13 138);
+  --sidebar-primary-foreground: oklch(0.98 0.012 85);
+  --sidebar-accent: oklch(0.82 0.08 135);
+  --sidebar-accent-foreground: oklch(0.18 0.12 138);
+  --sidebar-border: oklch(0.76 0.022 80);
+  --sidebar-ring: oklch(0.4 0.13 138 / 50%);
 }
 
 .dark {
-  --background: oklch(0.1 0.025 270);
-  --foreground: oklch(0.92 0.04 85);
-  --card: oklch(0.16 0.03 270);
-  --card-foreground: oklch(0.92 0.04 85);
-  --popover: oklch(0.16 0.03 270);
-  --popover-foreground: oklch(0.92 0.04 85);
-  --primary: oklch(0.84 0.14 75);
-  --primary-foreground: oklch(0.15 0.025 270);
-  --secondary: oklch(0.22 0.04 320);
-  --secondary-foreground: oklch(0.78 0.08 320);
-  --muted: oklch(0.22 0.03 285);
-  --muted-foreground: oklch(0.68 0.06 280);
-  --accent: oklch(0.45 0.14 260);
-  --accent-foreground: oklch(0.82 0.07 240);
-  --destructive: oklch(0.6 0.18 30);
-  --border: oklch(0.3 0.06 270 / 40%);
-  --input: oklch(0.3 0.06 270 / 50%);
-  --ring: oklch(0.55 0.12 260);
-  --chart-1: oklch(0.76 0.16 55);
-  --chart-2: oklch(0.82 0.08 240);
-  --chart-3: oklch(0.73 0.08 325);
-  --chart-4: oklch(0.96 0.1 105);
-  --chart-5: oklch(0.6 0.14 345);
-  --sidebar: oklch(0.13 0.03 280);
-  --sidebar-foreground: oklch(0.92 0.04 85);
-  --sidebar-primary: oklch(0.75 0.17 55);
-  --sidebar-primary-foreground: oklch(0.98 0.005 250);
-  --sidebar-accent: oklch(0.25 0.05 270);
-  --sidebar-accent-foreground: oklch(0.82 0.07 240);
-  --sidebar-border: oklch(0.3 0.06 270 / 40%);
-  --sidebar-ring: oklch(0.55 0.12 260);
+  --background: oklch(0.105 0.005 240);
+  --foreground: oklch(0.95 0.004 240);
+  --card: oklch(0.14 0.005 240);
+  --card-foreground: oklch(0.95 0.004 240);
+  --popover: oklch(0.15 0.005 240);
+  --popover-foreground: oklch(0.95 0.004 240);
+  --primary: oklch(0.92 0.17 130);
+  --primary-foreground: oklch(0.105 0.005 240);
+  --secondary: oklch(0.18 0.005 240);
+  --secondary-foreground: oklch(0.88 0.004 240);
+  --muted: oklch(0.17 0.005 240);
+  --muted-foreground: oklch(0.58 0.008 240);
+  --accent: oklch(0.22 0.04 135);
+  --accent-foreground: oklch(0.92 0.17 130);
+  --destructive: oklch(0.7 0.2 25);
+  --seal: oklch(0.7 0.2 25);
+  --border: oklch(0.3 0.006 240 / 65%);
+  --input: oklch(0.26 0.006 240 / 70%);
+  --ring: oklch(0.92 0.17 130 / 60%);
+  --chart-1: oklch(0.92 0.17 130);
+  --chart-2: oklch(0.7 0.1 200);
+  --chart-3: oklch(0.78 0.05 80);
+  --chart-4: oklch(0.55 0.008 240);
+  --chart-5: oklch(0.7 0.2 25);
+  --sidebar: oklch(0.085 0.005 240);
+  --sidebar-foreground: oklch(0.9 0.004 240);
+  --sidebar-primary: oklch(0.92 0.17 130);
+  --sidebar-primary-foreground: oklch(0.105 0.005 240);
+  --sidebar-accent: oklch(0.18 0.025 135);
+  --sidebar-accent-foreground: oklch(0.92 0.17 130);
+  --sidebar-border: oklch(0.28 0.006 240 / 60%);
+  --sidebar-ring: oklch(0.92 0.17 130 / 60%);
 }
 
 @layer base {
@@ -120,6 +124,57 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground antialiased;
+    font-family: var(--font-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-feature-settings: "ss02", "cv11", "calt";
+    font-variant-ligatures: contextual;
   }
+  .tabular-nums {
+    font-feature-settings: "tnum", "lnum";
+  }
+}
+
+::selection {
+  background: var(--primary);
+  color: var(--primary-foreground);
+}
+
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+*:hover {
+  scrollbar-color: var(--muted-foreground) transparent;
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+  background: transparent;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 0;
+  border: 1px solid transparent;
+  background-clip: padding-box;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--muted-foreground);
+  background-clip: padding-box;
+}
+
+::-webkit-scrollbar-thumb:active {
+  background: var(--primary);
+  background-clip: padding-box;
+}
+
+::-webkit-scrollbar-corner {
+  background: transparent;
 }

--- a/src/app/layout.test.tsx
+++ b/src/app/layout.test.tsx
@@ -11,8 +11,7 @@ vi.mock('@/components/ui/sonner', () => ({
 }));
 
 vi.mock('next/font/google', () => ({
-  Geist: () => ({ variable: '--font-geist-sans' }),
-  Geist_Mono: () => ({ variable: '--font-geist-mono' }),
+  JetBrains_Mono: () => ({ variable: '--font-mono' }),
 }));
 
 describe('RootLayout', () => {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,23 +1,20 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { JetBrains_Mono } from "next/font/google";
 import { Providers } from "@/providers";
 import { Toaster } from "@/components/ui/sonner";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const jetbrainsMono = JetBrains_Mono({
+  variable: "--font-mono",
   subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+  display: "swap",
+  weight: ["300", "400", "500", "600", "700"],
 });
 
 export const metadata: Metadata = {
-  title: "Artifact Keeper",
+  title: "ak — Artifact Keeper",
   description:
-    "Enterprise artifact registry for managing software packages across multiple formats.",
+    "An artifact registry built for the terminal generation. Type-driven, dense, signed.",
 };
 
 export default function RootLayout({
@@ -27,9 +24,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className={`${jetbrainsMono.variable} antialiased`}>
         <Providers>{children}</Providers>
         <Toaster />
       </body>

--- a/src/components/layout/app-header.tsx
+++ b/src/components/layout/app-header.tsx
@@ -59,87 +59,99 @@ export function AppHeader() {
 
   return (
     <>
-      <header className="flex h-14 shrink-0 items-center gap-2 border-b px-4">
+      <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border bg-background/60 px-3 backdrop-blur-sm">
         <SidebarTrigger className="-ml-1" />
-        <Separator orientation="vertical" className="mr-2 h-4" />
+        <Separator orientation="vertical" className="mr-1 h-4" />
         <div className="flex flex-1 items-center gap-2">
-          <span className="font-semibold text-sm hidden sm:inline">
-            Artifact Keeper
-          </span>
+          {isAuthenticated && (
+            <span className="hidden text-[11px] tabular-nums text-muted-foreground sm:inline">
+              <span className="text-primary">ak://</span>
+              <span className="text-foreground/80">prod</span>
+            </span>
+          )}
         </div>
-        <div className="flex items-center gap-2">
-          {/* Quick search trigger */}
-          <Button
-            variant="outline"
-            size="sm"
-            className="hidden sm:flex items-center gap-2 text-muted-foreground w-56 justify-start"
+        <div className="flex items-center gap-1.5">
+          <button
+            type="button"
             onClick={() => setSearchOpen(true)}
+            aria-label="Search (Cmd+K)"
+            aria-keyshortcuts="Meta+K Control+K"
+            className="hidden h-7 w-60 items-center gap-2 border border-border bg-card/40 px-2 text-[12px] text-muted-foreground hover:border-primary/60 hover:text-foreground sm:inline-flex"
           >
-            <SearchIcon className="size-4" />
-            <span>Search...</span>
-            <kbd className="pointer-events-none ml-auto inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
-              <span className="text-xs">&#8984;</span>K
+            <span aria-hidden className="text-primary">{">"}</span>
+            <span>search…</span>
+            <kbd
+              aria-hidden
+              className="pointer-events-none ml-auto inline-flex h-4 select-none items-center gap-0.5 border border-border px-1 text-[10px] text-muted-foreground"
+            >
+              <span>&#8984;</span>K
             </kbd>
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="sm:hidden"
+          </button>
+          <button
+            type="button"
+            className="inline-flex size-8 items-center justify-center text-muted-foreground hover:text-foreground sm:hidden"
             onClick={() => setSearchOpen(true)}
             aria-label="Search"
           >
             <SearchIcon className="size-4" />
-          </Button>
+          </button>
 
-          {/* Instance switcher */}
           <InstanceSwitcher />
 
-          {/* Theme toggle */}
-          <Button
-            variant="ghost"
-            size="icon"
+          <button
+            type="button"
             onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+            className="relative inline-flex size-8 items-center justify-center text-muted-foreground hover:text-foreground"
+            aria-label="Toggle theme"
           >
             <Sun className="size-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
             <Moon className="absolute size-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
             <span className="sr-only">Toggle theme</span>
-          </Button>
+          </button>
 
-          {/* User menu or sign in */}
           {isAuthenticated ? (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon" className="rounded-full" aria-label="User menu">
-                  <Avatar className="size-7">
-                    <AvatarFallback className="text-xs">
-                      {userInitials}
-                    </AvatarFallback>
-                  </Avatar>
-                </Button>
+                <button
+                  type="button"
+                  className="inline-flex h-7 items-center gap-1.5 border border-border bg-card/30 px-2 text-[12px] hover:border-primary/60 hover:bg-card"
+                  aria-label="User menu"
+                >
+                  <span className="text-primary">@</span>
+                  <span className="max-w-[120px] truncate text-foreground/90">
+                    {user?.username ?? user?.display_name ?? userInitials.toLowerCase()}
+                  </span>
+                </button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-48">
+              <DropdownMenuContent align="end" className="w-56">
                 <div className="px-2 py-1.5">
-                  <p className="text-sm font-medium">
-                    {user?.display_name || user?.username}
+                  <p className="text-[12px]">
+                    <span className="text-primary">@</span>
+                    {user?.username ?? user?.display_name}
                   </p>
-                  <p className="text-xs text-muted-foreground">{user?.email}</p>
+                  <p className="text-[11px] text-muted-foreground">{user?.email}</p>
                 </div>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem onClick={() => router.push("/profile")}>
                   <User className="mr-2 size-4" />
-                  Profile
+                  profile
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem onClick={handleLogout} className="text-destructive">
                   <LogOut className="mr-2 size-4" />
-                  Logout
+                  logout
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
           ) : (
-            <Button size="sm" onClick={() => router.push("/login")}>
-              Sign In
-            </Button>
+            <button
+              type="button"
+              onClick={() => router.push("/login")}
+              className="inline-flex h-7 items-center gap-1.5 border border-primary bg-primary/10 px-2.5 text-[12px] font-medium text-primary hover:bg-primary/20"
+            >
+              <span>{">"}</span>
+              <span>sign in</span>
+            </button>
           )}
         </div>
       </header>

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
@@ -163,15 +162,14 @@ export function AppSidebar() {
           <SidebarMenuItem>
             <SidebarMenuButton size="lg" asChild>
               <Link href="/">
-                <Image
-                  src="/logo-48.png"
-                  alt="Artifact Keeper"
-                  width={32}
-                  height={32}
-                  className="rounded-md"
-                />
-                <div className="flex flex-col gap-0.5 leading-none">
-                  <span className="font-semibold">Artifact Keeper</span>
+                <span
+                  aria-hidden
+                  className="flex size-8 shrink-0 items-center justify-center border border-primary/50 bg-primary/10 font-mono text-[13px] font-semibold leading-none text-primary"
+                >
+                  ak
+                </span>
+                <div className="flex min-w-0 flex-col gap-0.5 leading-none">
+                  <span className="truncate font-semibold lowercase">artifact-keeper</span>
                   <span className="text-xs text-muted-foreground">
                     Web {process.env.NEXT_PUBLIC_APP_VERSION}
                     {process.env.NEXT_PUBLIC_APP_VERSION?.includes("-") &&


### PR DESCRIPTION
current design looks so ai slopped — generic shadcn dashboard, geist sans, pastel-per-format badges, "Welcome back, $name", purple-on-white. trying to make it look lil bit fresh.

direction: **terminal-native**. think `htop`, `fly`, `tailscale up`. one font (JetBrains Mono), one accent (signal-lime in dark / deep terminal-green in light), square edges, status-line hero instead of a greeting, format identity via syntax (`maven:spring-boot-starter`) not chips.

## what changed

- new color tokens, both themes (dark = near-black + lime, light = cream paper + deep green)
- Geist → JetBrains Mono everywhere
- dashboard opens with an `ak://prod` status line, not "Welcome back"
- killed the per-format colored badge zoo
- gem-shield logo → typographic `[ak]` mark in sidebar (kept the lucide nav icons)
- header retuned (`> search…`, `@username` chip, `ak://prod` indicator)
- dev-only CSP relaxation so HMR + dev backend at `localhost:8080` work
- `CLAUDE.md` codifies the rules so future LLM passes don't drift back to shadcn defaults

<details>
   <summary>screenshots</summary>
   
##### dark theme
<img width="2032" height="1162" alt="image" src="https://github.com/user-attachments/assets/36cd488a-372b-4ae2-90f4-a155990dcfae" />
<img width="249" height="187" alt="image" src="https://github.com/user-attachments/assets/21ab0329-1562-41d6-9f03-ef1a8df701bd" />
<img width="2032" height="1162" alt="image" src="https://github.com/user-attachments/assets/38a9d822-a901-46ee-89ae-3ee9f2085aef" />
<img width="2032" height="1162" alt="image" src="https://github.com/user-attachments/assets/0c010680-95d5-458e-939a-6202198e0ca9" />

### basic theme
<img width="2032" height="1162" alt="image" src="https://github.com/user-attachments/assets/00fa3bba-f69f-4f9d-b957-4c93b4bfa5d0" />
<img width="2032" height="1162" alt="image" src="https://github.com/user-attachments/assets/1a840b35-20df-4afd-96d4-a765b637f629" />
<img width="2032" height="1162" alt="image" src="https://github.com/user-attachments/assets/ac2fbb93-ba6e-482d-80a0-c8f5a366de52" />
</details>

I understand that the product is currently in the stabilization phase; I simply wanted to share my perspective on the design as a constructive contribution.
