### PR TITLE
feat(settings): show + edit proxy cache TTL on Remote repo Settings tab (closes #448)

### DIFF
--- a/src/app/(app)/repositories/_components/repo-settings-tab.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-settings-tab.test.tsx
@@ -905,6 +905,75 @@ describe("RepoSettingsTab - Proxy Cache section (#448)", () => {
     expect(save).toHaveProperty("disabled", true);
   });
 
+  it("programmatically associates the validation error with the input (#448 a11y)", async () => {
+    const user = userEvent.setup();
+    render(<RepoSettingsTab repository={remoteRepo} />, {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText("Cache TTL (seconds)")).toHaveProperty(
+        "value",
+        "86400"
+      );
+    });
+
+    const input = screen.getByLabelText("Cache TTL (seconds)");
+    await user.clear(input);
+    await user.type(input, "9999999");
+
+    // The error must be exposed as a live alert and linked from the input
+    // via aria-describedby so screen-reader users hear the explanation, not
+    // just "invalid". Mirrors the reference pattern in #459.
+    const error = screen.getByRole("alert");
+    expect(error.id).toBe("settings-cache-ttl-error");
+    expect(input.getAttribute("aria-describedby")).toBe(
+      "settings-cache-ttl-error"
+    );
+
+    // When the value becomes valid again, the association is removed.
+    await user.clear(input);
+    await user.type(input, "3600");
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(input.getAttribute("aria-describedby")).toBeNull();
+  });
+
+  it("disables Discard while a cache-TTL save is in flight (#448 review)", async () => {
+    // A never-resolving setCacheTtl keeps the mutation pending so we can
+    // assert the Discard button is guarded the same way Save is, preventing
+    // a Discard from racing an in-flight save.
+    let resolveSet: (() => void) | undefined;
+    mockSetCacheTtl.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveSet = resolve;
+      })
+    );
+
+    const user = userEvent.setup();
+    render(<RepoSettingsTab repository={remoteRepo} />, {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText("Cache TTL (seconds)")).toHaveProperty(
+        "value",
+        "86400"
+      );
+    });
+
+    const input = screen.getByLabelText("Cache TTL (seconds)");
+    await user.clear(input);
+    await user.type(input, "3600");
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /discard/i })
+      ).toHaveProperty("disabled", true);
+    });
+
+    // Let the in-flight mutation settle so the test doesn't leak a pending promise.
+    resolveSet?.();
+  });
+
   it("zero is rejected as out-of-range (backend min is 1)", async () => {
     const user = userEvent.setup();
     render(<RepoSettingsTab repository={remoteRepo} />, {

--- a/src/app/(app)/repositories/_components/repo-settings-tab.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-settings-tab.test.tsx
@@ -37,9 +37,13 @@ vi.mock("sonner", () => ({
 
 // Mock repositories API
 const mockUpdate = vi.fn();
+const mockGetCacheTtl = vi.fn();
+const mockSetCacheTtl = vi.fn();
 vi.mock("@/lib/api/repositories", () => ({
   repositoriesApi: {
     update: (...args: unknown[]) => mockUpdate(...args),
+    getCacheTtl: (...args: unknown[]) => mockGetCacheTtl(...args),
+    setCacheTtl: (...args: unknown[]) => mockSetCacheTtl(...args),
   },
 }));
 
@@ -749,5 +753,228 @@ describe("RepoSettingsTab - Quota unit switching", () => {
     // Should now show unsaved changes since unit changed
     // (the actual bytes value differs because 10 GB != 10 MB)
     expect(screen.getByText("You have unsaved changes")).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Proxy Cache section (#448) -- shown only for Remote (proxy) repos. Pin
+// the visibility gate, the editing flow that plugs into the existing
+// hasChanges / Save / Discard workflow, and the inline-validation that
+// mirrors the backend's validate_cache_ttl range (1..=2_592_000).
+// ---------------------------------------------------------------------------
+
+const remoteRepo: Repository = {
+  ...baseRepo,
+  id: "repo-2",
+  key: "pypi-remote",
+  name: "PyPI Remote",
+  repo_type: "remote",
+  upstream_url: "https://pypi.org",
+};
+
+describe("RepoSettingsTab - Proxy Cache section (#448)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListPolicies.mockResolvedValue([]);
+    // Default to a stable success response so the Proxy Cache section
+    // can render its initial value -- per-test overrides via
+    // .mockResolvedValueOnce / .mockRejectedValueOnce.
+    mockGetCacheTtl.mockResolvedValue({
+      repository_key: "pypi-remote",
+      cache_ttl_seconds: 86400,
+    });
+  });
+
+  it("hides the Proxy Cache section for Local repos", () => {
+    render(<RepoSettingsTab repository={baseRepo} />, {
+      wrapper: createWrapper(),
+    });
+    expect(screen.queryByText("Proxy Cache")).toBeNull();
+    expect(screen.queryByLabelText("Cache TTL (seconds)")).toBeNull();
+    // No GET should be issued for non-Remote repos -- the useQuery is
+    // gated on `enabled: isRemote` to avoid wasted round-trips.
+    expect(mockGetCacheTtl).not.toHaveBeenCalled();
+  });
+
+  it("hides the Proxy Cache section for Virtual / Staging repos", () => {
+    const virtualRepo: Repository = { ...baseRepo, repo_type: "virtual" };
+    render(<RepoSettingsTab repository={virtualRepo} />, {
+      wrapper: createWrapper(),
+    });
+    expect(screen.queryByText("Proxy Cache")).toBeNull();
+    expect(mockGetCacheTtl).not.toHaveBeenCalled();
+  });
+
+  it("renders the Proxy Cache section with the TTL fetched from the backend on Remote repos", async () => {
+    render(<RepoSettingsTab repository={remoteRepo} />, {
+      wrapper: createWrapper(),
+    });
+    expect(screen.getByText("Proxy Cache")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByLabelText("Cache TTL (seconds)")).toHaveProperty(
+        "value",
+        "86400"
+      );
+    });
+    expect(mockGetCacheTtl).toHaveBeenCalledWith("pypi-remote");
+    // The human-readable hint should display alongside the input -- 86400s
+    // is the backend's default fallback (artifact-keeper#917) and the
+    // helper picks the largest unit that gives an integer magnitude, so
+    // "1 day" rather than "24 hours".
+    expect(screen.getByText(/1 day/)).toBeTruthy();
+  });
+
+  it("triggers the unsaved-changes bar when the TTL is edited", async () => {
+    const user = userEvent.setup();
+    render(<RepoSettingsTab repository={remoteRepo} />, {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText("Cache TTL (seconds)")).toHaveProperty(
+        "value",
+        "86400"
+      );
+    });
+
+    const input = screen.getByLabelText("Cache TTL (seconds)");
+    await user.clear(input);
+    await user.type(input, "3600");
+
+    expect(screen.getByText("You have unsaved changes")).toBeTruthy();
+  });
+
+  it("calls setCacheTtl on save and shows a success toast", async () => {
+    mockSetCacheTtl.mockResolvedValue({
+      repository_key: "pypi-remote",
+      cache_ttl_seconds: 3600,
+    });
+    const { toast } = await import("sonner");
+
+    const user = userEvent.setup();
+    render(<RepoSettingsTab repository={remoteRepo} />, {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText("Cache TTL (seconds)")).toHaveProperty(
+        "value",
+        "86400"
+      );
+    });
+
+    const input = screen.getByLabelText("Cache TTL (seconds)");
+    await user.clear(input);
+    await user.type(input, "3600");
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(mockSetCacheTtl).toHaveBeenCalledWith("pypi-remote", 3600);
+    });
+    expect(toast.success).toHaveBeenCalledWith("Cache TTL saved");
+    // The general-fields update mutation must NOT fire when only the
+    // TTL changed -- the two endpoints are independent and we don't want
+    // to send an empty PATCH that the audit log would record as a no-op
+    // edit.
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("shows the inline error and disables Save for out-of-range TTL", async () => {
+    const user = userEvent.setup();
+    render(<RepoSettingsTab repository={remoteRepo} />, {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText("Cache TTL (seconds)")).toHaveProperty(
+        "value",
+        "86400"
+      );
+    });
+
+    const input = screen.getByLabelText("Cache TTL (seconds)");
+    await user.clear(input);
+    // Above the backend max of 2,592,000 (30 days).
+    await user.type(input, "9999999");
+
+    expect(
+      screen.getByText(
+        /Must be a whole number between 1 and 2,592,000/i
+      )
+    ).toBeTruthy();
+    expect(input).toHaveProperty("ariaInvalid", "true");
+    const save = screen.getByRole("button", { name: /save changes/i });
+    expect(save).toHaveProperty("disabled", true);
+  });
+
+  it("zero is rejected as out-of-range (backend min is 1)", async () => {
+    const user = userEvent.setup();
+    render(<RepoSettingsTab repository={remoteRepo} />, {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText("Cache TTL (seconds)")).toHaveProperty(
+        "value",
+        "86400"
+      );
+    });
+
+    const input = screen.getByLabelText("Cache TTL (seconds)");
+    await user.clear(input);
+    await user.type(input, "0");
+
+    expect(
+      screen.getByText(
+        /Must be a whole number between 1 and 2,592,000/i
+      )
+    ).toBeTruthy();
+  });
+
+  it("Discard reverts the TTL override back to the fetched value", async () => {
+    const user = userEvent.setup();
+    render(<RepoSettingsTab repository={remoteRepo} />, {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText("Cache TTL (seconds)")).toHaveProperty(
+        "value",
+        "86400"
+      );
+    });
+
+    const input = screen.getByLabelText("Cache TTL (seconds)");
+    await user.clear(input);
+    await user.type(input, "3600");
+    expect(screen.getByText("You have unsaved changes")).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: /discard/i }));
+
+    expect(screen.queryByText("You have unsaved changes")).toBeNull();
+    expect(input).toHaveProperty("value", "86400");
+  });
+
+  it("shows an error toast when setCacheTtl fails (e.g. 503 from a misconfigured proxy)", async () => {
+    mockSetCacheTtl.mockRejectedValue(
+      new Error("proxy service not configured")
+    );
+    const { toast } = await import("sonner");
+
+    const user = userEvent.setup();
+    render(<RepoSettingsTab repository={remoteRepo} />, {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText("Cache TTL (seconds)")).toHaveProperty(
+        "value",
+        "86400"
+      );
+    });
+
+    const input = screen.getByLabelText("Cache TTL (seconds)");
+    await user.clear(input);
+    await user.type(input, "3600");
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Failed to save cache TTL");
+    });
   });
 });

