### PR TITLE
fix(a11y): repo dialog and SSO form WCAG 2.2 AA gaps

### DIFF
--- a/e2e/suites/interactions/repositories/repo-dialog-a11y.spec.ts
+++ b/e2e/suites/interactions/repositories/repo-dialog-a11y.spec.ts
@@ -1,0 +1,161 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Accessibility regression tests for the repository create/edit dialogs
+ * (issues #410, #411, #412, #413). These assert the concrete WCAG 2.2 AA
+ * behaviours that automated scanners miss:
+ *
+ *  - #411: the create-dialog "key already taken" error has role="alert" and
+ *          is referenced by the input's aria-describedby (and aria-invalid).
+ *  - #412: toggling the upstream-auth view <-> edit moves focus to the first
+ *          control of the newly-revealed view (no focus dumped on <body>).
+ *  - #410: saving upstream auth announces the outcome via an in-dialog live
+ *          region (role="status" / aria-live).
+ *  - #413: required inputs expose aria-required; the edit auth-type select has
+ *          a programmatic label.
+ *
+ * Runs against the 1.2.0 backend image. The suite is serial so the seeded
+ * repos are created, exercised, and torn down in order.
+ */
+test.describe.serial('Repository Dialog Accessibility', () => {
+  const REMOTE_KEY = 'e2e-a11y-remote';
+  const EXISTING_KEY = 'e2e-a11y-existing';
+
+  test.beforeAll(async ({ request }) => {
+    // A remote repo whose edit dialog exposes the upstream-auth section.
+    await request.post('/api/v1/repositories', {
+      data: {
+        key: REMOTE_KEY,
+        name: 'E2E A11y Remote',
+        description: 'a11y test fixture',
+        format: 'npm',
+        repo_type: 'remote',
+        is_public: true,
+        upstream_url: 'https://registry.npmjs.org',
+      },
+    }).catch(() => {});
+
+    // A second repo whose key we will collide with in the create dialog.
+    await request.post('/api/v1/repositories', {
+      data: {
+        key: EXISTING_KEY,
+        name: 'E2E A11y Existing',
+        format: 'generic',
+        repo_type: 'local',
+        is_public: true,
+      },
+    }).catch(() => {});
+  });
+
+  test.afterAll(async ({ request }) => {
+    await request.delete(`/api/v1/repositories/${REMOTE_KEY}`).catch(() => {});
+    await request.delete(`/api/v1/repositories/${EXISTING_KEY}`).catch(() => {});
+  });
+
+  test('#411 create dialog duplicate-key error is role=alert and linked via aria-describedby', async ({ page }) => {
+    await page.goto('/repositories');
+    await page.waitForLoadState('domcontentloaded');
+
+    const createBtn = page.getByRole('button', { name: /create repository/i }).first();
+    await expect(createBtn).toBeVisible({ timeout: 10000 });
+    await createBtn.click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    const keyInput = dialog.locator('#create-key');
+    await expect(keyInput).toBeVisible({ timeout: 5000 });
+
+    // Type the key of an existing repo to trigger the "already taken" state.
+    await keyInput.fill(EXISTING_KEY);
+
+    // The error message must be an alert so screen readers announce it.
+    const alert = dialog.getByRole('alert');
+    await expect(alert).toBeVisible({ timeout: 5000 });
+    await expect(alert).toContainText(/already taken/i);
+
+    // The input must mark itself invalid and point at the alert.
+    await expect(keyInput).toHaveAttribute('aria-invalid', 'true');
+    const describedBy = await keyInput.getAttribute('aria-describedby');
+    expect(describedBy, 'key input should reference the error via aria-describedby').toBeTruthy();
+    const errorId = await alert.getAttribute('id');
+    expect(describedBy).toBe(errorId);
+
+    // #413: required inputs expose aria-required.
+    await expect(dialog.locator('#create-name')).toHaveAttribute('aria-required', 'true');
+
+    await dialog.getByRole('button', { name: /cancel/i }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+  });
+
+  async function openRemoteEditDialog(page: import('@playwright/test').Page) {
+    await page.goto(`/repositories?selected=${REMOTE_KEY}`);
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForTimeout(2000);
+
+    // Open the per-repo actions menu, then choose Edit.
+    const actionsBtn = page
+      .getByRole('button', { name: new RegExp(`repository actions for`, 'i') })
+      .first();
+    await expect(actionsBtn).toBeVisible({ timeout: 10000 });
+    await actionsBtn.click();
+
+    const editItem = page.getByRole('menuitem', { name: /edit/i }).first();
+    await expect(editItem).toBeVisible({ timeout: 5000 });
+    await editItem.click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    return dialog;
+  }
+
+  test('#412 + #413 toggling upstream-auth view to edit moves focus to the labelled auth-type select', async ({ page }) => {
+    const dialog = await openRemoteEditDialog(page);
+
+    // The remote repo has no auth configured -> the view shows a Configure button.
+    const toggleBtn = dialog.locator('#edit-upstream-auth-toggle');
+    await expect(toggleBtn).toBeVisible({ timeout: 5000 });
+    await toggleBtn.click();
+
+    // After toggling, focus must land on the first control of the edit view:
+    // the auth-type select trigger, which must carry a programmatic label.
+    const authTypeSelect = dialog.locator('#edit-upstream-auth-type');
+    await expect(authTypeSelect).toBeVisible({ timeout: 5000 });
+    await expect(authTypeSelect).toBeFocused({ timeout: 5000 });
+
+    // #413: the select has an associated label (it is a labelable control id).
+    const label = dialog.locator('label[for="edit-upstream-auth-type"]');
+    await expect(label).toBeVisible();
+
+    await dialog.getByRole('button', { name: /^cancel$/i }).first().click();
+  });
+
+  test('#410 saving upstream auth announces the outcome via an in-dialog live region', async ({ page }) => {
+    const dialog = await openRemoteEditDialog(page);
+
+    // The live region exists and is wired as an aria-live status region.
+    const liveRegion = dialog.getByTestId('upstream-auth-status');
+    await expect(liveRegion).toHaveAttribute('aria-live', /polite|assertive/);
+
+    // Configure -> choose bearer -> enter a token -> Save Authentication.
+    await dialog.locator('#edit-upstream-auth-toggle').click();
+
+    const authTypeSelect = dialog.locator('#edit-upstream-auth-type');
+    await expect(authTypeSelect).toBeVisible({ timeout: 5000 });
+    await authTypeSelect.click();
+    await page.getByRole('option', { name: /bearer/i }).click();
+
+    const tokenInput = dialog.locator('#edit-upstream-token');
+    await expect(tokenInput).toBeVisible({ timeout: 5000 });
+    await tokenInput.fill('e2e-a11y-token');
+
+    await dialog.getByRole('button', { name: /save authentication/i }).click();
+
+    // The live region must receive announced text (success or, if the backend
+    // rejects, an error) - either way the screen reader hears the outcome.
+    await expect(liveRegion).not.toBeEmpty({ timeout: 15000 });
+    await expect(liveRegion).toHaveText(/updated|fail|error/i, { timeout: 15000 });
+
+    await page.keyboard.press('Escape');
+  });
+});

--- a/src/app/(app)/(admin)/settings/sso/page.tsx
+++ b/src/app/(app)/(admin)/settings/sso/page.tsx
@@ -369,6 +369,7 @@ function OidcTab() {
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder="Google Workspace"
+                aria-required="true"
               />
             </div>
 
@@ -379,6 +380,7 @@ function OidcTab() {
                 value={issuerUrl}
                 onChange={(e) => setIssuerUrl(e.target.value)}
                 placeholder="https://accounts.google.com"
+                aria-required="true"
               />
             </div>
 
@@ -389,6 +391,7 @@ function OidcTab() {
                 value={clientId}
                 onChange={(e) => setClientId(e.target.value)}
                 placeholder="your-client-id"
+                aria-required="true"
               />
             </div>
 
@@ -402,6 +405,7 @@ function OidcTab() {
                 placeholder={
                   editTarget ? "Leave blank to keep existing" : "your-client-secret"
                 }
+                aria-required={!editTarget}
               />
             </div>
 
@@ -856,6 +860,7 @@ function LdapTab() {
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder="Corporate LDAP"
+                aria-required="true"
               />
             </div>
 
@@ -866,6 +871,7 @@ function LdapTab() {
                 value={serverUrl}
                 onChange={(e) => setServerUrl(e.target.value)}
                 placeholder="ldap://ldap.example.com:389"
+                aria-required="true"
               />
             </div>
 
@@ -899,6 +905,7 @@ function LdapTab() {
                 value={userBaseDn}
                 onChange={(e) => setUserBaseDn(e.target.value)}
                 placeholder="ou=users,dc=example,dc=com"
+                aria-required="true"
               />
             </div>
 
@@ -1358,6 +1365,7 @@ function SamlTab() {
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder="Okta"
+                aria-required="true"
               />
             </div>
 
@@ -1368,6 +1376,7 @@ function SamlTab() {
                 value={entityId}
                 onChange={(e) => setEntityId(e.target.value)}
                 placeholder="https://idp.example.com/metadata"
+                aria-required="true"
               />
             </div>
 
@@ -1378,6 +1387,7 @@ function SamlTab() {
                 value={ssoUrl}
                 onChange={(e) => setSsoUrl(e.target.value)}
                 placeholder="https://idp.example.com/sso/saml"
+                aria-required="true"
               />
             </div>
 
@@ -1404,6 +1414,7 @@ function SamlTab() {
                 }
                 rows={5}
                 className="font-mono text-xs"
+                aria-required={!editTarget}
               />
             </div>
 

--- a/src/app/(app)/repositories/_components/repo-dialogs.tsx
+++ b/src/app/(app)/repositories/_components/repo-dialogs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useCallback, useEffect } from "react";
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import type { Repository, CreateRepositoryRequest, RepositoryFormat, RepositoryType, VirtualRepoMemberInput } from "@/types";
 import { FORMAT_OPTIONS, TYPE_OPTIONS } from "../_lib/constants";
 import { DEFAULT_UPSTREAM_URLS } from "../_lib/default-upstream-urls";
@@ -68,6 +68,14 @@ interface RepoDialogsProps {
   editPending: boolean;
   onUpstreamAuthUpdate?: (key: string, payload: { auth_type: string; username?: string; password?: string }) => void;
   upstreamAuthPending?: boolean;
+  /**
+   * Result of the most recent upstream-auth save, surfaced to a live region
+   * inside the edit dialog so screen readers hear the outcome (#410). The
+   * save itself resolves via a parent mutation whose only feedback was a
+   * visual toast, which assistive tech outside the dialog does not reliably
+   * announce.
+   */
+  upstreamAuthStatus?: { state: "idle" | "success" | "error"; message?: string };
   deleteOpen: boolean;
   onDeleteOpenChange: (open: boolean) => void;
   deleteRepo: Repository | null;
@@ -89,6 +97,7 @@ export function RepoDialogs({
   editPending,
   onUpstreamAuthUpdate,
   upstreamAuthPending = false,
+  upstreamAuthStatus = { state: "idle" },
   deleteOpen,
   onDeleteOpenChange,
   deleteRepo,
@@ -143,6 +152,33 @@ export function RepoDialogs({
   const [editAuthUsername, setEditAuthUsername] = useState("");
   const [editAuthPassword, setEditAuthPassword] = useState("");
   const [removeAuthConfirm, setRemoveAuthConfirm] = useState(false);
+
+  // Focus management for the upstream-auth view <-> edit toggle (#412).
+  // When the user switches modes the previously focused control unmounts, so
+  // focus would otherwise fall back to <body> and screen-reader / keyboard
+  // users lose their place. We move focus to the first control of whichever
+  // view just became visible. We target elements by id (rather than a ref)
+  // because the underlying shadcn SelectTrigger does not forward a ref.
+  // Skip the very first render (dialog open) so we don't steal focus from the
+  // dialog's own initial focus target; only react to genuine toggles.
+  const editAuthModeInitialized = useRef(false);
+  useEffect(() => {
+    if (!editOpen) {
+      editAuthModeInitialized.current = false;
+      return;
+    }
+    if (!editAuthModeInitialized.current) {
+      editAuthModeInitialized.current = true;
+      return;
+    }
+    const targetId =
+      editAuthMode === "edit" ? "edit-upstream-auth-type" : "edit-upstream-auth-toggle";
+    // Defer to the next frame so the newly-rendered control exists in the DOM.
+    const id = requestAnimationFrame(() => {
+      document.getElementById(targetId)?.focus();
+    });
+    return () => cancelAnimationFrame(id);
+  }, [editAuthMode, editOpen]);
 
   // Quota state for edit dialog — initialized from editRepo
   const editQuotaDefaults = useMemo(() => bytesToQuota(editRepo?.quota_bytes), [editRepo]);
@@ -272,10 +308,13 @@ export function RepoDialogs({
                   setCreateForm((f) => ({ ...f, key: e.target.value }))
                 }
                 required
+                aria-required="true"
+                aria-invalid={keyTaken}
+                aria-describedby={keyTaken ? "create-key-error" : undefined}
                 className={keyTaken ? "border-red-500 focus-visible:ring-red-500" : ""}
               />
               {keyTaken && (
-                <p className="text-sm text-red-500">
+                <p id="create-key-error" role="alert" className="text-sm text-red-500">
                   Repository key &quot;{createForm.key}&quot; is already taken. Please choose a different key.
                 </p>
               )}
@@ -290,6 +329,7 @@ export function RepoDialogs({
                   setCreateForm((f) => ({ ...f, name: e.target.value }))
                 }
                 required
+                aria-required="true"
               />
             </div>
             <div className="space-y-2">
@@ -582,9 +622,15 @@ export function RepoDialogs({
                   setEditFormOverrides((f) => ({ ...f, key: e.target.value.toLowerCase() }))
                 }
                 required
+                aria-required="true"
+                aria-describedby={editKeyChanged ? "edit-key-warning" : undefined}
               />
               {editKeyChanged && (
-                <p className="text-sm text-yellow-600 dark:text-yellow-500">
+                <p
+                  id="edit-key-warning"
+                  role="status"
+                  className="text-sm text-yellow-600 dark:text-yellow-500"
+                >
                   Changing the key will update all URLs for this repository.
                 </p>
               )}
@@ -598,6 +644,7 @@ export function RepoDialogs({
                   setEditFormOverrides((f) => ({ ...f, name: e.target.value }))
                 }
                 required
+                aria-required="true"
               />
             </div>
             <div className="space-y-2">
@@ -660,6 +707,29 @@ export function RepoDialogs({
                   Credentials are stored encrypted and saved separately from other repository settings.
                 </p>
 
+                {/*
+                  #410: Announce the outcome of the upstream-auth save to
+                  assistive technology. The save resolves via a parent mutation
+                  whose only feedback was a visual toast; this polite live
+                  region (role="status") gives screen-reader users the result
+                  inside the dialog where their focus already is. The error
+                  case uses role="alert" semantics via aria-live="assertive".
+                */}
+                <div
+                  data-testid="upstream-auth-status"
+                  role={upstreamAuthStatus.state === "error" ? "alert" : "status"}
+                  aria-live={upstreamAuthStatus.state === "error" ? "assertive" : "polite"}
+                  className={
+                    upstreamAuthStatus.state === "error"
+                      ? "text-sm text-destructive"
+                      : "text-sm text-emerald-600 dark:text-emerald-500"
+                  }
+                >
+                  {upstreamAuthStatus.state !== "idle" && upstreamAuthStatus.message
+                    ? upstreamAuthStatus.message
+                    : ""}
+                </div>
+
                 {editAuthMode === "view" ? (
                   <div className="space-y-2">
                     {editRepo.upstream_auth_configured ? (
@@ -669,6 +739,7 @@ export function RepoDialogs({
                         </p>
                         <div className="flex gap-2">
                           <Button
+                            id="edit-upstream-auth-toggle"
                             type="button"
                             variant="outline"
                             size="sm"
@@ -696,6 +767,7 @@ export function RepoDialogs({
                           No authentication configured
                         </p>
                         <Button
+                          id="edit-upstream-auth-toggle"
                           type="button"
                           variant="outline"
                           size="sm"
@@ -737,8 +809,12 @@ export function RepoDialogs({
                   </div>
                 ) : (
                   <div className="space-y-3">
+                    <Label htmlFor="edit-upstream-auth-type">Authentication type</Label>
                     <Select value={editAuthType} onValueChange={setEditAuthType}>
-                      <SelectTrigger className="w-full">
+                      <SelectTrigger
+                        className="w-full"
+                        id="edit-upstream-auth-type"
+                      >
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>

--- a/src/app/(app)/repositories/_components/repo-list-item.tsx
+++ b/src/app/(app)/repositories/_components/repo-list-item.tsx
@@ -73,7 +73,12 @@ export function RepoListItem({ repo, isSelected, onSelect, onEdit, onDelete, art
         {(onEdit || onDelete) && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
-              <Button variant="ghost" size="icon-xs" className="shrink-0 text-muted-foreground hover:text-foreground">
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                className="shrink-0 text-muted-foreground hover:text-foreground"
+                aria-label={`Repository actions for ${repo.name}`}
+              >
                 <Settings className="size-3.5" />
               </Button>
             </DropdownMenuTrigger>

--- a/src/app/(app)/repositories/_components/repositories-content.tsx
+++ b/src/app/(app)/repositories/_components/repositories-content.tsx
@@ -35,7 +35,7 @@ import {
   ResizableHandle,
 } from "@/components/ui/resizable";
 
-import { mutationErrorToast } from "@/lib/error-utils";
+import { mutationErrorToast, toUserMessage } from "@/lib/error-utils";
 import { FORMAT_GROUPS, TYPE_OPTIONS } from "../_lib/constants";
 import { RepoListItem } from "./repo-list-item";
 import { RepoDetailPanel } from "./repo-detail-panel";
@@ -67,6 +67,13 @@ export function RepositoriesContent() {
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [dialogRepo, setDialogRepo] = useState<Repository | null>(null);
+
+  // #410: outcome of the most recent upstream-auth save, mirrored into a live
+  // region inside the edit dialog so screen-reader users hear success/failure.
+  const [upstreamAuthStatus, setUpstreamAuthStatus] = useState<{
+    state: "idle" | "success" | "error";
+    message?: string;
+  }>({ state: "idle" });
 
   // --- query ---
   const { data, isLoading, isFetching } = useQuery({
@@ -144,11 +151,22 @@ export function RepositoriesContent() {
   const upstreamAuthMutation = useMutation({
     mutationFn: ({ key, payload }: { key: string; payload: UpstreamAuthPayload }) =>
       repositoriesApi.updateUpstreamAuth(key, payload),
+    onMutate: () => {
+      // Clear any previous outcome so the live region re-announces a repeat
+      // result (e.g. two consecutive successes).
+      setUpstreamAuthStatus({ state: "idle" });
+    },
     onSuccess: () => {
       invalidateAllRepoQueries();
-      toast.success("Upstream authentication updated");
+      const message = "Upstream authentication updated";
+      toast.success(message);
+      setUpstreamAuthStatus({ state: "success", message });
     },
-    onError: mutationErrorToast("Failed to update upstream authentication"),
+    onError: (err: unknown) => {
+      const message = toUserMessage(err, "Failed to update upstream authentication");
+      toast.error(message);
+      setUpstreamAuthStatus({ state: "error", message });
+    },
   });
 
   // --- handlers ---
@@ -448,13 +466,17 @@ export function RepositoriesContent() {
         editOpen={editOpen}
         onEditOpenChange={(o) => {
           setEditOpen(o);
-          if (!o) setDialogRepo(null);
+          if (!o) {
+            setDialogRepo(null);
+            setUpstreamAuthStatus({ state: "idle" });
+          }
         }}
         editRepo={dialogRepo}
         onEditSubmit={(key, d) => updateMutation.mutate({ key, data: d })}
         editPending={updateMutation.isPending}
         onUpstreamAuthUpdate={(key, payload) => upstreamAuthMutation.mutate({ key, payload })}
         upstreamAuthPending={upstreamAuthMutation.isPending}
+        upstreamAuthStatus={upstreamAuthStatus}
         deleteOpen={deleteOpen}
         onDeleteOpenChange={(o) => {
           setDeleteOpen(o);


### PR DESCRIPTION
## Summary

Fixes four WCAG 2.2 AA accessibility gaps in the repository create/edit dialogs and the SSO settings forms (v1.2.0).

- **#410** Repo edit dialog now mirrors the upstream-auth save outcome into an in-dialog aria-live region. Success renders `role="status"` (`aria-live="polite"`); failure renders `role="alert"` (`aria-live="assertive"`). Previously the only feedback was a visual toast, which assistive tech outside the dialog did not reliably announce while focus stayed inside the open dialog. Wired from the parent mutation in `repositories-content.tsx`.
- **#411** Create dialog "key already taken" error now has `role="alert"`, and the key input sets `aria-invalid` and `aria-describedby` pointing at the message id, so screen readers announce the error and tie it to the field.
- **#412** Toggling the upstream-auth view to edit (and back) now moves focus to the first control of the newly-revealed view (the labelled auth-type select in edit mode, the Change/Configure button in view mode) instead of dropping focus on `<body>`. Implemented with an effect that targets the control by id and defers a frame so the new control exists in the DOM.
- **#413** Broader gap fixes: required inputs across the repo dialogs and SSO OIDC/LDAP/SAML forms expose `aria-required`; the edit-dialog auth-type select gains a programmatic `<label>`; the repository row actions menu trigger gains an accessible name; the edit-key warning is associated via `aria-describedby`.

Closes #410
Closes #411
Closes #412
Closes #413

## Test Checklist
- [ ] Unit tests added/updated
- [x] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

New spec `e2e/suites/interactions/repositories/repo-dialog-a11y.spec.ts` asserts the error/alert + `aria-describedby` association (#411), focus movement on the auth toggle and the auth-type select label (#412/#413), and the live-region save announcement (#410). Existing unit suites (`repo-dialogs.test.tsx` 77 tests, repositories `page.test.tsx`, SSO `page.test.tsx`) pass unchanged. `eslint` clean on changed files (one pre-existing unrelated warning); `tsc --noEmit` reports only pre-existing errors in untouched test files.

## UI Changes
- [x] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes

No visual layout changes; additions are ARIA attributes, a focus-management effect, and a status text line in the upstream-auth section of the edit dialog.