### PR TITLE
fix: absolute download URL and resilient server version display

### DIFF
--- a/e2e/suites/interactions/repositories/download-url-and-version.spec.ts
+++ b/e2e/suites/interactions/repositories/download-url-and-version.spec.ts
@@ -1,0 +1,123 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Regression tests for two v1.2.0 web bugs.
+ *
+ * #455 — The artifact detail "Download URL" field showed a host-less path
+ *        (e.g. /api/v1/repositories/.../download/...), so copying it produced a
+ *        broken URL. The displayed value must be a full, absolute URL.
+ *
+ * #456 — The sidebar hid the backend (Server) version whenever /health returned
+ *        a non-2xx status, even though the version is present in the response
+ *        body. The version must be shown regardless of the /health status code.
+ */
+test.describe('Download URL and version display', () => {
+  const REPO_KEY = 'e2e-maven-local';
+  const ARTIFACT_CONTENT = 'Hello from Playwright download-url test';
+
+  async function uploadArtifact(
+    request: import('@playwright/test').APIRequestContext
+  ): Promise<string> {
+    const path = `e2e/download-url-test-${Date.now()}.txt`;
+    const resp = await request.put(
+      `/api/v1/repositories/${REPO_KEY}/artifacts/${path}`,
+      {
+        data: ARTIFACT_CONTENT,
+        headers: { 'Content-Type': 'application/octet-stream' },
+      }
+    );
+    expect(resp.ok(), `Upload failed: ${resp.status()}`).toBeTruthy();
+    const body = await resp.json();
+    return body.path || path;
+  }
+
+  test('Download URL in detail panel is an absolute, well-formed URL (#455)', async ({
+    page,
+    request,
+  }) => {
+    const artifactPath = await uploadArtifact(request);
+    const artifactName = artifactPath.split('/').pop()!;
+
+    await page.goto(`/repositories/${REPO_KEY}`);
+    await page.waitForLoadState('domcontentloaded');
+
+    const table = page.getByRole('table').first();
+    await expect(table).toBeVisible({ timeout: 15000 });
+
+    const searchInput = page.getByPlaceholder(/search/i).first();
+    if (await searchInput.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await searchInput.fill(artifactName);
+      await page.waitForTimeout(2000);
+    }
+
+    const artifactRow = table.getByRole('row').filter({ hasText: artifactName });
+    if (!(await artifactRow.isVisible({ timeout: 5000 }).catch(() => false))) {
+      await request
+        .delete(`/api/v1/repositories/${REPO_KEY}/artifacts/${artifactPath}`)
+        .catch(() => {});
+      test.skip(true, 'Artifact not visible in table');
+      return;
+    }
+
+    await artifactRow.click();
+    await page.waitForTimeout(1500);
+
+    const downloadUrlLabel = page.getByText('Download URL');
+    if (!(await downloadUrlLabel.isVisible({ timeout: 5000 }).catch(() => false))) {
+      await request
+        .delete(`/api/v1/repositories/${REPO_KEY}/artifacts/${artifactPath}`)
+        .catch(() => {});
+      test.skip(true, 'Download URL field not visible in detail panel');
+      return;
+    }
+
+    // The value lives in the detail row next to the "Download URL" label.
+    const urlContainer = downloadUrlLabel.locator('..').locator('..');
+    const urlText = (await urlContainer.textContent())?.trim() ?? '';
+
+    // Extract the URL portion (the row also contains the "Download URL" label).
+    const match = urlText.match(/https?:\/\/\S+/);
+    expect(
+      match,
+      `Download URL should be absolute (http/https). Got: "${urlText}"`
+    ).not.toBeNull();
+
+    const url = match![0];
+
+    // Must be parseable and carry an origin + the backend download route.
+    let parsed: URL | null = null;
+    expect(() => {
+      parsed = new URL(url);
+    }).not.toThrow();
+    expect(parsed!.protocol).toMatch(/^https?:$/);
+    expect(parsed!.host.length).toBeGreaterThan(0);
+    expect(parsed!.pathname).toContain(`/download/`);
+    expect(parsed!.pathname).toContain(REPO_KEY);
+
+    await request
+      .delete(`/api/v1/repositories/${REPO_KEY}/artifacts/${artifactPath}`)
+      .catch(() => {});
+  });
+
+  test('Sidebar shows the backend (Server) version (#456)', async ({ page, request }) => {
+    // Sanity-check what the backend reports so the assertion is grounded in the
+    // real value, regardless of the /health status code.
+    const healthResp = await request.get('/health');
+    const healthBody = await healthResp.json().catch(() => null);
+    const expectedVersion: string | undefined = healthBody?.version;
+
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    // The sidebar header renders "Web <x> / Server <version>".
+    const serverVersion = page.getByText(/Server\s+\S+/);
+    await expect(serverVersion.first()).toBeVisible({ timeout: 15000 });
+
+    const text = (await serverVersion.first().textContent())?.trim() ?? '';
+    expect(text).toMatch(/Server\s+\S+/);
+
+    if (expectedVersion) {
+      expect(text).toContain(`Server ${expectedVersion}`);
+    }
+  });
+});

