### PR TITLE
feat(repositories): release target and routing rules settings

### DIFF
--- a/e2e/suites/interactions/repositories/release-target-settings.spec.ts
+++ b/e2e/suites/interactions/repositories/release-target-settings.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E coverage for release-target configuration on the repository Settings tab
+ * (issue #260).
+ *
+ * A staging repository can be linked to a single local release repository of
+ * the same format. The link is persisted via:
+ *   PATCH /api/v1/repositories/{key}  { release_repository_key: "..." }
+ * Passing an empty string removes the link. The backend rejects links to a
+ * non-local repository or a repository of a different format.
+ *
+ * The UI settings section is admin only, so the UI-driven test is best effort
+ * and skips when the Settings tab is not reachable. The API contract tests are
+ * the load-bearing assertions.
+ */
+test.describe.serial('Release Target Settings', () => {
+  const STAGING_KEY = 'e2e-release-staging';
+  const RELEASE_KEY = 'e2e-release-local';
+  const WRONG_FORMAT_KEY = 'e2e-release-wrong-format';
+
+  test.beforeAll(async ({ request }) => {
+    await request.post('/api/v1/repositories', {
+      data: {
+        key: RELEASE_KEY,
+        name: 'E2E Release Local',
+        format: 'maven',
+        repo_type: 'local',
+        is_public: true,
+      },
+    });
+    await request.post('/api/v1/repositories', {
+      data: {
+        key: WRONG_FORMAT_KEY,
+        name: 'E2E Release Wrong Format',
+        format: 'npm',
+        repo_type: 'local',
+        is_public: true,
+      },
+    });
+    await request.post('/api/v1/repositories', {
+      data: {
+        key: STAGING_KEY,
+        name: 'E2E Release Staging',
+        format: 'maven',
+        repo_type: 'staging',
+        is_public: true,
+      },
+    });
+  });
+
+  test.afterAll(async ({ request }) => {
+    await request.delete(`/api/v1/repositories/${STAGING_KEY}`).catch(() => {});
+    await request.delete(`/api/v1/repositories/${RELEASE_KEY}`).catch(() => {});
+    await request.delete(`/api/v1/repositories/${WRONG_FORMAT_KEY}`).catch(() => {});
+  });
+
+  test('linking a same-format local repo as release target succeeds', async ({ request }) => {
+    const resp = await request.patch(`/api/v1/repositories/${STAGING_KEY}`, {
+      data: { release_repository_key: RELEASE_KEY },
+    });
+    expect(resp.ok(), `Link failed: ${resp.status()} ${await resp.text()}`).toBeTruthy();
+  });
+
+  test('linking a different-format repo is rejected', async ({ request }) => {
+    const resp = await request.patch(`/api/v1/repositories/${STAGING_KEY}`, {
+      data: { release_repository_key: WRONG_FORMAT_KEY },
+    });
+    expect(resp.status()).toBe(400);
+  });
+
+  test('unlinking with an empty release target key succeeds', async ({ request }) => {
+    // Ensure it is linked first.
+    await request.patch(`/api/v1/repositories/${STAGING_KEY}`, {
+      data: { release_repository_key: RELEASE_KEY },
+    });
+    const resp = await request.patch(`/api/v1/repositories/${STAGING_KEY}`, {
+      data: { release_repository_key: '' },
+    });
+    expect(resp.ok()).toBeTruthy();
+  });
+
+  test('release target linking is rejected for non-staging repositories', async ({ request }) => {
+    const resp = await request.patch(`/api/v1/repositories/${RELEASE_KEY}`, {
+      data: { release_repository_key: STAGING_KEY },
+    });
+    expect(resp.status()).toBe(400);
+  });
+
+  test('UI: set the release target on the staging settings tab', async ({ page, request }) => {
+    // Reset to unlinked before the UI flow.
+    await request.patch(`/api/v1/repositories/${STAGING_KEY}`, {
+      data: { release_repository_key: '' },
+    });
+
+    await page.goto(`/repositories/${STAGING_KEY}`);
+    await page.waitForLoadState('domcontentloaded');
+
+    const settingsTab = page.getByRole('tab', { name: /settings/i });
+    if (!(await settingsTab.isVisible({ timeout: 8000 }).catch(() => false))) {
+      test.skip(true, 'Settings tab not visible (requires admin); API tests cover the contract');
+      return;
+    }
+    await settingsTab.click();
+
+    const heading = page.getByRole('heading', { name: /release target/i });
+    await expect(heading).toBeVisible({ timeout: 8000 });
+
+    // Open the release repository select and pick the eligible local repo.
+    const select = page.getByRole('combobox').filter({ hasText: /release|select/i }).first();
+    await select.click();
+
+    const option = page.getByRole('option', { name: new RegExp(RELEASE_KEY, 'i') });
+    if (!(await option.isVisible({ timeout: 5000 }).catch(() => false))) {
+      // The candidate list may be empty in a constrained CI seed; the API
+      // tests above already prove the contract.
+      await page.keyboard.press('Escape');
+      test.skip(true, 'No eligible release repository option rendered');
+      return;
+    }
+    await option.click();
+
+    await page.getByRole('button', { name: /save release target/i }).click();
+
+    // A success toast confirms the save.
+    const toast = page
+      .locator('[data-sonner-toast][data-type="success"]')
+      .or(page.getByRole('status').filter({ hasText: /release target/i }));
+    await expect(toast.first()).toBeVisible({ timeout: 10000 });
+  });
+
+  test('UI: non-staging repository shows the staging-only notice', async ({ page }) => {
+    await page.goto(`/repositories/${RELEASE_KEY}`);
+    await page.waitForLoadState('domcontentloaded');
+
+    const settingsTab = page.getByRole('tab', { name: /settings/i });
+    if (!(await settingsTab.isVisible({ timeout: 8000 }).catch(() => false))) {
+      test.skip(true, 'Settings tab not visible (requires admin)');
+      return;
+    }
+    await settingsTab.click();
+
+    // Local repositories do not render the release-target section at all
+    // (it is gated to staging in the settings tab), so the heading must be
+    // absent. This documents the intended gating.
+    await expect(
+      page.getByRole('heading', { name: /release target/i })
+    ).toHaveCount(0);
+  });
+});

--- a/e2e/suites/interactions/repositories/routing-rules-settings.spec.ts
+++ b/e2e/suites/interactions/repositories/routing-rules-settings.spec.ts
@@ -1,0 +1,160 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E coverage for routing rules management on the repository Settings tab
+ * (issue #263).
+ *
+ * Routing rules rewrite the request path before it is forwarded upstream. The
+ * backend stores the full ordered list under repository_config and exposes:
+ *   GET    /api/v1/repositories/{key}/routing-rules
+ *   POST   /api/v1/repositories/{key}/routing-rules   { rules: [...] }
+ *   DELETE /api/v1/repositories/{key}/routing-rules
+ *
+ * The UI settings section is admin only, so the UI-driven test is best effort
+ * and falls back to skipping when the Settings tab is not reachable. The API
+ * contract tests are the load-bearing assertions.
+ */
+test.describe.serial('Routing Rules Settings', () => {
+  const REPO_KEY = 'e2e-routing-remote';
+
+  test.beforeAll(async ({ request }) => {
+    // A remote repository is the natural home for routing rules. Create one to
+    // operate on. Ignore conflicts so reruns are stable.
+    await request.post('/api/v1/repositories', {
+      data: {
+        key: REPO_KEY,
+        name: 'E2E Routing Remote',
+        format: 'generic',
+        repo_type: 'remote',
+        upstream_url: 'https://example.com',
+        is_public: true,
+      },
+    });
+    // Start from a clean slate.
+    await request.delete(`/api/v1/repositories/${REPO_KEY}/routing-rules`).catch(() => {});
+  });
+
+  test.afterAll(async ({ request }) => {
+    await request.delete(`/api/v1/repositories/${REPO_KEY}/routing-rules`).catch(() => {});
+    await request.delete(`/api/v1/repositories/${REPO_KEY}`).catch(() => {});
+  });
+
+  test('routing rules API round-trips set, get, and delete', async ({ request }) => {
+    const rules = [
+      { path_pattern: 'releases/(.+)', rewrite_to: 'download/$1' },
+      { path_pattern: 'latest', rewrite_to: 'v1/latest' },
+    ];
+
+    const setResp = await request.post(
+      `/api/v1/repositories/${REPO_KEY}/routing-rules`,
+      { data: { rules } }
+    );
+    expect(setResp.ok(), `Set failed: ${setResp.status()}`).toBeTruthy();
+
+    const getResp = await request.get(
+      `/api/v1/repositories/${REPO_KEY}/routing-rules`
+    );
+    expect(getResp.ok()).toBeTruthy();
+    const body = await getResp.json();
+    expect(body.repository_key).toBe(REPO_KEY);
+    expect(body.rules).toHaveLength(2);
+    expect(body.rules[0].path_pattern).toBe('releases/(.+)');
+    expect(body.rules[0].rewrite_to).toBe('download/$1');
+
+    const delResp = await request.delete(
+      `/api/v1/repositories/${REPO_KEY}/routing-rules`
+    );
+    expect(delResp.ok()).toBeTruthy();
+
+    const afterDelete = await request.get(
+      `/api/v1/repositories/${REPO_KEY}/routing-rules`
+    );
+    expect(afterDelete.ok()).toBeTruthy();
+    expect((await afterDelete.json()).rules).toHaveLength(0);
+  });
+
+  test('invalid regex pattern is rejected', async ({ request }) => {
+    const resp = await request.post(
+      `/api/v1/repositories/${REPO_KEY}/routing-rules`,
+      { data: { rules: [{ path_pattern: '(', rewrite_to: 'x' }] } }
+    );
+    expect(resp.status()).toBe(400);
+  });
+
+  test('UI: add a routing rule on the settings tab', async ({ page, request }) => {
+    // Ensure no rules exist before the UI flow.
+    await request.delete(`/api/v1/repositories/${REPO_KEY}/routing-rules`).catch(() => {});
+
+    await page.goto(`/repositories/${REPO_KEY}`);
+    await page.waitForLoadState('domcontentloaded');
+
+    const settingsTab = page.getByRole('tab', { name: /settings/i });
+    if (!(await settingsTab.isVisible({ timeout: 8000 }).catch(() => false))) {
+      test.skip(true, 'Settings tab not visible (requires admin); API tests cover the contract');
+      return;
+    }
+    await settingsTab.click();
+
+    // The Routing Rules section renders its own heading.
+    const heading = page.getByRole('heading', { name: /routing rules/i });
+    await expect(heading).toBeVisible({ timeout: 8000 });
+
+    // Fill the add-rule draft and submit.
+    await page.getByLabel(/^path pattern$/i).fill('docs/(.+)');
+    await page.getByLabel(/^rewrite to$/i).fill('static/$1');
+    await page.getByRole('button', { name: /add rule/i }).click();
+
+    // Confirm the rule was persisted via the API.
+    await expect(async () => {
+      const resp = await request.get(
+        `/api/v1/repositories/${REPO_KEY}/routing-rules`
+      );
+      const body = await resp.json();
+      expect(body.rules).toHaveLength(1);
+      expect(body.rules[0].path_pattern).toBe('docs/(.+)');
+      expect(body.rules[0].rewrite_to).toBe('static/$1');
+    }).toPass({ timeout: 10000 });
+
+    // The new rule should appear in the rules table.
+    await expect(page.getByRole('table', { name: /routing rules/i })).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(page.getByLabel(/rule 1 path pattern/i)).toHaveValue('docs/(.+)', {
+      timeout: 5000,
+    });
+  });
+
+  test('UI: remove a routing rule on the settings tab', async ({ page, request }) => {
+    // Seed a single rule to remove.
+    await request.post(`/api/v1/repositories/${REPO_KEY}/routing-rules`, {
+      data: { rules: [{ path_pattern: 'remove/(.+)', rewrite_to: 'gone/$1' }] },
+    });
+
+    await page.goto(`/repositories/${REPO_KEY}`);
+    await page.waitForLoadState('domcontentloaded');
+
+    const settingsTab = page.getByRole('tab', { name: /settings/i });
+    if (!(await settingsTab.isVisible({ timeout: 8000 }).catch(() => false))) {
+      test.skip(true, 'Settings tab not visible (requires admin); API tests cover the contract');
+      return;
+    }
+    await settingsTab.click();
+
+    await expect(page.getByRole('heading', { name: /routing rules/i })).toBeVisible({
+      timeout: 8000,
+    });
+
+    const removeBtn = page.getByRole('button', { name: /remove rule 1/i });
+    await expect(removeBtn).toBeVisible({ timeout: 5000 });
+    await removeBtn.click();
+
+    // Removing the last rule clears the config entirely.
+    await expect(async () => {
+      const resp = await request.get(
+        `/api/v1/repositories/${REPO_KEY}/routing-rules`
+      );
+      const body = await resp.json();
+      expect(body.rules).toHaveLength(0);
+    }).toPass({ timeout: 10000 });
+  });
+});

--- a/src/app/(app)/repositories/_components/release-target-settings.tsx
+++ b/src/app/(app)/repositories/_components/release-target-settings.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Loader2, Target, Info } from "lucide-react";
+import { toast } from "sonner";
+
+import { repositoriesApi } from "@/lib/api/repositories";
+import { mutationErrorToast } from "@/lib/error-utils";
+import type { Repository } from "@/types";
+
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+
+const NONE_VALUE = "__none__";
+
+interface ReleaseTargetSettingsProps {
+  repository: Repository;
+}
+
+/**
+ * Release target configuration for staging repositories (issue #260).
+ *
+ * A staging repository can be linked to a single local "release" repository of
+ * the same package format. Promotions from the staging repo then default to the
+ * linked release repo, and promotions to any other repository are rejected by
+ * the backend.
+ *
+ * The backend has no GET that returns the current link, so this control is a
+ * write-through "set the release target" form. Eligible targets are local
+ * repositories that share the staging repo's format.
+ */
+export function ReleaseTargetSettings({ repository }: ReleaseTargetSettingsProps) {
+  const queryClient = useQueryClient();
+
+  // Only staging repositories support release-target linking.
+  const isStaging = repository.repo_type === "staging";
+
+  const { data: repoList, isLoading: candidatesLoading } = useQuery({
+    queryKey: ["repositories", "release-target-candidates", repository.format],
+    // Pull local repos of the matching format. The backend enforces the same
+    // format + local-type constraints, so this keeps the picker in sync.
+    queryFn: () =>
+      repositoriesApi.list({
+        repo_type: "local",
+        format: repository.format,
+        per_page: 200,
+      }),
+    enabled: isStaging,
+  });
+
+  const candidates = useMemo(
+    () => (repoList?.items ?? []).filter((r) => r.id !== repository.id),
+    [repoList, repository.id]
+  );
+
+  const [selected, setSelected] = useState<string>(NONE_VALUE);
+
+  const saveMutation = useMutation({
+    mutationFn: (releaseKey: string) =>
+      repositoriesApi.setReleaseTarget(repository.key, releaseKey),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["repository", repository.key] });
+      queryClient.invalidateQueries({ queryKey: ["repositories"] });
+      toast.success(
+        selected === NONE_VALUE
+          ? "Release target link removed"
+          : "Release target saved"
+      );
+    },
+    onError: mutationErrorToast("Failed to save release target"),
+  });
+
+  if (!isStaging) {
+    return (
+      <section aria-labelledby="settings-release-target-heading">
+        <div className="flex items-center gap-2 mb-2">
+          <Target className="size-4 text-muted-foreground" />
+          <h3
+            id="settings-release-target-heading"
+            className="text-base font-semibold"
+          >
+            Release Target
+          </h3>
+        </div>
+        <p className="text-xs text-muted-foreground mb-3">
+          Release-target promotion links artifacts from a staging repository to a
+          release repository.
+        </p>
+        <Alert>
+          <Info className="size-4" />
+          <AlertDescription>
+            Release targets are only available for staging repositories. This
+            repository is a <span className="capitalize">{repository.repo_type}</span>{" "}
+            repository.
+          </AlertDescription>
+        </Alert>
+      </section>
+    );
+  }
+
+  const handleSave = () => {
+    // An empty string tells the backend to remove the link.
+    saveMutation.mutate(selected === NONE_VALUE ? "" : selected);
+  };
+
+  return (
+    <section aria-labelledby="settings-release-target-heading">
+      <div className="flex items-center gap-2 mb-2">
+        <Target className="size-4 text-muted-foreground" />
+        <h3
+          id="settings-release-target-heading"
+          className="text-base font-semibold"
+        >
+          Release Target
+        </h3>
+        <Badge variant="secondary" className="text-xs">
+          Staging
+        </Badge>
+      </div>
+      <p className="text-xs text-muted-foreground mb-4">
+        Link this staging repository to a release repository. Promotions from
+        here default to the linked target, and promotions elsewhere are rejected.
+        The target must be a local repository using the same{" "}
+        <span className="font-medium uppercase">{repository.format}</span> format.
+      </p>
+
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="release-target-select">Release repository</Label>
+          {candidatesLoading ? (
+            <Skeleton className="h-10 w-full" />
+          ) : (
+            <Select value={selected} onValueChange={setSelected}>
+              <SelectTrigger id="release-target-select" className="w-full">
+                <SelectValue placeholder="Select a release repository" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={NONE_VALUE}>No release target (unlink)</SelectItem>
+                {candidates.map((repo) => (
+                  <SelectItem key={repo.id} value={repo.key}>
+                    {repo.name} ({repo.key})
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+          {!candidatesLoading && candidates.length === 0 && (
+            <p className="text-xs text-muted-foreground">
+              No eligible release repositories found. Create a local{" "}
+              <span className="uppercase">{repository.format}</span> repository to
+              use as a release target.
+            </p>
+          )}
+        </div>
+
+        <Button
+          onClick={handleSave}
+          disabled={saveMutation.isPending}
+          className="w-fit"
+        >
+          {saveMutation.isPending ? (
+            <>
+              <Loader2 className="size-4 animate-spin" />
+              Saving...
+            </>
+          ) : (
+            "Save release target"
+          )}
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/src/app/(app)/repositories/_components/repo-settings-tab.tsx
+++ b/src/app/(app)/repositories/_components/repo-settings-tab.tsx
@@ -13,6 +13,8 @@ import type { Repository } from "@/types";
 import type { LifecyclePolicy, PolicyType } from "@/types/lifecycle";
 import { POLICY_TYPE_LABELS } from "@/types/lifecycle";
 import { quotaToBytes, bytesToQuota } from "./repo-dialogs";
+import { ReleaseTargetSettings } from "./release-target-settings";
+import { RoutingRulesSettings } from "./routing-rules-settings";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -342,6 +344,24 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
       </section>
 
       <Separator />
+
+      {/* -- Release Target Section (staging promotion, #260) -- */}
+      {repository.repo_type === "staging" && (
+        <>
+          <ReleaseTargetSettings repository={repository} />
+          <Separator />
+        </>
+      )}
+
+      {/* -- Routing Rules Section (path rewriting for proxy repos, #263) -- */}
+      {(repository.repo_type === "remote" ||
+        repository.repo_type === "virtual" ||
+        repository.repo_type === "staging") && (
+        <>
+          <RoutingRulesSettings repository={repository} />
+          <Separator />
+        </>
+      )}
 
       {/* -- Cleanup Policies Section -- */}
       <section aria-labelledby="settings-cleanup-heading">

--- a/src/app/(app)/repositories/_components/routing-rules-settings.tsx
+++ b/src/app/(app)/repositories/_components/routing-rules-settings.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Loader2, Plus, Trash2, Route, ArrowRight } from "lucide-react";
+import { toast } from "sonner";
+
+import { repositoriesApi, type RoutingRule } from "@/lib/api/repositories";
+import { mutationErrorToast } from "@/lib/error-utils";
+import type { Repository } from "@/types";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+interface RoutingRulesSettingsProps {
+  repository: Repository;
+}
+
+/**
+ * Routing rules management for a repository (issue #263).
+ *
+ * Routing rules rewrite the request path before it is forwarded to an upstream
+ * server. Each rule is a regex `path_pattern` and a `rewrite_to` template that
+ * may reference capture groups (`$1`, `$2`, ...). Rules are evaluated in order
+ * and the first match wins.
+ *
+ * The backend stores the full ordered list, so add/edit/remove all save the
+ * complete set via a single POST. Deleting the last rule clears all rules.
+ */
+export function RoutingRulesSettings({ repository }: RoutingRulesSettingsProps) {
+  const queryClient = useQueryClient();
+  const queryKey = useMemo(
+    () => ["repository", repository.key, "routing-rules"],
+    [repository.key]
+  );
+
+  const { data, isLoading } = useQuery({
+    queryKey,
+    queryFn: () => repositoriesApi.getRoutingRules(repository.key),
+  });
+
+  // Local editable copy of the rule list. Synced from the server response using
+  // the "adjust state during render" pattern (React docs) rather than an effect,
+  // so the table reflects fresh query data without an extra commit cycle.
+  const [rules, setRules] = useState<RoutingRule[]>([]);
+  const [syncedRef, setSyncedRef] = useState<RoutingRule[] | null>(null);
+  // Draft for the "add rule" row.
+  const [draft, setDraft] = useState<RoutingRule>({
+    path_pattern: "",
+    rewrite_to: "",
+  });
+
+  if (data?.rules && data.rules !== syncedRef) {
+    setSyncedRef(data.rules);
+    setRules(data.rules);
+  }
+
+  const saveMutation = useMutation({
+    mutationFn: (next: RoutingRule[]) =>
+      repositoriesApi.setRoutingRules(repository.key, next),
+    onSuccess: (resp) => {
+      setRules(resp.rules);
+      queryClient.invalidateQueries({ queryKey });
+      toast.success("Routing rules saved");
+    },
+    onError: mutationErrorToast("Failed to save routing rules"),
+  });
+
+  const clearMutation = useMutation({
+    mutationFn: () => repositoriesApi.deleteRoutingRules(repository.key),
+    onSuccess: () => {
+      setRules([]);
+      queryClient.invalidateQueries({ queryKey });
+      toast.success("Routing rules cleared");
+    },
+    onError: mutationErrorToast("Failed to clear routing rules"),
+  });
+
+  const isBusy = saveMutation.isPending || clearMutation.isPending;
+
+  const handleAdd = () => {
+    const pattern = draft.path_pattern.trim();
+    const rewrite = draft.rewrite_to.trim();
+    if (!pattern || !rewrite) {
+      toast.error("Both pattern and rewrite target are required");
+      return;
+    }
+    const next = [...rules, { path_pattern: pattern, rewrite_to: rewrite }];
+    saveMutation.mutate(next, {
+      onSuccess: (resp) => {
+        setRules(resp.rules);
+        setDraft({ path_pattern: "", rewrite_to: "" });
+        queryClient.invalidateQueries({ queryKey });
+        toast.success("Routing rule added");
+      },
+    });
+  };
+
+  const handleRemove = (index: number) => {
+    const next = rules.filter((_, i) => i !== index);
+    if (next.length === 0) {
+      // No rules left: clear the config entry entirely.
+      clearMutation.mutate();
+      return;
+    }
+    saveMutation.mutate(next, {
+      onSuccess: (resp) => {
+        setRules(resp.rules);
+        queryClient.invalidateQueries({ queryKey });
+        toast.success("Routing rule removed");
+      },
+    });
+  };
+
+  const handleEditField = (
+    index: number,
+    field: keyof RoutingRule,
+    value: string
+  ) => {
+    setRules((prev) =>
+      prev.map((rule, i) => (i === index ? { ...rule, [field]: value } : rule))
+    );
+  };
+
+  // Whether the locally edited rules differ from the server copy.
+  const dirty = useMemo(() => {
+    const serverRules = data?.rules ?? [];
+    if (serverRules.length !== rules.length) return true;
+    return rules.some(
+      (rule, i) =>
+        rule.path_pattern !== serverRules[i]?.path_pattern ||
+        rule.rewrite_to !== serverRules[i]?.rewrite_to
+    );
+  }, [data, rules]);
+
+  return (
+    <section aria-labelledby="settings-routing-rules-heading">
+      <div className="flex items-center gap-2 mb-2">
+        <Route className="size-4 text-muted-foreground" />
+        <h3
+          id="settings-routing-rules-heading"
+          className="text-base font-semibold"
+        >
+          Routing Rules
+        </h3>
+      </div>
+      <p className="text-xs text-muted-foreground mb-4">
+        Rewrite request paths before they are forwarded upstream. Each rule is a
+        regex pattern and a rewrite template. Reference capture groups with{" "}
+        <code className="font-mono">$1</code>,{" "}
+        <code className="font-mono">$2</code>, and so on. Rules are evaluated in
+        order; the first match wins.
+      </p>
+
+      {isLoading ? (
+        <div className="space-y-2">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {rules.length === 0 ? (
+            <div className="rounded-md border border-dashed p-6 text-center">
+              <p className="text-sm text-muted-foreground">
+                No routing rules configured. Requests are forwarded upstream
+                unchanged.
+              </p>
+            </div>
+          ) : (
+            <Table aria-label="Routing rules">
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-12">#</TableHead>
+                  <TableHead>Path pattern</TableHead>
+                  <TableHead>Rewrite to</TableHead>
+                  <TableHead className="w-12" />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rules.map((rule, index) => (
+                  <TableRow key={index}>
+                    <TableCell className="text-muted-foreground tabular-nums">
+                      {index + 1}
+                    </TableCell>
+                    <TableCell>
+                      <Input
+                        aria-label={`Rule ${index + 1} path pattern`}
+                        value={rule.path_pattern}
+                        onChange={(e) =>
+                          handleEditField(index, "path_pattern", e.target.value)
+                        }
+                        className="font-mono text-xs"
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <Input
+                        aria-label={`Rule ${index + 1} rewrite to`}
+                        value={rule.rewrite_to}
+                        onChange={(e) =>
+                          handleEditField(index, "rewrite_to", e.target.value)
+                        }
+                        className="font-mono text-xs"
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <Button
+                        variant="ghost"
+                        size="icon-xs"
+                        className="text-destructive hover:text-destructive"
+                        onClick={() => handleRemove(index)}
+                        disabled={isBusy}
+                        aria-label={`Remove rule ${index + 1}`}
+                      >
+                        <Trash2 className="size-3.5" />
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+
+          {/* Save edits to existing rules */}
+          {dirty && rules.length > 0 && (
+            <div className="flex items-center gap-2">
+              <Button
+                onClick={() => saveMutation.mutate(rules)}
+                disabled={isBusy}
+                size="sm"
+              >
+                {saveMutation.isPending ? (
+                  <>
+                    <Loader2 className="size-4 animate-spin" />
+                    Saving...
+                  </>
+                ) : (
+                  "Save changes"
+                )}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setRules(data?.rules ?? [])}
+                disabled={isBusy}
+              >
+                Discard
+              </Button>
+            </div>
+          )}
+
+          {/* Add a new rule */}
+          <div className="rounded-md border p-4 space-y-3">
+            <p className="text-sm font-medium">Add a rule</p>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-[1fr_auto_1fr]">
+              <div className="space-y-1.5">
+                <Label htmlFor="routing-rule-pattern" className="text-xs">
+                  Path pattern
+                </Label>
+                <Input
+                  id="routing-rule-pattern"
+                  value={draft.path_pattern}
+                  onChange={(e) =>
+                    setDraft((d) => ({ ...d, path_pattern: e.target.value }))
+                  }
+                  placeholder="releases/(.+)"
+                  className="font-mono text-xs"
+                />
+              </div>
+              <div className="hidden items-end pb-2 text-muted-foreground sm:flex">
+                <ArrowRight className="size-4" />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="routing-rule-rewrite" className="text-xs">
+                  Rewrite to
+                </Label>
+                <Input
+                  id="routing-rule-rewrite"
+                  value={draft.rewrite_to}
+                  onChange={(e) =>
+                    setDraft((d) => ({ ...d, rewrite_to: e.target.value }))
+                  }
+                  placeholder="download/$1"
+                  className="font-mono text-xs"
+                />
+              </div>
+            </div>
+            <Button
+              onClick={handleAdd}
+              disabled={isBusy || !draft.path_pattern.trim() || !draft.rewrite_to.trim()}
+              size="sm"
+            >
+              {saveMutation.isPending ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Plus className="size-4" />
+              )}
+              Add rule
+            </Button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/lib/api/repositories.ts
+++ b/src/lib/api/repositories.ts
@@ -47,6 +47,22 @@ export interface UpstreamAuthPayload {
   password?: string;
 }
 
+/**
+ * A single routing rule for path rewriting on remote/proxy repositories.
+ * Mirrors the backend `RoutingRule` struct: a regex `path_pattern` matched
+ * against the request path and a `rewrite_to` template that may reference
+ * capture groups with `$1`, `$2`, and so on.
+ */
+export interface RoutingRule {
+  path_pattern: string;
+  rewrite_to: string;
+}
+
+export interface RoutingRulesResponse {
+  repository_key: string;
+  rules: RoutingRule[];
+}
+
 const REPO_TYPES = new Set<RepositoryType>(['local', 'remote', 'virtual', 'staging']);
 
 const REPO_FORMATS = new Set<RepositoryFormat>([
@@ -253,6 +269,54 @@ export const repositoriesApi = {
     return apiFetch(`/api/v1/repositories/${encodeURIComponent(repoKey)}/test-upstream`, {
       method: 'POST',
     });
+  },
+
+  // Routing rules management (issue #263). The generated SDK does not yet expose
+  // these endpoints, so they go through the shared apiFetch wrapper, the same
+  // pattern used for upstream-auth and test-upstream above.
+  getRoutingRules: async (repoKey: string): Promise<RoutingRulesResponse> => {
+    return apiFetch<RoutingRulesResponse>(
+      `/api/v1/repositories/${encodeURIComponent(repoKey)}/routing-rules`
+    );
+  },
+
+  setRoutingRules: async (
+    repoKey: string,
+    rules: RoutingRule[]
+  ): Promise<RoutingRulesResponse> => {
+    return apiFetch<RoutingRulesResponse>(
+      `/api/v1/repositories/${encodeURIComponent(repoKey)}/routing-rules`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ rules }),
+      }
+    );
+  },
+
+  deleteRoutingRules: async (repoKey: string): Promise<void> => {
+    await apiFetch<void>(
+      `/api/v1/repositories/${encodeURIComponent(repoKey)}/routing-rules`,
+      { method: 'DELETE' }
+    );
+  },
+
+  // Release target configuration for staging repositories (issue #260).
+  // Persisted via PATCH /repositories/{key} with the `release_repository_key`
+  // field. Pass an empty string to remove an existing link. The generated SDK's
+  // UpdateRepositoryRequest may not carry this field yet, so it is sent through
+  // apiFetch to guarantee it reaches the backend.
+  setReleaseTarget: async (
+    repoKey: string,
+    releaseRepositoryKey: string
+  ): Promise<Repository> => {
+    const sdk = await apiFetch<RepositoryResponse>(
+      `/api/v1/repositories/${encodeURIComponent(repoKey)}`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ release_repository_key: releaseRepositoryKey }),
+      }
+    );
+    return adaptRepository(sdk);
   },
 };
 


### PR DESCRIPTION
## Summary

Adds two sections to the repository Settings tab.

Release target (#260): staging repositories can be linked to a local release repository of the same package format. The picker lists eligible local repos and saves through `PATCH /repositories/{key}` with `release_repository_key`. Selecting "No release target" unlinks. Non-staging repositories render a short notice explaining the control is staging only, and the section is gated to staging repos in the settings tab.

Routing rules (#263): view, add, edit, and remove path-rewriting rules for remote, virtual, and staging repositories. Each rule is a regex `path_pattern` and a `rewrite_to` template that can reference capture groups (`$1`, `$2`, ...). Rules are evaluated in order, first match wins. The backend stores a single ordered list, so every change saves the full set via `POST /repositories/{key}/routing-rules`; removing the last rule clears the config via `DELETE`.

Both sections reuse `repositoriesApi` with new `getRoutingRules`, `setRoutingRules`, `deleteRoutingRules`, and `setReleaseTarget` methods backed by the shared `apiFetch` helper, since the generated SDK does not expose these endpoints yet.

Closes #260
Closes #263

## Test Checklist
- [ ] Unit tests added/updated
- [x] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [x] Playwright E2E spec covers the change
- [x] Responsive layout verified (mobile + desktop)
- [x] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes