### PR TITLE
fix(tickets): bind download/stream ticket resource_path to the request path

### DIFF
--- a/src/lib/api/__tests__/artifacts.test.ts
+++ b/src/lib/api/__tests__/artifacts.test.ts
@@ -270,6 +270,26 @@ describe("artifactsApi", () => {
     await expect(artifactsApi.createDownloadTicket("repo-key", "lib.jar")).rejects.toBe("fail");
   });
 
+  it("createDownloadTicket binds resource_path to the absolute download request path", async () => {
+    // The backend ticket middleware compares the bound resource_path against
+    // request.uri().path() by byte equality, so it must be absolute and match
+    // exactly what getDownloadUrl produces. Regression test for web#453.
+    mockCreateDownloadTicket.mockResolvedValue({
+      data: { ticket: "tk123" },
+      error: undefined,
+    });
+    const { artifactsApi } = await import("../artifacts");
+    const artifactPath = "com/example/lib/1.0/lib-1.0.jar";
+    await artifactsApi.createDownloadTicket("repo-key", artifactPath);
+    const expectedPath = artifactsApi.getDownloadUrl("repo-key", artifactPath);
+    expect(expectedPath).toBe(
+      "/api/v1/repositories/repo-key/download/com/example/lib/1.0/lib-1.0.jar"
+    );
+    expect(mockCreateDownloadTicket).toHaveBeenCalledWith({
+      body: { purpose: "download", resource_path: expectedPath },
+    });
+  });
+
   // ---- upload() via XMLHttpRequest ----
 
   describe("upload", () => {

--- a/src/lib/api/__tests__/migration.test.ts
+++ b/src/lib/api/__tests__/migration.test.ts
@@ -582,6 +582,18 @@ describe("migrationApi", () => {
     await expect(migrationApi.createStreamTicket("m1")).rejects.toBe("fail");
   });
 
+  it("createStreamTicket binds resource_path to the absolute stream request path", async () => {
+    // The backend ticket middleware compares the bound resource_path against
+    // request.uri().path() by byte equality, so it must be the absolute path
+    // the EventSource stream request uses. Regression test for web#453.
+    mockCreateDownloadTicket.mockResolvedValue({ data: { ticket: "tk123" }, error: undefined });
+    const { migrationApi } = await import("../migration");
+    await migrationApi.createStreamTicket("m1");
+    expect(mockCreateDownloadTicket).toHaveBeenCalledWith({
+      body: { purpose: "stream", resource_path: "/api/v1/migrations/m1/stream" },
+    });
+  });
+
   it("narrowSourceRepoType warns on unknown type", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     mockListSourceRepositories.mockResolvedValue({

--- a/src/lib/api/artifacts.ts
+++ b/src/lib/api/artifacts.ts
@@ -151,8 +151,15 @@ export const artifactsApi = {
   },
 
   createDownloadTicket: async (repoKey: string, artifactPath: string): Promise<string> => {
+    // The backend binds the ticket to this exact path and, at consume time,
+    // compares it against request.uri().path() by byte equality. It must be the
+    // absolute path the subsequent download request will carry, which is the
+    // same value getDownloadUrl produces.
     const { data, error } = await createDownloadTicket({
-      body: { purpose: 'download', resource_path: `${repoKey}/${artifactPath}` },
+      body: {
+        purpose: 'download',
+        resource_path: `/api/v1/repositories/${repoKey}/download/${artifactPath}`,
+      },
     });
     if (error) throw error;
     return assertData(data, 'artifactsApi.createDownloadTicket').ticket;

--- a/src/lib/api/migration.ts
+++ b/src/lib/api/migration.ts
@@ -477,9 +477,12 @@ export const migrationApi = {
 
   // Download/stream tickets
   createStreamTicket: async (jobId: string): Promise<string> => {
+    // The backend binds the ticket to this exact path and compares it against
+    // request.uri().path() by byte equality at consume time, so it must be the
+    // absolute path the EventSource request below will use.
     const body: SdkCreateTicketRequest = {
       purpose: 'stream',
-      resource_path: `migration/${jobId}`,
+      resource_path: `/api/v1/migrations/${jobId}/stream`,
     };
     const { data, error } = await sdkCreateDownloadTicket({ body });
     if (error) throw error;


### PR DESCRIPTION
## Summary

UI artifact downloads and migration progress streaming are broken because the web client binds download tickets to a `resource_path` the backend cannot match.

The backend binds a download ticket to an exact request path and, at consume time, compares `bound_path == request.uri().path()` by byte equality (`backend/src/api/middleware/auth.rs`). The minter is responsible for sending the exact absolute path the later request will carry. Two call sites sent the wrong value:

| Call site | Sent (wrong) | Now binds |
|-----------|--------------|-----------|
| `artifactsApi.createDownloadTicket` | `` `${repoKey}/${artifactPath}` `` | `` `/api/v1/repositories/${repoKey}/download/${artifactPath}` `` |
| `migrationApi.createStreamTicket` | `` `migration/${jobId}` `` | `` `/api/v1/migrations/${jobId}/stream` `` |

Each was wrong twice: not absolute (the `resource_path must start with '/'` rejection @flopma hit), and not the full request path, so even an absolute form would have been consumed against a mismatching path and silently burned.

No backend change is needed; the backend validator and consumer middleware behave as designed.

Fixes #453

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

Added regression tests asserting the exact `resource_path` passed to the SDK for both call sites (`src/lib/api/__tests__/artifacts.test.ts`, `src/lib/api/__tests__/migration.test.ts`). Ran the affected suites locally: 73 passed. ESLint clean on changed files.

## UI Changes
- [x] N/A - no UI changes

This is a client-side request-payload fix in the API layer. No rendered UI changed, though it restores the download and migration-stream flows the UI depends on.
