### PR TITLE
feat(maven): search by GAV and surface POM in the UI

### DIFF
--- a/e2e/suites/interactions/repositories/maven-gav-search-pom.spec.ts
+++ b/e2e/suites/interactions/repositories/maven-gav-search-pom.spec.ts
@@ -1,0 +1,152 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Regression tests for Maven GAV search (issue #441) and POM reachability
+ * (issue #442).
+ *
+ * - #441: users must be able to find a Maven artifact from its GAV coordinates
+ *   (groupId / artifactId / version / classifier / extension) via the GAVC tab
+ *   on the Advanced Search page.
+ * - #442: the POM file of a Maven GAV must be listed and downloadable from the
+ *   repository browser, and the artifact detail view must surface the GAV.
+ *
+ * The fix routes GAVC fields into the backend's full-text `query` (the
+ * advanced-search endpoint matches name + path + version, it does not filter on
+ * the separate path/version params) and renders each component file as a
+ * download link plus a GAV section in the detail panel.
+ */
+test.describe('Maven GAV search and POM', () => {
+  const REPO_KEY = 'e2e-maven-local';
+  // Unique per run so parallel/retried runs do not collide.
+  const STAMP = Date.now();
+  const GROUP_ID = `com.akweb.e2e${STAMP}`;
+  const GROUP_PATH = GROUP_ID.replace(/\./g, '/');
+  const ARTIFACT_ID = 'gav-search-lib';
+  const VERSION = '1.0.0';
+  const BASE = `${GROUP_PATH}/${ARTIFACT_ID}/${VERSION}`;
+  const JAR_NAME = `${ARTIFACT_ID}-${VERSION}.jar`;
+  const POM_NAME = `${ARTIFACT_ID}-${VERSION}.pom`;
+  const JAR_PATH = `${BASE}/${JAR_NAME}`;
+  const POM_PATH = `${BASE}/${POM_NAME}`;
+
+  const POM_CONTENT = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<project xmlns="http://maven.apache.org/POM/4.0.0">',
+    '  <modelVersion>4.0.0</modelVersion>',
+    `  <groupId>${GROUP_ID}</groupId>`,
+    `  <artifactId>${ARTIFACT_ID}</artifactId>`,
+    `  <version>${VERSION}</version>`,
+    '</project>',
+  ].join('\n');
+
+  async function put(
+    request: import('@playwright/test').APIRequestContext,
+    path: string,
+    data: string,
+    contentType: string
+  ): Promise<void> {
+    const resp = await request.put(
+      `/api/v1/repositories/${REPO_KEY}/artifacts/${path}`,
+      { data, headers: { 'Content-Type': contentType } }
+    );
+    expect(resp.ok(), `Upload of ${path} failed: ${resp.status()}`).toBeTruthy();
+  }
+
+  test.beforeAll(async ({ request }) => {
+    await put(request, JAR_PATH, 'fake-jar-bytes-for-gav-search', 'application/java-archive');
+    await put(request, POM_PATH, POM_CONTENT, 'application/xml');
+  });
+
+  test.afterAll(async ({ request }) => {
+    await request.delete(`/api/v1/repositories/${REPO_KEY}/artifacts/${JAR_PATH}`).catch(() => {});
+    await request.delete(`/api/v1/repositories/${REPO_KEY}/artifacts/${POM_PATH}`).catch(() => {});
+  });
+
+  test('the GAV-derived POM is downloadable from its Maven path (#442)', async ({ request }) => {
+    const resp = await request.get(`/api/v1/repositories/${REPO_KEY}/download/${POM_PATH}`);
+    expect(resp.status()).toBe(200);
+    expect(await resp.text()).toContain(`<artifactId>${ARTIFACT_ID}</artifactId>`);
+  });
+
+  test('GAVC search finds the artifact by group, artifact, and version (#441)', async ({ page }) => {
+    await page.goto('/search');
+    await page.waitForTimeout(1000);
+
+    const tablist = page.locator('[role="tablist"]').first();
+    await tablist.getByRole('tab', { name: /gavc/i }).click();
+    await page.waitForTimeout(500);
+
+    await page.locator('#search-gavc-group').fill(GROUP_ID);
+    await page.locator('#search-gavc-artifact').fill(ARTIFACT_ID);
+    await page.locator('#search-gavc-version').fill(VERSION);
+
+    // The Extension field is part of the fix for #441.
+    await expect(page.locator('#search-gavc-extension')).toBeVisible({ timeout: 10000 });
+    await page.locator('#search-gavc-extension').fill('jar');
+
+    await page.getByRole('button', { name: /search/i }).first().click();
+
+    // The results table should contain our uploaded jar.
+    const resultsTable = page.getByRole('table').first();
+    await expect(resultsTable).toBeVisible({ timeout: 15000 });
+    await expect(resultsTable.getByText(JAR_NAME, { exact: false })).toBeVisible({
+      timeout: 15000,
+    });
+  });
+
+  test('POM file is listed and linked in the grouped Maven browser (#442)', async ({ page }) => {
+    await page.goto(`/repositories/${REPO_KEY}`);
+    await page.waitForLoadState('domcontentloaded');
+
+    // The grouped Maven view renders <MavenComponentList>; find our GAV row.
+    const gavRow = page.locator(
+      `[data-gav="${GROUP_ID}:${ARTIFACT_ID}:${VERSION}"]`
+    );
+    if (!(await gavRow.isVisible({ timeout: 15000 }).catch(() => false))) {
+      test.skip(true, 'Maven grouped view did not render the GAV row');
+      return;
+    }
+
+    // Expand the component to reveal its files.
+    await gavRow.getByRole('button').first().click();
+    await page.waitForTimeout(500);
+
+    // The POM file row is marked and links to the GAV download path.
+    const pomLink = gavRow.getByRole('link', { name: POM_NAME });
+    await expect(pomLink).toBeVisible({ timeout: 10000 });
+    await expect(pomLink).toHaveAttribute('href', new RegExp(`/download/${GROUP_PATH}/${ARTIFACT_ID}/${VERSION}/${POM_NAME}$`));
+  });
+
+  test('artifact detail view shows GAV coordinates and a pom.xml snippet (#442)', async ({ page }) => {
+    await page.goto(`/repositories/${REPO_KEY}?view=flat&path=${encodeURIComponent(JAR_PATH)}`);
+    await page.waitForLoadState('domcontentloaded');
+
+    const table = page.getByRole('table').first();
+    if (!(await table.isVisible({ timeout: 15000 }).catch(() => false))) {
+      test.skip(true, 'Flat artifact table did not render');
+      return;
+    }
+
+    const searchInput = page.getByPlaceholder(/search/i).first();
+    if (await searchInput.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await searchInput.fill(JAR_NAME);
+      await page.waitForTimeout(2000);
+    }
+
+    const row = table.getByRole('row').filter({ hasText: JAR_NAME });
+    if (!(await row.isVisible({ timeout: 8000 }).catch(() => false))) {
+      test.skip(true, 'Jar not visible in flat table');
+      return;
+    }
+    await row.click();
+    await page.waitForTimeout(1500);
+
+    const gavSection = page.getByTestId('maven-gav-section');
+    await expect(gavSection).toBeVisible({ timeout: 10000 });
+    await expect(gavSection.getByText(GROUP_ID)).toBeVisible();
+
+    const snippet = page.getByTestId('maven-pom-snippet');
+    await expect(snippet).toContainText(`<artifactId>${ARTIFACT_ID}</artifactId>`);
+    await expect(snippet).toContainText(`<version>${VERSION}</version>`);
+  });
+});