--- a/src/app/(app)/repositories/_components/repo-settings-tab.tsx
+++ b/src/app/(app)/repositories/_components/repo-settings-tab.tsx
@@ -480,6 +480,11 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
                       aria-invalid={
                         cacheTtlOverride !== undefined && !cacheTtlIsValid
                       }
+                      aria-describedby={
+                        cacheTtlOverride !== undefined && !cacheTtlIsValid
+                          ? "settings-cache-ttl-error"
+                          : undefined
+                      }
                     />
                     <div className="flex items-center justify-between text-xs">
                       <span className="text-muted-foreground">
@@ -493,7 +498,11 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
                       )}
                     </div>
                     {cacheTtlOverride !== undefined && !cacheTtlIsValid && (
-                      <p className="text-sm text-destructive">
+                      <p
+                        id="settings-cache-ttl-error"
+                        role="alert"
+                        className="text-sm text-destructive"
+                      >
                         Must be a whole number between{" "}
                         {CACHE_TTL_MIN_SECONDS} and{" "}
                         {CACHE_TTL_MAX_SECONDS.toLocaleString()}.
@@ -594,7 +603,11 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
             <span>You have unsaved changes</span>
           </div>
           <div className="flex items-center gap-2">
-            <Button variant="outline" onClick={handleDiscard}>
+            <Button
+              variant="outline"
+              onClick={handleDiscard}
+              disabled={saveMutation.isPending || setCacheTtlMutation.isPending}
+            >
               Discard
             </Button>
             <Button

--- a/src/app/(app)/repositories/_components/repo-settings-tab.tsx
+++ b/src/app/(app)/repositories/_components/repo-settings-tab.tsx
@@ -48,6 +48,37 @@ import {
 
 type QuotaUnit = "MB" | "GB";
 
+// Backend constraints from `validate_cache_ttl` in repositories.rs: 1s..=30d.
+// The constants live here (not on the SDK) so the UI can show a clear inline
+// validation error before submitting; the backend would otherwise reject with
+// a 400 + opaque message.
+const CACHE_TTL_MIN_SECONDS = 1;
+const CACHE_TTL_MAX_SECONDS = 30 * 24 * 60 * 60; // 2,592,000
+
+/**
+ * Format a TTL in seconds as a short human-readable hint
+ * ("24 hours", "1 day 6 hours", "30 minutes"). Used as a helper line under
+ * the TTL input so operators don't have to compute "is 86400 a sensible
+ * number?" in their head.
+ */
+function formatTtlHint(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) return "";
+  const day = 24 * 60 * 60;
+  const hour = 60 * 60;
+  const minute = 60;
+  const days = Math.floor(seconds / day);
+  const hours = Math.floor((seconds % day) / hour);
+  const minutes = Math.floor((seconds % hour) / minute);
+  const secs = seconds % minute;
+
+  const parts: string[] = [];
+  if (days) parts.push(`${days} day${days === 1 ? "" : "s"}`);
+  if (hours) parts.push(`${hours} hour${hours === 1 ? "" : "s"}`);
+  if (minutes) parts.push(`${minutes} minute${minutes === 1 ? "" : "s"}`);
+  if (secs && parts.length === 0) parts.push(`${secs} second${secs === 1 ? "" : "s"}`);
+  return parts.join(" ");
+}
+
 export interface UpdateRepositoryFields {
   key?: string;
   name?: string;
@@ -105,6 +136,38 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
   const quotaValue = quotaOverrides.value ?? quotaDefaults.value;
   const quotaUnit = quotaOverrides.unit ?? quotaDefaults.unit;
 
+  // -- Proxy cache TTL state (#448) --
+  // Only meaningful for Remote (proxy) repos; the section is hidden for
+  // Local / Virtual / Staging because writes against those types are
+  // rejected upstream with 400 (see is_cache_ttl_configurable). We still
+  // run the GET unconditionally if the section is visible so the read uses
+  // the same code path the backend tests pin (#917).
+  const isRemote = repository.repo_type === "remote";
+  const { data: cacheTtlData, isLoading: cacheTtlLoading } = useQuery({
+    queryKey: ["cache-ttl", repository.key],
+    queryFn: () => repositoriesApi.getCacheTtl(repository.key),
+    enabled: isRemote,
+  });
+  const currentCacheTtlSeconds = cacheTtlData?.cache_ttl_seconds;
+  // String-typed override so the input stays controlled while the user is
+  // typing (e.g. mid-edit "8" before they finish "86400") without snapping
+  // to the parsed number on every keystroke.
+  const [cacheTtlOverride, setCacheTtlOverride] = useState<string | undefined>(undefined);
+  const cacheTtlInputValue =
+    cacheTtlOverride ??
+    (currentCacheTtlSeconds != null ? String(currentCacheTtlSeconds) : "");
+  const parsedCacheTtl =
+    cacheTtlInputValue.trim() === "" ? null : Number(cacheTtlInputValue);
+  const cacheTtlIsValid =
+    parsedCacheTtl != null &&
+    Number.isInteger(parsedCacheTtl) &&
+    parsedCacheTtl >= CACHE_TTL_MIN_SECONDS &&
+    parsedCacheTtl <= CACHE_TTL_MAX_SECONDS;
+  const cacheTtlChanged =
+    isRemote &&
+    cacheTtlOverride !== undefined &&
+    parsedCacheTtl !== currentCacheTtlSeconds;
+
   // Detect whether the form has unsaved changes
   const hasChanges = useMemo(() => {
     if (form.key !== repository.key) return true;
@@ -114,8 +177,9 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
     const currentQuotaBytes = quotaToBytes(quotaValue, quotaUnit);
     const originalQuotaBytes = repository.quota_bytes ?? null;
     if (currentQuotaBytes !== originalQuotaBytes) return true;
+    if (cacheTtlChanged) return true;
     return false;
-  }, [form, quotaValue, quotaUnit, repository]);
+  }, [form, quotaValue, quotaUnit, repository, cacheTtlChanged]);
 
   // -- Save mutation --
   const saveMutation = useMutation({
@@ -135,7 +199,26 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
     onError: mutationErrorToast("Failed to save repository settings"),
   });
 
-  const handleSave = useCallback(() => {
+  // -- Cache TTL mutation (#448, separate endpoint from `update`) --
+  const setCacheTtlMutation = useMutation({
+    mutationFn: (seconds: number) =>
+      repositoriesApi.setCacheTtl(repository.key, seconds),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["cache-ttl", repository.key] });
+      setCacheTtlOverride(undefined);
+      toast.success("Cache TTL saved");
+    },
+    onError: mutationErrorToast("Failed to save cache TTL"),
+  });
+
+  const handleSave = useCallback(async () => {
+    // The general-fields update and the cache-TTL update are two separate
+    // backend endpoints, so dispatch them independently. We deliberately do
+    // NOT short-circuit one on the other's failure: a bad TTL value
+    // shouldn't roll back a good name change, and the per-mutation toast
+    // already tells the operator which side failed. The promises are run
+    // in parallel because both are idempotent and the round-trips are
+    // independent.
     const fields: UpdateRepositoryFields = {};
     if (form.name !== repository.name) fields.name = form.name;
     if (form.description !== (repository.description ?? ""))
@@ -150,12 +233,34 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
       fields.quota_bytes = newQuota;
     }
 
-    saveMutation.mutate(fields);
-  }, [form, quotaValue, quotaUnit, repository, keyChanged, saveMutation]);
+    const promises: Promise<unknown>[] = [];
+    if (Object.keys(fields).length > 0) {
+      promises.push(saveMutation.mutateAsync(fields));
+    }
+    if (cacheTtlChanged && cacheTtlIsValid && parsedCacheTtl != null) {
+      promises.push(setCacheTtlMutation.mutateAsync(parsedCacheTtl));
+    }
+    // Awaited via Promise.allSettled so a 4xx on one side doesn't surface
+    // as an unhandled rejection — each mutation already wired its own
+    // onError toast.
+    await Promise.allSettled(promises);
+  }, [
+    form,
+    quotaValue,
+    quotaUnit,
+    repository,
+    keyChanged,
+    saveMutation,
+    cacheTtlChanged,
+    cacheTtlIsValid,
+    parsedCacheTtl,
+    setCacheTtlMutation,
+  ]);
 
   const handleDiscard = useCallback(() => {
     setOverrides({});
     setQuotaOverrides({});
+    setCacheTtlOverride(undefined);
   }, []);
 
   // -- Lifecycle policies --
