### PR TITLE
feat(search): surface OpenSearch capabilities in the search UI

### DIFF
--- a/e2e/suites/interactions/search/opensearch-search.spec.ts
+++ b/e2e/suites/interactions/search/opensearch-search.spec.ts
@@ -1,0 +1,198 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Search UI coverage for the OpenSearch backend (issue #269, v1.2.0).
+ *
+ * The backend migrated search indexing to OpenSearch in 1.2.0. This suite
+ * exercises the capabilities the UI now exposes on top of that:
+ *
+ * 1. Relevance is the default sort (OpenSearch ranks results, no explicit
+ *    sort_by is sent). Date, Name, Size, and Downloads are explicit sorts.
+ * 2. A sort-direction toggle sends sort_order=asc|desc, and is disabled while
+ *    sorting by relevance (relevance has no direction).
+ * 3. The advanced search request carries sort_by and sort_order when an
+ *    explicit field sort is chosen.
+ * 4. Facets returned by the backend render as clickable refine chips that
+ *    re-issue the search with the facet applied.
+ *
+ * Runs in CI against the :1.2.0 backend image. Tests that need indexed data
+ * seed it through the public artifact API, mirroring artifact-download.spec.ts.
+ */
+test.describe('OpenSearch Search UI', () => {
+  const REPO_KEY = 'e2e-maven-local';
+
+  async function uploadArtifact(
+    request: import('@playwright/test').APIRequestContext,
+    name: string
+  ): Promise<string> {
+    const path = `e2e/opensearch/${name}-${Date.now()}.txt`;
+    const resp = await request.put(
+      `/api/v1/repositories/${REPO_KEY}/artifacts/${path}`,
+      {
+        data: `OpenSearch indexing fixture for ${name}`,
+        headers: { 'Content-Type': 'application/octet-stream' },
+      }
+    );
+    expect(resp.ok(), `Upload failed: ${resp.status()}`).toBeTruthy();
+    const body = await resp.json();
+    return body.path || path;
+  }
+
+  test('sort menu offers relevance, date, name, size, and downloads', async ({
+    page,
+  }) => {
+    await page.goto('/search');
+    await page.getByPlaceholder('e.g., react, lodash').fill('test');
+    await page.getByRole('button', { name: /^search$/i }).first().click();
+
+    // Results header (results or empty state) must be present before the
+    // sort control renders.
+    await expect(page.getByText(/results/i).first()).toBeVisible({
+      timeout: 15000,
+    });
+
+    const sortSelect = page.getByRole('combobox', { name: /sort by/i });
+    await expect(sortSelect).toBeVisible({ timeout: 10000 });
+    await sortSelect.click();
+
+    // Radix Select renders options into a listbox popover.
+    await expect(
+      page.getByRole('option', { name: /relevance/i })
+    ).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('option', { name: /^date$/i })).toBeVisible();
+    await expect(page.getByRole('option', { name: /^name$/i })).toBeVisible();
+    await expect(page.getByRole('option', { name: /^size$/i })).toBeVisible();
+    await expect(
+      page.getByRole('option', { name: /downloads/i })
+    ).toBeVisible();
+  });
+
+  test('sort direction toggle is disabled for relevance and enabled for field sorts', async ({
+    page,
+  }) => {
+    await page.goto('/search');
+    await page.getByPlaceholder('e.g., react, lodash').fill('test');
+    await page.getByRole('button', { name: /^search$/i }).first().click();
+    await expect(page.getByText(/results/i).first()).toBeVisible({
+      timeout: 15000,
+    });
+
+    // Default sort is relevance, so the direction toggle is disabled (there is
+    // no ascending/descending relevance).
+    const toggle = page.getByRole('button', { name: /sort (descending|ascending)/i });
+    await expect(toggle).toBeVisible({ timeout: 10000 });
+    await expect(toggle).toBeDisabled();
+
+    // Switch to an explicit field sort; the direction toggle becomes enabled.
+    const sortSelect = page.getByRole('combobox', { name: /sort by/i });
+    await sortSelect.click();
+    await page.getByRole('option', { name: /^date$/i }).click();
+    await expect(toggle).toBeEnabled({ timeout: 10000 });
+  });
+
+  test('advanced search request carries sort_by and sort_order for field sorts', async ({
+    page,
+  }) => {
+    await page.goto('/search');
+    await page.getByPlaceholder('e.g., react, lodash').fill('test');
+    await page.getByRole('button', { name: /^search$/i }).first().click();
+    await expect(page.getByText(/results/i).first()).toBeVisible({
+      timeout: 15000,
+    });
+
+    // Choose Size sort, which sends sort_by=size_bytes. Capture the next
+    // advanced-search request to assert the OpenSearch sort params travel.
+    const requestPromise = page.waitForRequest(
+      (req) =>
+        req.url().includes('/api/v1/search/advanced') &&
+        req.url().includes('sort_by=size_bytes'),
+      { timeout: 15000 }
+    );
+
+    const sortSelect = page.getByRole('combobox', { name: /sort by/i });
+    await sortSelect.click();
+    await page.getByRole('option', { name: /^size$/i }).click();
+
+    const request = await requestPromise;
+    const url = new URL(request.url());
+    expect(url.searchParams.get('sort_by')).toBe('size_bytes');
+    // Default direction is descending until the toggle flips it.
+    expect(url.searchParams.get('sort_order')).toBe('desc');
+
+    // Flipping the direction toggle re-issues the search with sort_order=asc.
+    const ascRequest = page.waitForRequest(
+      (req) =>
+        req.url().includes('/api/v1/search/advanced') &&
+        req.url().includes('sort_order=asc'),
+      { timeout: 15000 }
+    );
+    await page.getByRole('button', { name: /sort (descending|ascending)/i }).click();
+    const asc = await ascRequest;
+    expect(new URL(asc.url()).searchParams.get('sort_order')).toBe('asc');
+  });
+
+  test('relevance sort omits sort_by from the request', async ({ page }) => {
+    await page.goto('/search');
+
+    // The very first search uses the default relevance sort. Capture it and
+    // assert sort_by is absent (the backend then applies relevance ranking).
+    const requestPromise = page.waitForRequest(
+      (req) => req.url().includes('/api/v1/search/advanced'),
+      { timeout: 15000 }
+    );
+    await page.getByPlaceholder('e.g., react, lodash').fill('test');
+    await page.getByRole('button', { name: /^search$/i }).first().click();
+
+    const request = await requestPromise;
+    const params = new URL(request.url()).searchParams;
+    expect(params.get('sort_by')).toBeNull();
+    expect(params.get('sort_order')).toBeNull();
+  });
+
+  test('facets render and apply as refine filters when the backend returns them', async ({
+    page,
+    request,
+  }) => {
+    // Seed an indexed artifact so the OpenSearch facet aggregations are
+    // non-empty for at least the maven format / e2e repository.
+    const path = await uploadArtifact(request, 'facettest');
+
+    await page.goto('/search');
+    await page.getByPlaceholder('e.g., react, lodash').fill('facettest');
+    await page.getByRole('button', { name: /^search$/i }).first().click();
+    await expect(page.getByText(/results/i).first()).toBeVisible({
+      timeout: 15000,
+    });
+
+    // The facet panel only renders when the backend returns aggregations.
+    // Indexing is asynchronous, so treat an absent panel as a soft skip rather
+    // than a hard failure; when present, a facet chip must filter the results.
+    const facets = page.getByTestId('search-facets');
+    if (await facets.isVisible({ timeout: 8000 }).catch(() => false)) {
+      const refineRequest = page.waitForRequest(
+        (req) =>
+          req.url().includes('/api/v1/search/advanced') &&
+          (req.url().includes('format=') ||
+            req.url().includes('repository_key=')),
+        { timeout: 15000 }
+      );
+      const firstChip = facets.getByRole('button').first();
+      await firstChip.click();
+      await refineRequest;
+
+      // After selecting a facet, the clear-filters control appears.
+      await expect(
+        page.getByRole('button', { name: /clear filters/i })
+      ).toBeVisible({ timeout: 10000 });
+    } else {
+      test.info().annotations.push({
+        type: 'note',
+        description: 'Facet panel not shown (artifact not yet indexed)',
+      });
+    }
+
+    await request
+      .delete(`/api/v1/repositories/${REPO_KEY}/artifacts/${path}`)
+      .catch(() => {});
+  });
+});