--- a/src/app/(app)/repositories/_components/maven-component-list.tsx
+++ b/src/app/(app)/repositories/_components/maven-component-list.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronRight, FileIcon, Package as PackageIcon } from "lucide-react";
+import { ChevronRight, Download, FileIcon, Package as PackageIcon } from "lucide-react";
 
 import {
   Collapsible,
@@ -11,6 +11,8 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { artifactsApi } from "@/lib/api/artifacts";
+import { isPomFile, mavenFilePath } from "@/lib/maven";
 import { cn, formatBytes } from "@/lib/utils";
 import type { MavenComponent } from "@/types";
 
@@ -162,15 +164,43 @@ function MavenComponentRow({ component }: MavenComponentRowProps) {
             data-testid="maven-component-files"
             role="list"
           >
-            {component.artifact_files.map((filename) => (
-              <li
-                key={filename}
-                className="flex items-center gap-2 px-12 py-2 text-xs text-muted-foreground"
-              >
-                <FileIcon className="size-3.5 shrink-0" aria-hidden="true" />
-                <span className="truncate font-mono">{filename}</span>
-              </li>
-            ))}
+            {component.artifact_files.map((filename) => {
+              const isPom = isPomFile(filename);
+              // Build the repository-relative path from the GAV layout so each
+              // file (including the .pom) is directly downloadable. (issue #442)
+              const downloadUrl = artifactsApi.getDownloadUrl(
+                component.repository_key,
+                mavenFilePath(component, filename),
+              );
+              return (
+                <li
+                  key={filename}
+                  className="flex items-center gap-2 px-12 py-2 text-xs"
+                  data-testid={isPom ? "maven-component-pom-file" : "maven-component-file"}
+                >
+                  <FileIcon
+                    className="size-3.5 shrink-0 text-muted-foreground"
+                    aria-hidden="true"
+                  />
+                  <a
+                    href={downloadUrl}
+                    className="truncate font-mono text-foreground hover:underline focus-visible:underline"
+                    download
+                  >
+                    {filename}
+                  </a>
+                  {isPom && (
+                    <Badge variant="secondary" className="font-normal">
+                      POM
+                    </Badge>
+                  )}
+                  <Download
+                    className="ml-auto size-3.5 shrink-0 text-muted-foreground"
+                    aria-hidden="true"
+                  />
+                </li>
+              );
+            })}
           </ul>
         </CollapsibleContent>
       </Collapsible>

--- a/src/app/(app)/repositories/_components/repo-detail-content.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.tsx
@@ -24,6 +24,7 @@ import { artifactsApi } from "@/lib/api/artifacts";
 import securityApi from "@/lib/api/security";
 import { mutationErrorToast } from "@/lib/error-utils";
 import { isActivelyQuarantined } from "@/lib/quarantine";
+import { buildPomDependencySnippet, parseMavenGav } from "@/lib/maven";
 import type { Artifact } from "@/types";
 import type { UpsertScanConfigRequest } from "@/types/security";
 import { SbomTabContent } from "./sbom-tab-content";
@@ -901,6 +902,9 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
                     copy
                     mono
                   />
+                  {(repoFormat === "maven" || repoFormat === "gradle") && (
+                    <MavenGavSection path={selectedArtifact.path} />
+                  )}
                   {selectedArtifact.metadata &&
                     Object.keys(selectedArtifact.metadata).length > 0 && (
                       <div>
@@ -971,6 +975,38 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
 }
 
 // -- detail row helper --
+
+/**
+ * Maven GAV coordinates plus a copy/paste pom.xml dependency snippet, derived
+ * from the artifact path. Shown in the artifact detail view for maven/gradle
+ * repositories so users can identify the GAV and reuse it. (issue #442)
+ */
+function MavenGavSection({ path }: { path: string }) {
+  const gav = parseMavenGav(path);
+  if (!gav) return null;
+  const snippet = buildPomDependencySnippet(gav);
+  return (
+    <div data-testid="maven-gav-section" className="space-y-3">
+      <DetailRow label="Group ID" value={gav.groupId} copy mono />
+      <DetailRow label="Artifact ID" value={gav.artifactId} copy mono />
+      <DetailRow label="GAV Version" value={gav.version} copy mono />
+      <div>
+        <div className="mb-1 flex items-center justify-between">
+          <p className="text-xs font-medium text-muted-foreground">
+            pom.xml dependency
+          </p>
+          <CopyButton value={snippet} />
+        </div>
+        <pre
+          data-testid="maven-pom-snippet"
+          className="overflow-auto rounded-md bg-muted p-3 text-xs"
+        >
+          {snippet}
+        </pre>
+      </div>
+    </div>
+  );
+}
 
 function DetailRow({
   label,

--- a/src/app/(app)/search/_components/search-content.tsx
+++ b/src/app/(app)/search/_components/search-content.tsx
@@ -41,6 +41,7 @@ import {
 import { searchApi, type SearchResult } from "@/lib/api/search";
 import { artifactsApi } from "@/lib/api/artifacts";
 import { repositoriesApi } from "@/lib/api/repositories";
+import { buildMavenSearchQuery } from "@/lib/maven";
 import { QuarantineBadge } from "@/components/common/quarantine-badge";
 import { formatBytes as formatBytesUtil, formatDate } from "@/lib/utils";
 
@@ -73,6 +74,7 @@ interface GavcSearchValues {
   artifactId: string;
   version: string;
   classifier: string;
+  extension: string;
 }
 
 interface ChecksumSearchValues {
@@ -135,6 +137,7 @@ export function SearchContent() {
     artifactId: "",
     version: "",
     classifier: "",
+    extension: "",
   });
   const [checksumValues, setChecksumValues] = useState<ChecksumSearchValues>({
     value: "",
@@ -177,15 +180,27 @@ export function SearchContent() {
           sort_by: sortField,
         };
       }
-      case "gavc":
+      case "gavc": {
+        // The backend advanced-search endpoint matches a single full-text
+        // `query` against name + path + version; it does not filter on the
+        // separate `path`/`version` params. Maven GAV coordinates live in the
+        // artifact path, so fold the supplied fields into one query string and
+        // scope the search to the maven format. (issue #441)
+        const query = buildMavenSearchQuery({
+          groupId: gavcValues.groupId,
+          artifactId: gavcValues.artifactId,
+          version: gavcValues.version,
+          classifier: gavcValues.classifier,
+          extension: gavcValues.extension,
+        });
         return {
-          path: gavcValues.groupId || undefined,
-          name: gavcValues.artifactId || undefined,
-          version: gavcValues.version || undefined,
+          query: query || undefined,
+          format: "maven",
           page,
           per_page: pageSize,
           sort_by: sortField,
         };
+      }
       case "checksum":
         return null; // Checksum handled separately
     }
@@ -545,6 +560,21 @@ export function SearchContent() {
                       setGavcValues((v) => ({
                         ...v,
                         classifier: e.target.value,
+                      }))
+                    }
+                    onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <label htmlFor="search-gavc-extension" className="text-sm font-medium">Extension</label>
+                  <Input
+                    id="search-gavc-extension"
+                    placeholder="e.g., jar, pom, war"
+                    value={gavcValues.extension}
+                    onChange={(e) =>
+                      setGavcValues((v) => ({
+                        ...v,
+                        extension: e.target.value,
                       }))
                     }
                     onKeyDown={(e) => e.key === "Enter" && handleSearch()}

--- a/src/lib/__tests__/maven.test.ts
+++ b/src/lib/__tests__/maven.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildMavenSearchQuery,
+  groupIdToPath,
+  mavenFilePath,
+  isPomFile,
+  findPomFile,
+  parseMavenGav,
+  buildPomDependencySnippet,
+} from "../maven";
+
+describe("buildMavenSearchQuery", () => {
+  it("joins all supplied fields with spaces", () => {
+    expect(
+      buildMavenSearchQuery({
+        groupId: "org.junit.jupiter",
+        artifactId: "junit-jupiter-api",
+        version: "5.11.0",
+        classifier: "sources",
+        extension: "jar",
+      }),
+    ).toBe("org.junit.jupiter junit-jupiter-api 5.11.0 sources jar");
+  });
+
+  it("skips empty and whitespace-only fields", () => {
+    expect(
+      buildMavenSearchQuery({
+        groupId: "com.example",
+        artifactId: "",
+        version: "   ",
+        classifier: undefined,
+      }),
+    ).toBe("com.example");
+  });
+
+  it("trims surrounding whitespace from each field", () => {
+    expect(
+      buildMavenSearchQuery({ groupId: "  com.example  ", artifactId: " lib " }),
+    ).toBe("com.example lib");
+  });
+
+  it("strips a leading dot from the extension", () => {
+    expect(buildMavenSearchQuery({ artifactId: "lib", extension: ".pom" })).toBe(
+      "lib pom",
+    );
+  });
+
+  it("returns an empty string when nothing is supplied", () => {
+    expect(buildMavenSearchQuery({})).toBe("");
+  });
+});
+
+describe("groupIdToPath", () => {
+  it("replaces dots with slashes", () => {
+    expect(groupIdToPath("org.junit.jupiter")).toBe("org/junit/jupiter");
+  });
+
+  it("drops empty segments", () => {
+    expect(groupIdToPath("com..example.")).toBe("com/example");
+  });
+});
+
+describe("mavenFilePath", () => {
+  it("builds the repository-relative path from the GAV layout", () => {
+    expect(
+      mavenFilePath(
+        {
+          group_id: "org.junit.jupiter",
+          artifact_id: "junit-jupiter-api",
+          version: "5.11.0",
+        },
+        "junit-jupiter-api-5.11.0.pom",
+      ),
+    ).toBe(
+      "org/junit/jupiter/junit-jupiter-api/5.11.0/junit-jupiter-api-5.11.0.pom",
+    );
+  });
+});
+
+describe("isPomFile", () => {
+  it("matches .pom files case-insensitively", () => {
+    expect(isPomFile("lib-1.0.pom")).toBe(true);
+    expect(isPomFile("lib-1.0.POM")).toBe(true);
+  });
+
+  it("rejects jars, checksums, and signatures", () => {
+    expect(isPomFile("lib-1.0.jar")).toBe(false);
+    expect(isPomFile("lib-1.0.pom.sha1")).toBe(false);
+    expect(isPomFile("lib-1.0.pom.asc")).toBe(false);
+  });
+});
+
+describe("findPomFile", () => {
+  it("returns the POM filename when present", () => {
+    expect(
+      findPomFile(["lib-1.0.jar", "lib-1.0.pom", "lib-1.0.pom.sha1"]),
+    ).toBe("lib-1.0.pom");
+  });
+
+  it("returns undefined when no POM is present", () => {
+    expect(findPomFile(["lib-1.0.jar", "lib-1.0.jar.sha1"])).toBeUndefined();
+  });
+});
+
+describe("parseMavenGav", () => {
+  it("parses a standard Maven layout path", () => {
+    expect(
+      parseMavenGav(
+        "org/junit/jupiter/junit-jupiter-api/5.11.0/junit-jupiter-api-5.11.0.jar",
+      ),
+    ).toEqual({
+      groupId: "org.junit.jupiter",
+      artifactId: "junit-jupiter-api",
+      version: "5.11.0",
+    });
+  });
+
+  it("tolerates a leading slash", () => {
+    expect(
+      parseMavenGav("/com/example/lib/1.0/lib-1.0.jar"),
+    ).toEqual({ groupId: "com.example", artifactId: "lib", version: "1.0" });
+  });
+
+  it("returns undefined for non-Maven paths", () => {
+    expect(parseMavenGav("lib.jar")).toBeUndefined();
+    expect(parseMavenGav("a/b/c")).toBeUndefined();
+  });
+});
+
+describe("buildPomDependencySnippet", () => {
+  it("renders a dependency block", () => {
+    expect(
+      buildPomDependencySnippet({
+        groupId: "org.junit.jupiter",
+        artifactId: "junit-jupiter-api",
+        version: "5.11.0",
+      }),
+    ).toBe(
+      [
+        "<dependency>",
+        "  <groupId>org.junit.jupiter</groupId>",
+        "  <artifactId>junit-jupiter-api</artifactId>",
+        "  <version>5.11.0</version>",
+        "</dependency>",
+      ].join("\n"),
+    );
+  });
+});

--- a/src/lib/maven.ts
+++ b/src/lib/maven.ts
@@ -1,0 +1,137 @@
+/**
+ * Maven coordinate helpers shared by the search UI (issue #441) and the
+ * repository browser / artifact detail view (issue #442).
+ *
+ * Maven artifacts are addressed by GAV coordinates: groupId, artifactId,
+ * version, plus an optional classifier and a file extension. On disk and in
+ * the registry, a component lives under a path derived from those
+ * coordinates:
+ *
+ *   <groupId with dots replaced by slashes>/<artifactId>/<version>/<filename>
+ *
+ * e.g. org.junit.jupiter:junit-jupiter-api:5.11.0 (jar) maps to
+ *   org/junit/jupiter/junit-jupiter-api/5.11.0/junit-jupiter-api-5.11.0.jar
+ */
+
+/** The GAV-style fields a user can search Maven artifacts by. */
+export interface MavenGavcQuery {
+  groupId?: string;
+  artifactId?: string;
+  version?: string;
+  classifier?: string;
+  /** File extension such as `jar`, `pom`, `war` (with or without a leading dot). */
+  extension?: string;
+}
+
+/**
+ * Build a full-text query string from GAV/classifier/extension fields.
+ *
+ * The backend advanced-search endpoint matches a single `query` string against
+ * a text vector built from each artifact's name, path, and version. Maven
+ * coordinates are encoded in the path (dotted groupIds become path segments,
+ * which the tokenizer splits the same way it splits the dotted form), so
+ * feeding the coordinates in as space-separated terms lets the full-text
+ * search prefix-match every supplied component. Empty fields are skipped, and
+ * a leading dot on the extension is stripped so `.jar` and `jar` behave the
+ * same.
+ */
+export function buildMavenSearchQuery(q: MavenGavcQuery): string {
+  const terms: string[] = [];
+  const push = (raw: string | undefined) => {
+    const value = raw?.trim();
+    if (value) terms.push(value);
+  };
+
+  push(q.groupId);
+  push(q.artifactId);
+  push(q.version);
+  push(q.classifier);
+
+  const ext = q.extension?.trim().replace(/^\.+/, "");
+  if (ext) terms.push(ext);
+
+  return terms.join(" ");
+}
+
+/**
+ * Convert a Maven groupId into its path form (dots become slashes).
+ *
+ *   org.junit.jupiter -> org/junit/jupiter
+ */
+export function groupIdToPath(groupId: string): string {
+  return groupId.split(".").filter(Boolean).join("/");
+}
+
+/**
+ * Build the repository-relative download path for a single file belonging to a
+ * Maven component. The filename already carries the artifactId, version, and
+ * classifier (e.g. `junit-jupiter-api-5.11.0-sources.jar`), so we only need to
+ * prefix the GAV directory layout.
+ */
+export function mavenFilePath(
+  component: { group_id: string; artifact_id: string; version: string },
+  filename: string,
+): string {
+  return [
+    groupIdToPath(component.group_id),
+    component.artifact_id,
+    component.version,
+    filename,
+  ]
+    .filter(Boolean)
+    .join("/");
+}
+
+/** True when a filename is the Maven POM for a component (not a checksum/sig). */
+export function isPomFile(filename: string): boolean {
+  return /\.pom$/i.test(filename);
+}
+
+/**
+ * Find the POM filename within a component's file list, if present. POM
+ * checksum and signature files (`.pom.sha1`, `.pom.asc`, …) are ignored.
+ */
+export function findPomFile(filenames: string[]): string | undefined {
+  return filenames.find(isPomFile);
+}
+
+/**
+ * Parse GAV coordinates out of a Maven artifact path. Returns `undefined` when
+ * the path does not look like a Maven layout (fewer than four segments). The
+ * version is the second-to-last segment and the artifactId the one before it;
+ * everything earlier is the dotted groupId.
+ *
+ *   org/junit/jupiter/junit-jupiter-api/5.11.0/junit-jupiter-api-5.11.0.jar
+ *     -> { groupId: org.junit.jupiter, artifactId: junit-jupiter-api, version: 5.11.0 }
+ */
+export function parseMavenGav(
+  path: string,
+): { groupId: string; artifactId: string; version: string } | undefined {
+  const segments = path.split("/").filter(Boolean);
+  if (segments.length < 4) return undefined;
+  // Last segment is the filename; the two before it are version and artifactId.
+  const version = segments[segments.length - 2];
+  const artifactId = segments[segments.length - 3];
+  const groupId = segments.slice(0, segments.length - 3).join(".");
+  if (!groupId || !artifactId || !version) return undefined;
+  return { groupId, artifactId, version };
+}
+
+/**
+ * Render a copy/paste-ready `<dependency>` snippet for a pom.xml. Used in the
+ * artifact detail view so users can drop a Maven coordinate straight into
+ * their build (issue #442).
+ */
+export function buildPomDependencySnippet(gav: {
+  groupId: string;
+  artifactId: string;
+  version: string;
+}): string {
+  return [
+    "<dependency>",
+    `  <groupId>${gav.groupId}</groupId>`,
+    `  <artifactId>${gav.artifactId}</artifactId>`,
+    `  <version>${gav.version}</version>`,
+    "</dependency>",
+  ].join("\n");
+}


### PR DESCRIPTION
## Summary

Two Maven UX fixes for v1.2.0.

**GAV search (Closes #441).** The Advanced Search GAVC tab sent groupId, artifactId, and version as the backend's `path`/`name`/`version` query params. The advanced-search endpoint ignores those: it matches a single full-text `query` against name + path + version. Because Maven coordinates live in the artifact path, GAVC searches returned nothing. The tab now folds the GAV fields, classifier, and a new **Extension** field into one full-text query scoped to the `maven` format. A shared `buildMavenSearchQuery` helper assembles the terms.

**POM and GAV display (Closes #442).** In the grouped Maven browser, each component file (jar, pom, checksums) now renders as a download link with the path derived from the GAV layout, and the `.pom` file is tagged with a POM badge so it is easy to find and download. The artifact detail view gains a Maven section that shows the parsed groupId / artifactId / version and a copy/paste `pom.xml` dependency snippet.

New `src/lib/maven.ts` holds the pure coordinate helpers (query building, GAV-to-path, POM detection, GAV parsing, dependency snippet).

## Test Checklist
- [x] Unit tests added/updated
- [x] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [x] Playwright E2E spec covers the change
- [x] Responsive layout verified (mobile + desktop)
- [x] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes

Validation: `eslint` clean on changed files, `tsc --noEmit` reports only two pre-existing errors in untouched test files, 16 new unit tests pass, existing maven-component-list (16) and search-content (48) suites still pass.