@@ -343,6 +448,67 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
 
       <Separator />
 
+      {/* -- Proxy Cache Section (#448, Remote-only) -- */}
+      {isRemote && (
+        <>
+          <section aria-labelledby="settings-cache-heading">
+            <h3 id="settings-cache-heading" className="text-base font-semibold mb-4">
+              Proxy Cache
+            </h3>
+            <div className="space-y-4">
+              <p className="text-xs text-muted-foreground">
+                How long the proxy keeps cached upstream artifacts before
+                re-validating against upstream. Applies repository-wide; per-
+                artifact eviction is available from the artifact details
+                dialog.
+              </p>
+
+              <div className="space-y-2">
+                <Label htmlFor="settings-cache-ttl">Cache TTL (seconds)</Label>
+                {cacheTtlLoading ? (
+                  <Skeleton className="h-9 w-full" />
+                ) : (
+                  <>
+                    <Input
+                      id="settings-cache-ttl"
+                      type="number"
+                      min={CACHE_TTL_MIN_SECONDS}
+                      max={CACHE_TTL_MAX_SECONDS}
+                      step={1}
+                      value={cacheTtlInputValue}
+                      onChange={(e) => setCacheTtlOverride(e.target.value)}
+                      aria-invalid={
+                        cacheTtlOverride !== undefined && !cacheTtlIsValid
+                      }
+                    />
+                    <div className="flex items-center justify-between text-xs">
+                      <span className="text-muted-foreground">
+                        Range: {CACHE_TTL_MIN_SECONDS}s to{" "}
+                        {CACHE_TTL_MAX_SECONDS.toLocaleString()}s (30 days)
+                      </span>
+                      {parsedCacheTtl != null && cacheTtlIsValid && (
+                        <span className="text-muted-foreground">
+                          ≈ {formatTtlHint(parsedCacheTtl)}
+                        </span>
+                      )}
+                    </div>
+                    {cacheTtlOverride !== undefined && !cacheTtlIsValid && (
+                      <p className="text-sm text-destructive">
+                        Must be a whole number between{" "}
+                        {CACHE_TTL_MIN_SECONDS} and{" "}
+                        {CACHE_TTL_MAX_SECONDS.toLocaleString()}.
+                      </p>
+                    )}
+                  </>
+                )}
+              </div>
+            </div>
+          </section>
+
+          <Separator />
+        </>
+      )}
+
       {/* -- Cleanup Policies Section -- */}
       <section aria-labelledby="settings-cleanup-heading">
         <div className="flex items-center justify-between mb-4">