--- a/src/app/(app)/repositories/_components/repo-detail-content.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.tsx
@@ -897,7 +897,7 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
                   />
                   <DetailRow
                     label="Download URL"
-                    value={artifactsApi.getDownloadUrl(repoKey, selectedArtifact.path)}
+                    value={artifactsApi.getAbsoluteDownloadUrl(repoKey, selectedArtifact.path)}
                     copy
                     mono
                   />

--- a/src/lib/api/__tests__/admin.test.ts
+++ b/src/lib/api/__tests__/admin.test.ts
@@ -119,6 +119,29 @@ describe("adminApi", () => {
     await expect(adminApi.getHealth()).rejects.toBe("down");
   });
 
+  it("getHealth uses the body version on a non-2xx degraded response (#456)", async () => {
+    // Backend returns 503 with a full HealthResponse body when a dependency is
+    // degraded. The SDK surfaces that body as `error`. The version must still
+    // be reported rather than discarded.
+    const degraded = {
+      status: "degraded",
+      version: "1.2.0",
+      commit: "abc1234567890",
+      dirty: false,
+      demo_mode: false,
+      checks: {
+        database: { status: "ok" },
+        storage: { status: "down", message: "disk full" },
+      },
+    };
+    mockHealthCheck.mockResolvedValue({ data: undefined, error: degraded });
+    const { adminApi } = await import("../admin");
+    const result = await adminApi.getHealth();
+    expect(result.version).toBe("1.2.0");
+    expect(result.status).toBe("degraded");
+    expect(result.checks.storage).toEqual({ status: "down", message: "disk full" });
+  });
+
   // ---- listUserTokens ----
 
   it("listUserTokens returns items array for a given user", async () => {

--- a/src/lib/api/__tests__/artifacts.test.ts
+++ b/src/lib/api/__tests__/artifacts.test.ts
@@ -255,6 +255,19 @@ describe("artifactsApi", () => {
     );
   });
 
+  it("getAbsoluteDownloadUrl returns a full, well-formed URL (#455)", async () => {
+    vi.stubEnv("NEXT_PUBLIC_API_URL", "https://registry.example.com");
+    const { artifactsApi } = await import("../artifacts");
+    const url = artifactsApi.getAbsoluteDownloadUrl("repo-key", "com/lib.jar");
+    expect(url).toBe(
+      "https://registry.example.com/api/v1/repositories/repo-key/download/com/lib.jar"
+    );
+    // Must be absolute and parseable by the URL constructor.
+    expect(() => new URL(url)).not.toThrow();
+    expect(new URL(url).protocol).toBe("https:");
+    vi.unstubAllEnvs();
+  });
+
   it("createDownloadTicket returns ticket string", async () => {
     mockCreateDownloadTicket.mockResolvedValue({
       data: { ticket: "tk123" },

--- a/src/lib/api/admin.ts
+++ b/src/lib/api/admin.ts
@@ -45,6 +45,15 @@ function adaptCheck(c: CheckStatus | null | undefined): { status: string; messag
   return { status: c.status, message: c.message ?? undefined };
 }
 
+// On a non-2xx /health response the SDK returns the parsed body as `error`.
+// A degraded backend still includes the version and check details, so detect
+// the HealthResponse shape and use it rather than discarding the version.
+function isSdkHealthResponse(value: unknown): value is SdkHealthResponse {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.version === 'string' && typeof v.checks === 'object' && v.checks !== null;
+}
+
 function adaptHealth(sdk: SdkHealthResponse): HealthResponse {
   const database = adaptCheck(sdk.checks.database) ?? { status: 'unknown' };
   const storage = adaptCheck(sdk.checks.storage) ?? { status: 'unknown' };
@@ -92,7 +101,16 @@ export const adminApi = {
 
   getHealth: async (): Promise<HealthResponse> => {
     const { data, error } = await healthCheck();
-    if (error) throw error;
+    // The backend returns 503 with a full HealthResponse body (including the
+    // version) when a dependency is degraded. The SDK surfaces that body as
+    // `error`. Adapt it so the reported version stays visible even when the
+    // service is unhealthy (#456).
+    if (error) {
+      if (isSdkHealthResponse(error)) {
+        return adaptHealth(error);
+      }
+      throw error;
+    }
     return adaptHealth(assertData(data, 'adminApi.getHealth'));
   },
 

--- a/src/lib/api/artifacts.ts
+++ b/src/lib/api/artifacts.ts
@@ -150,6 +150,29 @@ export const artifactsApi = {
     return `/api/v1/repositories/${repoKey}/download/${artifactPath}`;
   },
 
+  /**
+   * Returns the absolute download URL (origin + path) for an artifact.
+   *
+   * `getDownloadUrl` returns a host-less path, which works for issuing a
+   * download against the current origin but is broken when copied and pasted
+   * elsewhere (e.g. into a terminal or another browser). This resolves the
+   * path against the configured API base URL, falling back to the current
+   * window origin, so the copied value is a complete, working URL.
+   */
+  getAbsoluteDownloadUrl: (repoKey: string, artifactPath: string): string => {
+    const path = `/api/v1/repositories/${repoKey}/download/${artifactPath}`;
+    const apiBase = process.env.NEXT_PUBLIC_API_URL || "";
+    const origin =
+      apiBase ||
+      (typeof window !== "undefined" ? window.location.origin : "");
+    if (!origin) return path;
+    try {
+      return new URL(path, origin).toString();
+    } catch {
+      return `${origin.replace(/\/$/, "")}${path}`;
+    }
+  },
+
   createDownloadTicket: async (repoKey: string, artifactPath: string): Promise<string> => {
     const { data, error } = await createDownloadTicket({
       body: { purpose: 'download', resource_path: `${repoKey}/${artifactPath}` },


### PR DESCRIPTION
## Summary
Fixes two v1.2.0 web bugs.

**#455** - The artifact detail "Download URL" field rendered a host-less path (e.g. `/api/v1/repositories/.../download/...`), so copying it produced a broken URL. Added `artifactsApi.getAbsoluteDownloadUrl`, which resolves the download path against `NEXT_PUBLIC_API_URL` (falling back to `window.location.origin`), matching how downloads are actually issued. The copyable "Download URL" detail row now uses it. `getDownloadUrl` is unchanged for the same-origin download flow.

**#456** - The sidebar hid the backend (Server) version whenever `/health` returned a non-2xx status, because `adminApi.getHealth` threw on any SDK error. The backend returns 503 with a full `HealthResponse` body (including the version) when a dependency is degraded. `getHealth` now detects the `HealthResponse` shape on the error path and adapts it, so the version stays visible even on a degraded health response.

Closes #455
Closes #456

## Test Checklist
- [x] Unit tests added/updated
- [x] E2E Playwright tests added/updated
- [ ] Manually tested locally
- [x] No regressions in existing tests

Unit tests: added `getAbsoluteDownloadUrl` coverage in `artifacts.test.ts` and a degraded-503 case in `admin.test.ts`. E2E: new spec `e2e/suites/interactions/repositories/download-url-and-version.spec.ts` asserts the copied Download URL is absolute and parseable, and that the sidebar shows the backend version (cross-checked against the live `/health` body). Ran eslint, tsc, and vitest on the changed files; all green.

## UI Changes
- [x] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)

The change is to the value of an existing copyable field and an existing sidebar version label; no layout, styling, or markup structure changed.