--- a/src/app/(app)/_components/dashboard-content.tsx
+++ b/src/app/(app)/_components/dashboard-content.tsx
@@ -341,10 +341,13 @@ export function DashboardContent() {
                   status={health.checks.security_scanner.status}
                 />
               )}
-              {health?.checks?.meilisearch && (
+              {(health?.checks?.opensearch ?? health?.checks?.meilisearch) && (
                 <HealthCard
                   label="Search Engine"
-                  status={health.checks.meilisearch.status}
+                  status={
+                    (health?.checks?.opensearch ?? health?.checks?.meilisearch)!
+                      .status
+                  }
                 />
               )}
             </div>

--- a/src/app/(app)/search/_components/search-content.test.tsx
+++ b/src/app/(app)/search/_components/search-content.test.tsx
@@ -81,6 +81,9 @@ vi.mock("lucide-react", () => {
     FileSearch: stub("FileSearch"),
     ChevronLeft: stub("ChevronLeft"),
     ChevronRight: stub("ChevronRight"),
+    ArrowDownWideNarrow: stub("ArrowDownWideNarrow"),
+    ArrowUpWideNarrow: stub("ArrowUpWideNarrow"),
+    X: stub("X"),
   };
 });
 

--- a/src/app/(app)/search/_components/search-content.tsx
+++ b/src/app/(app)/search/_components/search-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import {
@@ -17,6 +17,9 @@ import {
   FileSearch,
   ChevronLeft,
   ChevronRight,
+  ArrowDownWideNarrow,
+  ArrowUpWideNarrow,
+  X,
 } from "lucide-react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Input } from "@/components/ui/input";
@@ -48,7 +51,16 @@ import { formatBytes as formatBytesUtil, formatDate } from "@/lib/utils";
 
 type SearchTab = "package" | "property" | "gavc" | "checksum";
 type ViewMode = "list" | "grid";
-type SortField = "name" | "created_at" | "size_bytes";
+// Sort fields accepted by the OpenSearch-backed /search/advanced endpoint.
+// `relevance` maps to no explicit sort_by so the backend returns its own
+// relevance ranking (the default and most useful order for a text query).
+type SortField =
+  | "relevance"
+  | "name"
+  | "created_at"
+  | "size_bytes"
+  | "download_count";
+type SortOrder = "asc" | "desc";
 
 interface PropertyFilter {
   id: string;
@@ -87,6 +99,30 @@ function formatBytes(bytes: number | undefined): string {
   return formatBytesUtil(bytes);
 }
 
+// OpenSearch returns highlight snippets with matched terms wrapped in <em>
+// tags. Render them as React nodes (emphasized spans) instead of injecting
+// raw HTML, so the markup can never execute arbitrary content. Anything that
+// is not inside <em>...</em> is rendered as plain text.
+function renderHighlight(snippet: string, keyPrefix: string) {
+  const parts = snippet.split(/(<em>.*?<\/em>)/g);
+  return parts
+    .filter((p) => p.length > 0)
+    .map((part, i) => {
+      const match = part.match(/^<em>(.*?)<\/em>$/);
+      if (match) {
+        return (
+          <mark
+            key={`${keyPrefix}-${i}`}
+            className="bg-transparent font-semibold text-foreground"
+          >
+            {match[1]}
+          </mark>
+        );
+      }
+      return <span key={`${keyPrefix}-${i}`}>{part}</span>;
+    });
+}
+
 const FORMAT_OPTIONS = [
   "maven",
   "npm",
@@ -116,9 +152,15 @@ export function SearchContent() {
   // Local state
   const [activeTab, setActiveTab] = useState<SearchTab>(urlTab);
   const [viewMode, setViewMode] = useState<ViewMode>("list");
-  const [sortField, setSortField] = useState<SortField>("created_at");
+  const [sortField, setSortField] = useState<SortField>("relevance");
+  const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
   const [page, setPage] = useState(1);
   const pageSize = 20;
+
+  // Active facet filters applied on top of the form query. Selecting a facet
+  // chip narrows results to that format/repository and re-runs the search.
+  const [facetFormat, setFacetFormat] = useState<string | null>(null);
+  const [facetRepository, setFacetRepository] = useState<string | null>(null);
 
   // Per-tab form state
   const [packageValues, setPackageValues] = useState<PackageSearchValues>({
@@ -153,38 +195,44 @@ export function SearchContent() {
 
   const repositories = reposData?.items ?? [];
 
-  // Build search params based on active tab
+  // Build search params based on active tab. `relevance` is the OpenSearch
+  // default ranking and is expressed by omitting sort_by, so the backend does
+  // not switch into an explicit field sort. Active facet chips override the
+  // matching form field (a selected format facet wins over the form's format).
   const buildSearchParams = useCallback(() => {
+    const sort = sortField === "relevance" ? undefined : sortField;
+    const common = {
+      page,
+      per_page: pageSize,
+      sort_by: sort,
+      sort_order: sort ? sortOrder : undefined,
+      format: facetFormat ?? undefined,
+      repository_key: facetRepository ?? undefined,
+    };
     switch (activeTab) {
       case "package":
         return {
+          ...common,
           query: packageValues.name || undefined,
           version: packageValues.version || undefined,
-          repository_key: packageValues.repository || undefined,
-          format: packageValues.format || undefined,
-          page,
-          per_page: pageSize,
-          sort_by: sortField,
+          repository_key: facetRepository ?? (packageValues.repository || undefined),
+          format: facetFormat ?? (packageValues.format || undefined),
         };
       case "property": {
         const queryParts = propertyFilters
           .filter((f) => f.key && f.value)
           .map((f) => `${f.key}:${f.value}`);
         return {
+          ...common,
           query: queryParts.length > 0 ? queryParts.join(" ") : undefined,
-          page,
-          per_page: pageSize,
-          sort_by: sortField,
         };
       }
       case "gavc":
         return {
+          ...common,
           path: gavcValues.groupId || undefined,
           name: gavcValues.artifactId || undefined,
           version: gavcValues.version || undefined,
-          page,
-          per_page: pageSize,
-          sort_by: sortField,
         };
       case "checksum":
         return null; // Checksum handled separately
@@ -197,6 +245,9 @@ export function SearchContent() {
     page,
     pageSize,
     sortField,
+    sortOrder,
+    facetFormat,
+    facetRepository,
   ]);
 
   // Main search query
@@ -205,7 +256,16 @@ export function SearchContent() {
     isLoading,
     isFetching,
   } = useQuery({
-    queryKey: ["advanced-search", searchKey, activeTab, page, sortField],
+    queryKey: [
+      "advanced-search",
+      searchKey,
+      activeTab,
+      page,
+      sortField,
+      sortOrder,
+      facetFormat,
+      facetRepository,
+    ],
     queryFn: async () => {
       if (activeTab === "checksum") {
         if (!checksumValues.value) return null;
@@ -231,6 +291,7 @@ export function SearchContent() {
             total: artifacts.length,
             total_pages: 1,
           },
+          facets: { formats: [], repositories: [], content_types: [] },
         };
       }
 
@@ -300,20 +361,40 @@ export function SearchContent() {
 
   const loading = isLoading || isFetching;
 
-  // Sort the results client-side as a fallback
-  const sortedResults = useMemo(() => {
-    const items: SearchResult[] = (searchResults?.items ?? []) as SearchResult[];
-    const copy = [...items];
-    copy.sort((a, b) => {
-      if (sortField === "name") return a.name.localeCompare(b.name);
-      if (sortField === "size_bytes")
-        return (b.size_bytes ?? 0) - (a.size_bytes ?? 0);
-      return (
-        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-      );
-    });
-    return copy;
-  }, [searchResults?.items, sortField]);
+  // Use the server's ordering directly. The OpenSearch backend already applies
+  // relevance ranking (or the requested sort_by + sort_order) across the full
+  // result set; re-sorting client-side only reorders the current page, which
+  // contradicts the server order and breaks once results span more than one
+  // page. So we render exactly what the backend returned.
+  const results: SearchResult[] = (searchResults?.items ?? []) as SearchResult[];
+  const facets = searchResults?.facets ?? {
+    formats: [],
+    repositories: [],
+    content_types: [],
+  };
+  const hasActiveFacets = facetFormat !== null || facetRepository !== null;
+
+  // Toggle a facet filter: selecting re-runs the search from page 1, clicking
+  // the active value again clears it.
+  const toggleFacet = useCallback(
+    (kind: "format" | "repository", value: string) => {
+      setPage(1);
+      setSearchKey((k) => k + 1);
+      if (kind === "format") {
+        setFacetFormat((cur) => (cur === value ? null : value));
+      } else {
+        setFacetRepository((cur) => (cur === value ? null : value));
+      }
+    },
+    []
+  );
+
+  const clearFacets = useCallback(() => {
+    setFacetFormat(null);
+    setFacetRepository(null);
+    setPage(1);
+    setSearchKey((k) => k + 1);
+  }, []);
 
   return (
     <div className="space-y-6">
@@ -626,22 +707,52 @@ export function SearchContent() {
                 )}
               </div>
               <div className="flex items-center gap-2">
-                <Select
-                  value={sortField}
-                  onValueChange={(val) => {
-                    setSortField(val as SortField);
-                    setSearchKey((k) => k + 1);
-                  }}
-                >
-                  <SelectTrigger className="w-36" size="sm">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="created_at">Date</SelectItem>
-                    <SelectItem value="name">Name</SelectItem>
-                    <SelectItem value="size_bytes">Size</SelectItem>
-                  </SelectContent>
-                </Select>
+                {activeTab !== "checksum" && (
+                  <>
+                    <Select
+                      value={sortField}
+                      onValueChange={(val) => {
+                        setSortField(val as SortField);
+                        setSearchKey((k) => k + 1);
+                      }}
+                    >
+                      <SelectTrigger
+                        className="w-36"
+                        size="sm"
+                        aria-label="Sort by"
+                      >
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="relevance">Relevance</SelectItem>
+                        <SelectItem value="created_at">Date</SelectItem>
+                        <SelectItem value="name">Name</SelectItem>
+                        <SelectItem value="size_bytes">Size</SelectItem>
+                        <SelectItem value="download_count">Downloads</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <Button
+                      variant="outline"
+                      size="icon-sm"
+                      disabled={sortField === "relevance"}
+                      onClick={() => {
+                        setSortOrder((o) => (o === "desc" ? "asc" : "desc"));
+                        setSearchKey((k) => k + 1);
+                      }}
+                      aria-label={
+                        sortOrder === "desc"
+                          ? "Sort descending, switch to ascending"
+                          : "Sort ascending, switch to descending"
+                      }
+                    >
+                      {sortOrder === "desc" ? (
+                        <ArrowDownWideNarrow className="size-4" />
+                      ) : (
+                        <ArrowUpWideNarrow className="size-4" />
+                      )}
+                    </Button>
+                  </>
+                )}
                 <div className="flex items-center rounded-md border">
                   <Button
                     variant={viewMode === "list" ? "secondary" : "ghost"}
@@ -665,6 +776,91 @@ export function SearchContent() {
               </div>
             </div>
 
+            {/* Facets: server-computed aggregations from OpenSearch. Clicking a
+                value filters the result set; the active value is highlighted
+                and can be cleared. Only shown for the index-backed tabs. */}
+            {!loading &&
+              activeTab !== "checksum" &&
+              (facets.formats.length > 0 ||
+                facets.repositories.length > 0 ||
+                hasActiveFacets) && (
+                <div
+                  className="mb-4 space-y-2 rounded-md border bg-muted/30 p-3"
+                  data-testid="search-facets"
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                      Refine
+                    </span>
+                    {hasActiveFacets && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-6 gap-1 px-2 text-xs"
+                        onClick={clearFacets}
+                      >
+                        <X className="size-3" />
+                        Clear filters
+                      </Button>
+                    )}
+                  </div>
+                  {facets.formats.length > 0 && (
+                    <div className="flex flex-wrap items-center gap-1.5">
+                      <span className="text-xs text-muted-foreground w-20 shrink-0">
+                        Format
+                      </span>
+                      {facets.formats.map((f) => (
+                        <button
+                          key={f.value}
+                          type="button"
+                          onClick={() => toggleFacet("format", f.value)}
+                          aria-pressed={facetFormat === f.value}
+                          className="inline-flex items-center"
+                        >
+                          <Badge
+                            variant={
+                              facetFormat === f.value ? "default" : "secondary"
+                            }
+                            className="cursor-pointer gap-1"
+                          >
+                            {f.value}
+                            <span className="opacity-70">{f.count}</span>
+                          </Badge>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                  {facets.repositories.length > 0 && (
+                    <div className="flex flex-wrap items-center gap-1.5">
+                      <span className="text-xs text-muted-foreground w-20 shrink-0">
+                        Repository
+                      </span>
+                      {facets.repositories.map((f) => (
+                        <button
+                          key={f.value}
+                          type="button"
+                          onClick={() => toggleFacet("repository", f.value)}
+                          aria-pressed={facetRepository === f.value}
+                          className="inline-flex items-center"
+                        >
+                          <Badge
+                            variant={
+                              facetRepository === f.value
+                                ? "default"
+                                : "secondary"
+                            }
+                            className="cursor-pointer gap-1"
+                          >
+                            {f.value}
+                            <span className="opacity-70">{f.count}</span>
+                          </Badge>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+
             {/* Loading state */}
             {loading && (
               <div className="flex items-center justify-center py-16">
@@ -673,7 +869,7 @@ export function SearchContent() {
             )}
 
             {/* Empty state */}
-            {!loading && sortedResults.length === 0 && (
+            {!loading && results.length === 0 && (
               <div className="flex flex-col items-center justify-center py-16 text-center">
                 <SearchIcon className="size-10 text-muted-foreground/40 mb-3" />
                 <p className="text-sm text-muted-foreground">
@@ -683,7 +879,7 @@ export function SearchContent() {
             )}
 
             {/* List view */}
-            {!loading && sortedResults.length > 0 && viewMode === "list" && (
+            {!loading && results.length > 0 && viewMode === "list" && (
               <Table>
                 <TableHeader>
                   <TableRow>
@@ -697,7 +893,7 @@ export function SearchContent() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {sortedResults.map((result) => (
+                  {results.map((result) => (
                     <TableRow
                       key={result.id}
                       className="cursor-pointer"
@@ -719,6 +915,14 @@ export function SearchContent() {
                             />
                           )}
                         </span>
+                        {result.highlights && result.highlights.length > 0 && (
+                          <p className="mt-0.5 truncate text-xs font-normal text-muted-foreground">
+                            {renderHighlight(
+                              result.highlights[0],
+                              `${result.id}-hl`
+                            )}
+                          </p>
+                        )}
                       </TableCell>
                       <TableCell className="text-muted-foreground">
                         {result.version || "--"}
@@ -757,9 +961,9 @@ export function SearchContent() {
             )}
 
             {/* Grid view */}
-            {!loading && sortedResults.length > 0 && viewMode === "grid" && (
+            {!loading && results.length > 0 && viewMode === "grid" && (
               <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-                {sortedResults.map((result) => (
+                {results.map((result) => (
                   <button
                     key={result.id}
                     type="button"
@@ -781,6 +985,14 @@ export function SearchContent() {
                           {result.repository_key}
                           {result.path ? `/${result.path}` : ""}
                         </p>
+                        {result.highlights && result.highlights.length > 0 && (
+                          <p className="mt-1 truncate text-xs text-muted-foreground">
+                            {renderHighlight(
+                              result.highlights[0],
+                              `${result.id}-grid-hl`
+                            )}
+                          </p>
+                        )}
                       </div>
                       <Button
                         variant="ghost"

--- a/src/lib/api/__tests__/admin.test.ts
+++ b/src/lib/api/__tests__/admin.test.ts
@@ -108,8 +108,55 @@ describe("adminApi", () => {
         database: { status: "ok", message: undefined },
         storage: { status: "ok", message: undefined },
         security_scanner: undefined,
+        opensearch: undefined,
         meilisearch: undefined,
       },
+    });
+  });
+
+  it("getHealth maps the 1.2.0 opensearch check onto the search engine fields", async () => {
+    const health = {
+      status: "ok",
+      version: "1.2.0",
+      demo_mode: false,
+      checks: {
+        database: { status: "ok" },
+        storage: { status: "ok" },
+        // Backend 1.2.0 reports the search engine under `opensearch`.
+        opensearch: { status: "healthy", message: "cluster status: green" },
+      },
+    };
+    mockHealthCheck.mockResolvedValue({ data: health, error: undefined });
+    const { adminApi } = await import("../admin");
+    const result = await adminApi.getHealth();
+    expect(result.checks.opensearch).toEqual({
+      status: "healthy",
+      message: "cluster status: green",
+    });
+    // The legacy alias is kept populated so older consumers keep rendering.
+    expect(result.checks.meilisearch).toEqual({
+      status: "healthy",
+      message: "cluster status: green",
+    });
+  });
+
+  it("getHealth falls back to a legacy meilisearch check when opensearch is absent", async () => {
+    const health = {
+      status: "ok",
+      version: "1.1.0",
+      demo_mode: false,
+      checks: {
+        database: { status: "ok" },
+        storage: { status: "ok" },
+        meilisearch: { status: "healthy" },
+      },
+    };
+    mockHealthCheck.mockResolvedValue({ data: health, error: undefined });
+    const { adminApi } = await import("../admin");
+    const result = await adminApi.getHealth();
+    expect(result.checks.opensearch).toEqual({
+      status: "healthy",
+      message: undefined,
     });
   });
 

--- a/src/lib/api/admin.ts
+++ b/src/lib/api/admin.ts
@@ -48,6 +48,15 @@ function adaptCheck(c: CheckStatus | null | undefined): { status: string; messag
 function adaptHealth(sdk: SdkHealthResponse): HealthResponse {
   const database = adaptCheck(sdk.checks.database) ?? { status: 'unknown' };
   const storage = adaptCheck(sdk.checks.storage) ?? { status: 'unknown' };
+  // Backend 1.2.0 renamed the search-engine health check from `meilisearch`
+  // to `opensearch`. The pinned SDK types only model `meilisearch`, so read
+  // the new field via passthrough and prefer it when present. Either field
+  // maps onto the single local `opensearch` check so the dashboard "Search
+  // Engine" card keeps rendering across both backend versions.
+  const checks = sdk.checks as typeof sdk.checks & {
+    opensearch?: CheckStatus | null;
+  };
+  const searchEngine = adaptCheck(checks.opensearch ?? checks.meilisearch);
   return {
     status: sdk.status,
     version: sdk.version,
@@ -57,7 +66,8 @@ function adaptHealth(sdk: SdkHealthResponse): HealthResponse {
       database,
       storage,
       security_scanner: adaptCheck(sdk.checks.security_scanner),
-      meilisearch: adaptCheck(sdk.checks.meilisearch),
+      opensearch: searchEngine,
+      meilisearch: searchEngine,
     },
   };
 }

--- a/src/lib/api/search.ts
+++ b/src/lib/api/search.ts
@@ -4,6 +4,8 @@ import type {
   SearchResultItem,
   AdvancedSearchResponse,
   ChecksumArtifact,
+  FacetValue as SdkFacetValue,
+  FacetsResponse as SdkFacetsResponse,
 } from '@artifact-keeper/sdk';
 import type { Artifact, PaginatedResponse } from '@/types';
 import { assertData, narrowEnum } from '@/lib/api/fetch';
@@ -50,6 +52,33 @@ export interface AdvancedSearchParams {
 export interface ChecksumSearchParams {
   checksum: string;
   algorithm?: 'sha256' | 'sha1' | 'md5';
+}
+
+/** A single facet bucket: a value and how many results carry it. */
+export interface SearchFacet {
+  value: string;
+  count: number;
+}
+
+/**
+ * Aggregations returned alongside advanced search results. The OpenSearch
+ * backend computes these server-side so the UI can show counts per format and
+ * per repository without a second round trip. Each array is sorted by the
+ * backend in descending count order.
+ */
+export interface SearchFacets {
+  formats: SearchFacet[];
+  repositories: SearchFacet[];
+  content_types: SearchFacet[];
+}
+
+/**
+ * Advanced search response: a paginated result set plus the facet
+ * aggregations. This is `PaginatedResponse<SearchResult>` widened with
+ * `facets` so callers that only need items keep working unchanged.
+ */
+export interface AdvancedSearchResult extends PaginatedResponse<SearchResult> {
+  facets: SearchFacets;
 }
 
 const SEARCH_RESULT_TYPES = new Set<SearchResult['type']>(['artifact', 'package', 'repository']);
@@ -111,10 +140,23 @@ function adaptChecksumArtifact(sdk: ChecksumArtifact): Artifact {
   };
 }
 
-function adaptAdvancedSearch(sdk: AdvancedSearchResponse): PaginatedResponse<SearchResult> {
+function adaptFacet(f: SdkFacetValue): SearchFacet {
+  return { value: f.value, count: f.count };
+}
+
+function adaptFacets(f: SdkFacetsResponse | undefined): SearchFacets {
+  return {
+    formats: (f?.formats ?? []).map(adaptFacet),
+    repositories: (f?.repositories ?? []).map(adaptFacet),
+    content_types: (f?.content_types ?? []).map(adaptFacet),
+  };
+}
+
+function adaptAdvancedSearch(sdk: AdvancedSearchResponse): AdvancedSearchResult {
   return {
     items: sdk.items.map(adaptSearchResult),
     pagination: sdk.pagination,
+    facets: adaptFacets(sdk.facets),
   };
 }
 
@@ -133,7 +175,7 @@ export const searchApi = {
 
   advancedSearch: async (
     params: AdvancedSearchParams
-  ): Promise<PaginatedResponse<SearchResult>> => {
+  ): Promise<AdvancedSearchResult> => {
     const { data, error } = await advancedSearch({ query: params });
     if (error) throw error;
     return adaptAdvancedSearch(assertData(data, 'searchApi.advancedSearch'));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -236,6 +236,13 @@ export interface HealthResponse {
     database: { status: string; message?: string };
     storage: { status: string; message?: string };
     security_scanner?: { status: string; message?: string };
+    /**
+     * Search backend health. As of backend 1.2.0 the search index migrated
+     * from Meilisearch to OpenSearch and the health payload exposes this under
+     * `opensearch`. Older backends used `meilisearch`. Both are kept here so the
+     * UI renders the "Search Engine" card regardless of which backend answers.
+     */
+    opensearch?: { status: string; message?: string };
     meilisearch?: { status: string; message?: string };
   };
 }


### PR DESCRIPTION
Closes #269

## Summary

The backend migrated search indexing from Meilisearch to OpenSearch in 1.2.0 (artifact-keeper/artifact-keeper#462). This PR is the investigation plus the concrete, high-value UI changes that migration calls for, answering the four questions in #269.

### Investigation findings

1. Response format: the `/search/advanced` shape is unchanged (items, pagination, facets) and the SDK types match. No breaking client changes were needed, but the UI was discarding parts of the existing response.
2. New capabilities now worth exposing:
   - Server-side sort honors `sort_by` plus `sort_order` (asc/desc) per field, and `sort_by` accepts `downloads` (alias `download_count`). The UI only ever sent `sort_by` and never the order or downloads.
   - `/search/advanced` returns facet aggregations (formats, repositories, content_types). The API adapter was dropping them entirely.
   - Results carry highlight snippets; the type modeled them but nothing rendered them.
3. Health endpoint: `/health` now exposes the search backend under `checks.opensearch` (it was `checks.meilisearch`). The web health adapter still read `meilisearch`, so after the backend upgrade the dashboard "Search Engine" card silently vanished.
4. Admin/dashboard status: the dashboard already renders a search-engine health card; the fix above restores it.

### Implemented changes

Search results UI (`search-content.tsx`):
- Relevance is now the default sort and sends no `sort_by`, letting OpenSearch apply its own ranking. Added a Downloads sort option.
- Added a sort-direction toggle that sends `sort_order=asc|desc`. It is disabled while sorting by relevance (no direction applies).
- Removed the client-side re-sort that only reordered the current page and contradicted the server ordering across pages.
- Render highlight snippets, parsing the `<em>` markers into React nodes instead of injecting raw HTML.
- Surface the formats and repositories facets as clickable refine chips that re-issue the search with the facet applied, plus a clear-filters control.

API + types:
- `searchApi.advancedSearch` now returns facets (`AdvancedSearchResult` widens `PaginatedResponse`).
- Health adapter reads `checks.opensearch` and falls back to `checks.meilisearch`; the dashboard reads whichever is present.

### Deferred (needs product input, noted not implemented)

- Saved searches and the broader property/GAVC filter model already exist as types but are out of scope here.
- Exposing the active search backend name (Meilisearch vs OpenSearch) as explicit UI copy was left out; the health card label stays the neutral "Search Engine". Surfacing engine identity or a reindex trigger in admin settings can follow once product decides whether to show it.

## Test Checklist
- [x] Unit tests added/updated
- [x] E2E Playwright tests added/updated
- [ ] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [x] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader)

The new sort controls and facet chips use semantic roles (`combobox` with `aria-label`, `aria-pressed` on facet toggles, `aria-label` describing the sort direction). New e2e spec: `e2e/suites/interactions/search/opensearch-search.spec.ts`.