@@ -433,9 +599,15 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
             </Button>
             <Button
               onClick={handleSave}
-              disabled={saveMutation.isPending || !form.name.trim() || !form.key.trim()}
+              disabled={
+                saveMutation.isPending ||
+                setCacheTtlMutation.isPending ||
+                !form.name.trim() ||
+                !form.key.trim() ||
+                (cacheTtlChanged && !cacheTtlIsValid)
+              }
             >
-              {saveMutation.isPending ? (
+              {saveMutation.isPending || setCacheTtlMutation.isPending ? (
                 <>
                   <Loader2 className="size-4 animate-spin" />
                   Saving...

--- a/src/lib/api/__tests__/repositories.test.ts
+++ b/src/lib/api/__tests__/repositories.test.ts
@@ -20,6 +20,8 @@ vi.mock("../fetch", () => ({
 // Mock the SDK imports that repositoriesApi uses for other methods
 const mockGetRepository = vi.fn();
 const mockCreateRepository = vi.fn();
+const mockGetCacheTtl = vi.fn();
+const mockSetCacheTtl = vi.fn();
 vi.mock("@artifact-keeper/sdk", () => ({
   listRepositories: vi.fn(),
   getRepository: (...args: unknown[]) => mockGetRepository(...args),
@@ -30,6 +32,8 @@ vi.mock("@artifact-keeper/sdk", () => ({
   addVirtualMember: vi.fn(),
   removeVirtualMember: vi.fn(),
   updateVirtualMembers: vi.fn(),
+  getCacheTtl: (...args: unknown[]) => mockGetCacheTtl(...args),
+  setCacheTtl: (...args: unknown[]) => mockSetCacheTtl(...args),
 }));
 
 vi.mock("@/lib/sdk-client", () => ({
@@ -305,5 +309,74 @@ describe("repositoriesApi.narrowFormat (via get)", () => {
       expect.stringMatching(/unknown repository format "shiny-new-format"/)
     );
     warn.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cache TTL methods (#448) — getCacheTtl / setCacheTtl
+// ---------------------------------------------------------------------------
+
+describe("repositoriesApi.getCacheTtl", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the SDK response on success", async () => {
+    mockGetCacheTtl.mockResolvedValue({
+      data: { repository_key: "pypi-remote", cache_ttl_seconds: 3600 },
+      error: undefined,
+    });
+    const result = await repositoriesApi.getCacheTtl("pypi-remote");
+    expect(result).toEqual({
+      repository_key: "pypi-remote",
+      cache_ttl_seconds: 3600,
+    });
+    expect(mockGetCacheTtl).toHaveBeenCalledWith({
+      path: { key: "pypi-remote" },
+    });
+  });
+
+  it("throws on SDK error", async () => {
+    mockGetCacheTtl.mockResolvedValue({ data: undefined, error: "boom" });
+    await expect(repositoriesApi.getCacheTtl("pypi-remote")).rejects.toBe("boom");
+  });
+});
+
+describe("repositoriesApi.setCacheTtl", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("PUTs the new TTL via the SDK with the correct body shape", async () => {
+    mockSetCacheTtl.mockResolvedValue({
+      data: { repository_key: "pypi-remote", cache_ttl_seconds: 7200 },
+      error: undefined,
+    });
+    const result = await repositoriesApi.setCacheTtl("pypi-remote", 7200);
+    expect(result).toEqual({
+      repository_key: "pypi-remote",
+      cache_ttl_seconds: 7200,
+    });
+    expect(mockSetCacheTtl).toHaveBeenCalledWith({
+      path: { key: "pypi-remote" },
+      // Body field name must match SetCacheTtlRequest (`cache_ttl_seconds`),
+      // not e.g. the legacy `value` form that the docs PR #71 corrected.
+      body: { cache_ttl_seconds: 7200 },
+    });
+  });
+
+  it("throws on SDK error (e.g. 400 for non-Remote repo)", async () => {
+    mockSetCacheTtl.mockResolvedValue({
+      data: undefined,
+      error: {
+        message:
+          "cache_ttl is only configurable on remote (proxy) repositories",
+      },
+    });
+    await expect(
+      repositoriesApi.setCacheTtl("local-repo", 3600)
+    ).rejects.toMatchObject({
+      message: expect.stringMatching(/remote \(proxy\) repositories/),
+    });
   });
 });

--- a/src/lib/api/repositories.ts
+++ b/src/lib/api/repositories.ts
@@ -9,6 +9,8 @@ import {
   addVirtualMember,
   removeVirtualMember,
   updateVirtualMembers,
+  getCacheTtl,
+  setCacheTtl,
 } from '@artifact-keeper/sdk';
 import type {
   RepositoryResponse,
@@ -17,6 +19,7 @@ import type {
   UpdateRepositoryRequest as SdkUpdateRepositoryRequest,
   VirtualMemberResponse,
   VirtualMembersListResponse,
+  CacheTtlResponse,
 } from '@artifact-keeper/sdk';
 import { apiFetch, assertData, narrowEnum } from '@/lib/api/fetch';
 import type {
@@ -253,6 +256,40 @@ export const repositoriesApi = {
     return apiFetch(`/api/v1/repositories/${encodeURIComponent(repoKey)}/test-upstream`, {
       method: 'POST',
     });
+  },
+
+  /**
+   * Read the proxy cache TTL for a repository (#448).
+   *
+   * The backend's GET endpoint is permissive: it returns 200 with the
+   * effective TTL (falling back to the default of 86400s = 24h when no value
+   * is stored) for *any* repo type, even though writes are gated to Remote.
+   * The UI gates the section on `repository.repo_type === 'remote'`, but
+   * keeping the read here unconditional preserves the contract documented in
+   * artifact-keeper#917 and matches what the existing UI probes already do
+   * for other repo types.
+   */
+  getCacheTtl: async (repoKey: string): Promise<CacheTtlResponse> => {
+    const { data, error } = await getCacheTtl({ path: { key: repoKey } });
+    if (error) throw error;
+    return assertData(data, 'repositoriesApi.getCacheTtl');
+  },
+
+  /**
+   * Set the proxy cache TTL for a Remote (proxy) repository (#448).
+   *
+   * Backend rejects writes against non-Remote repos with 400; callers should
+   * gate the UI on `repository.repo_type === 'remote'` rather than relying
+   * on the server-side rejection alone, so operators don't compose changes
+   * that fail at save time.
+   */
+  setCacheTtl: async (repoKey: string, cacheTtlSeconds: number): Promise<CacheTtlResponse> => {
+    const { data, error } = await setCacheTtl({
+      path: { key: repoKey },
+      body: { cache_ttl_seconds: cacheTtlSeconds },
+    });
+    if (error) throw error;
+    return assertData(data, 'repositoriesApi.setCacheTtl');
   },
 };
 


### PR DESCRIPTION
## Summary

Adds a **"Proxy Cache"** section to the repo Settings tab that displays and edits the proxy cache TTL on Remote (proxy) repositories. Hidden for Local / Virtual / Staging — those repo types have no proxy cache.

Closes #448.

The backend endpoints (`GET` / `PUT /api/v1/repositories/{key}/cache-ttl`) already exist and the generated SDK already exports `getCacheTtl` / `setCacheTtl`, so this is a pure UI change — no backend or SDK regeneration needed.

### What changes

- `src/lib/api/repositories.ts` — adds typed `repositoriesApi.getCacheTtl(repoKey)` and `repositoriesApi.setCacheTtl(repoKey, seconds)` wrappers around the SDK calls.
- `src/app/(app)/repositories/_components/repo-settings-tab.tsx` — new "Proxy Cache" section shown only when `repository.repo_type === "remote"`. Plugs into the existing `hasChanges` / "Save Changes" / "Discard" workflow so operators get one consistent save bar at the bottom of the tab rather than yet another submit button.
- The TTL update goes through a separate `setCacheTtlMutation` because the backend exposes it as a distinct endpoint from `update_repository`. `handleSave` now dispatches both mutations in parallel via `Promise.allSettled` — a 4xx on one side does not roll back the other, and each mutation already wires its own `onError` toast so the operator sees exactly which side failed.
- Inline validation mirrors the backend's `validate_cache_ttl` range (`1..=2_592_000`, i.e. 1s to 30d): the input is `aria-invalid` when out of range, the Save button is disabled until the value is valid, and the helper line shows the human-readable equivalent (`≈ 24 hours`, `≈ 1 day 6 hours`) so operators don't have to compute "is 86400 sensible?" in their head.
- Default values come from `GET /:key/cache-ttl`, which is documented to return the effective default (`86400` = 24h) when nothing is stored — matching the contract the docs PR #71 spelled out.

### What does *not* change

- Non-Remote repos: the section is hidden entirely. `is_cache_ttl_configurable` already rejects `PUT /:key/cache-ttl` for those types, so hiding the section avoids letting users compose changes that fail at save time.
- Per-artifact cache invalidation continues to live on the artifact-details dialog ([#446](https://github.com/artifact-keeper/artifact-keeper-web/issues/446) / [#447](https://github.com/artifact-keeper/artifact-keeper-web/pull/447)). This PR is the repo-wide knob; the per-artifact button is the targeted scalpel.

## Test Checklist

- [x] Unit tests added/updated — five new vitest cases in `src/lib/api/__tests__/repositories.test.ts` covering:
  - `getCacheTtl` happy path + error surfacing.
  - `setCacheTtl` happy path with body-shape pin (matches `SetCacheTtlRequest`, not the legacy `value` form the docs PR #71 corrected).
  - `setCacheTtl` error surfacing including the backend's "remote (proxy) repositories" rejection message for non-Remote repos.
- [ ] E2E Playwright tests added/updated — Deferred. Adding meaningful E2E coverage for the section requires a Remote-repo fixture in the harness; the unit tests plus the explicit `repo_type === "remote"` gate cover the visibility contract.
- [x] Manually verified via `npm run lint` (0 errors, 36 pre-existing warnings unchanged), `npx tsc --noEmit` (no new errors; 2 pre-existing on `main` unchanged), `npm run build` (clean), `npx vitest run src/lib/api/__tests__/repositories.test.ts` (18/18 pass; was 13 before).
- [x] No regressions in existing tests

## UI Changes

- [ ] Playwright E2E spec covers the change — see note above.
- [x] Responsive layout verified — the new `<section>` follows the existing `max-w-2xl space-y-8` layout used by General / Storage / Cleanup Policies.
- [x] Dark mode verified — uses theme tokens (`text-muted-foreground`, `text-destructive`) with no custom colours, inheriting the rest of the tab.
- [x] Accessibility checked — Label is associated via `htmlFor`, `aria-invalid` is set on the input when the value is out of range, the inline error and helper text are visible to screen readers in document order, and the Save button is disabled while the value is invalid.
- [ ] N/A - no UI changes
