### PR TITLE
Add package age policy and upload size limit configuration UIs

### DIFF
--- a/e2e/suites/interactions/admin/upload-size-limit.spec.ts
+++ b/e2e/suites/interactions/admin/upload-size-limit.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Configuration flow for the repository upload size limit (issue #189).
+ *
+ * The admin Settings -> Storage tab surfaces the current max upload size and
+ * lets an admin change it. The control reads from and writes to:
+ *   GET  /api/v1/admin/settings
+ *   POST /api/v1/admin/settings   (full SystemSettings body)
+ *
+ * Runs in CI against backend :1.2.0.
+ */
+test.describe('Admin - Upload Size Limit', () => {
+  test('admin settings expose and accept a new max upload size', async ({ request }) => {
+    const getResp = await request.get('/api/v1/admin/settings');
+    expect(getResp.ok(), `GET settings failed: ${getResp.status()}`).toBeTruthy();
+
+    const settings = await getResp.json();
+    expect(settings).toHaveProperty('max_upload_size_bytes');
+    const original = settings.max_upload_size_bytes;
+
+    // Send the whole object back with only the upload size changed, matching
+    // how the UI persists it (the POST replaces the full SystemSettings).
+    const target = 2 * 1024 * 1024 * 1024; // 2 GiB
+    const putResp = await request.post('/api/v1/admin/settings', {
+      data: { ...settings, max_upload_size_bytes: target },
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect(putResp.ok(), `POST settings failed: ${putResp.status()}`).toBeTruthy();
+
+    const verify = await request.get('/api/v1/admin/settings');
+    const after = await verify.json();
+    expect(after.max_upload_size_bytes).toBe(target);
+
+    // Restore the original value so the suite is idempotent.
+    await request
+      .post('/api/v1/admin/settings', {
+        data: { ...settings, max_upload_size_bytes: original },
+        headers: { 'Content-Type': 'application/json' },
+      })
+      .catch(() => {});
+  });
+
+  test('Storage tab shows an editable Max Upload Size control', async ({ page }) => {
+    await page.goto('/settings');
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForTimeout(2000);
+
+    const storageTab = page.getByRole('tab', { name: /storage/i }).first();
+    if (await storageTab.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await storageTab.click({ force: true });
+      await page.waitForTimeout(1000);
+    }
+
+    // The Max Upload Size label and its editable number input must be present.
+    await expect(page.getByText('Max Upload Size').first()).toBeVisible({
+      timeout: 10000,
+    });
+
+    const sizeInput = page.getByLabel('Max Upload Size');
+    await expect(sizeInput).toBeVisible({ timeout: 5000 });
+    await expect(sizeInput).toBeEditable();
+
+    // The unit selector and a Save button accompany the input.
+    await expect(
+      page.getByLabel('Upload size unit')
+    ).toBeVisible({ timeout: 5000 });
+
+    const body = await page.textContent('body');
+    expect(body).not.toContain('Application error');
+  });
+
+  test('saving a changed upload size issues a settings POST', async ({ page }) => {
+    await page.goto('/settings');
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForTimeout(2000);
+
+    const storageTab = page.getByRole('tab', { name: /storage/i }).first();
+    if (await storageTab.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await storageTab.click({ force: true });
+      await page.waitForTimeout(1000);
+    }
+
+    const sizeInput = page.getByLabel('Max Upload Size');
+    if (!(await sizeInput.isVisible({ timeout: 5000 }).catch(() => false))) {
+      test.skip(true, 'Upload size control not visible');
+      return;
+    }
+
+    // Capture the current value to restore later.
+    const originalValue = await sizeInput.inputValue();
+
+    await sizeInput.fill('512');
+
+    const postResponse = page.waitForResponse(
+      (r) =>
+        r.url().includes('/api/v1/admin/settings') &&
+        r.request().method() === 'POST',
+      { timeout: 10000 }
+    ).catch(() => null);
+
+    // The Save button next to the input. Scope to the upload-size row by
+    // finding the closest enabled "Save" button after editing.
+    await page.getByRole('button', { name: /^save$/i }).first().click();
+
+    const posted = await postResponse;
+    if (posted) {
+      expect(posted.status()).toBeLessThan(400);
+    }
+
+    // Best-effort restore via the UI so the next run starts clean.
+    if (originalValue) {
+      await sizeInput.fill(originalValue).catch(() => {});
+      await page.getByRole('button', { name: /^save$/i }).first().click().catch(() => {});
+    }
+  });
+});

--- a/e2e/suites/interactions/repositories/age-policy.spec.ts
+++ b/e2e/suites/interactions/repositories/age-policy.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Configuration flow for the package age policy (issue #265).
+ *
+ * The repo Settings tab exposes a "Package Age Policy" section that holds
+ * freshly published packages in quarantine for a cooldown window. Enabling it
+ * sends `quarantine_enabled` + `quarantine_duration_minutes` to:
+ *   PATCH /api/v1/repositories/{key}
+ *
+ * The age policy is most useful on remote (pull-through) repositories, so the
+ * seeded `e2e-npm-remote` repo is used. Runs in CI against backend :1.2.0.
+ */
+test.describe('Repository - Package Age Policy', () => {
+  const REPO_KEY = 'e2e-npm-remote';
+
+  test('PATCH stores the age policy on the repository', async ({ request }) => {
+    const resp = await request.fetch(`/api/v1/repositories/${REPO_KEY}`, {
+      method: 'PATCH',
+      data: { quarantine_enabled: true, quarantine_duration_minutes: 4320 },
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(
+      resp.ok(),
+      `Age policy update failed: ${resp.status()}`
+    ).toBeTruthy();
+
+    // Reset so the test is idempotent across runs.
+    await request
+      .fetch(`/api/v1/repositories/${REPO_KEY}`, {
+        method: 'PATCH',
+        data: { quarantine_enabled: false, quarantine_duration_minutes: 4320 },
+        headers: { 'Content-Type': 'application/json' },
+      })
+      .catch(() => {});
+  });
+
+  test('rejects a negative cooldown duration', async ({ request }) => {
+    const resp = await request.fetch(`/api/v1/repositories/${REPO_KEY}`, {
+      method: 'PATCH',
+      data: { quarantine_enabled: true, quarantine_duration_minutes: -10 },
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    // The backend validates the duration is non-negative.
+    expect(resp.status()).toBeGreaterThanOrEqual(400);
+  });
+
+  test('Settings tab exposes the age policy controls and saves', async ({ page }) => {
+    await page.goto(`/repositories/${REPO_KEY}`);
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForTimeout(3000);
+
+    const settingsTab = page.getByRole('tab', { name: /settings/i }).first();
+    const hasSettings = await settingsTab
+      .isVisible({ timeout: 10000 })
+      .catch(() => false);
+    test.skip(!hasSettings, 'Settings tab not visible (non-admin or repo missing)');
+
+    await settingsTab.click({ force: true });
+    await page.waitForTimeout(1500);
+
+    // The age policy section heading should be present.
+    await expect(
+      page.getByRole('heading', { name: /package age policy/i })
+    ).toBeVisible({ timeout: 5000 });
+
+    // The cooldown input starts disabled until the policy is enabled.
+    const cooldown = page.getByLabel('Cooldown period');
+    await expect(cooldown).toBeDisabled();
+
+    // Enable the policy via the toggle.
+    const enableToggle = page.getByLabel('Enable age policy');
+    await enableToggle.click();
+
+    await expect(cooldown).toBeEnabled({ timeout: 3000 });
+    await cooldown.fill('5');
+
+    // Save and confirm the request is accepted (toast or no error banner).
+    const saveResponse = page.waitForResponse(
+      (r) =>
+        r.url().includes(`/repositories/${REPO_KEY}`) &&
+        r.request().method() === 'PATCH',
+      { timeout: 10000 }
+    ).catch(() => null);
+
+    await page.getByRole('button', { name: /save age policy/i }).click();
+
+    const saved = await saveResponse;
+    if (saved) {
+      expect(saved.status()).toBeLessThan(400);
+    }
+
+    const body = await page.textContent('body');
+    expect(body).not.toContain('Application error');
+
+    // Reset to disabled so the suite stays idempotent.
+    await page
+      .request.fetch(`/api/v1/repositories/${REPO_KEY}`, {
+        method: 'PATCH',
+        data: { quarantine_enabled: false, quarantine_duration_minutes: 7200 },
+        headers: { 'Content-Type': 'application/json' },
+      })
+      .catch(() => {});
+  });
+});

--- a/src/app/(app)/(admin)/settings/__tests__/page.test.tsx
+++ b/src/app/(app)/(admin)/settings/__tests__/page.test.tsx
@@ -134,7 +134,7 @@ vi.mock("@/components/common/page-header", () => ({
 // Component under test
 // ---------------------------------------------------------------------------
 
-import SettingsPage from "../page";
+import SettingsPage, { bytesToUploadSize, uploadSizeToBytes } from "../page";
 import type { AdminSettings, SmtpConfig } from "@/lib/api/settings";
 import { ADMIN_SETTINGS_QUERY_KEY } from "@/hooks/use-admin-settings";
 
@@ -344,8 +344,10 @@ describe("SettingsPage", () => {
     const inputs = screen.getAllByRole("textbox") as HTMLInputElement[];
     expect(inputs.find((i) => i.value === "S3")).toBeDefined();
     expect(inputs.find((i) => i.value === "/data/storage")).toBeDefined();
-    // formatBytes from @/lib/utils renders 1 GiB as "1 GB" (no trailing .0).
-    expect(inputs.find((i) => i.value === "1 GB")).toBeDefined();
+    // Max Upload Size is now an editable number input (#189). 1 GiB shows
+    // as the value "1" with the unit selector set to GB.
+    const numberInputs = screen.getAllByRole("spinbutton") as HTMLInputElement[];
+    expect(numberInputs.find((i) => i.value === "1")).toBeDefined();
   });
 
   it("renders friendly storage backend labels", () => {
@@ -363,9 +365,10 @@ describe("SettingsPage", () => {
 
     const inputs = screen.getAllByRole("textbox") as HTMLInputElement[];
     expect(inputs.find((i) => i.value === "Local Filesystem")).toBeDefined();
-    // 0 bytes renders literally as "0 B" — we no longer invent an
-    // "Unlimited" semantic that isn't in the API contract.
-    expect(inputs.find((i) => i.value === "0 B")).toBeDefined();
+    // 0 bytes means "no limit" (#189): the editable number input is empty
+    // with the "No limit" placeholder.
+    const numberInputs = screen.getAllByRole("spinbutton") as HTMLInputElement[];
+    expect(numberInputs.find((i) => i.value === "")).toBeDefined();
   });
 
   it("falls back to raw storage backend value when label is unknown", () => {
@@ -383,7 +386,9 @@ describe("SettingsPage", () => {
 
     const inputs = screen.getAllByRole("textbox") as HTMLInputElement[];
     expect(inputs.find((i) => i.value === "minio")).toBeDefined();
-    expect(inputs.find((i) => i.value === "5 GB")).toBeDefined();
+    // 5 GiB shows as the value "5" in the editable number input (#189).
+    const numberInputs = screen.getAllByRole("spinbutton") as HTMLInputElement[];
+    expect(numberInputs.find((i) => i.value === "5")).toBeDefined();
   });
 
   it("shows Loading… in Storage fields while admin-settings is loading (#349)", () => {
@@ -801,10 +806,13 @@ describe("SettingsPage", () => {
   });
 
   it("disables Send Test Email button when test mutation is pending", () => {
+    // useMutation call order is: [1] upload-size save (storage tab, #189),
+    // [2] SMTP save, [3] send-test-email. The test-email mutation is the
+    // third call, so mark only that one pending.
     let mutationCallIndex = 0;
     mockUseMutation.mockImplementation(() => {
       mutationCallIndex++;
-      if (mutationCallIndex === 2) {
+      if (mutationCallIndex === 3) {
         return createMutationMock({ isPending: true });
       }
       return createMutationMock();
@@ -817,5 +825,42 @@ describe("SettingsPage", () => {
     const sendButtons = screen.getAllByText("Send Test Email");
     const sendButton = sendButtons.find((el) => el.closest("button"));
     expect(sendButton?.closest("button")?.disabled).toBe(true);
+  });
+});
+
+describe("upload size helpers (#189)", () => {
+  it("converts whole GB to value + GB unit", () => {
+    expect(bytesToUploadSize(5 * 1024 * 1024 * 1024)).toEqual({
+      value: "5",
+      unit: "GB",
+    });
+  });
+
+  it("falls back to MB for non-GB-aligned sizes", () => {
+    expect(bytesToUploadSize(100 * 1024 * 1024)).toEqual({
+      value: "100",
+      unit: "MB",
+    });
+  });
+
+  it("treats 0 bytes as no limit (empty value)", () => {
+    expect(bytesToUploadSize(0)).toEqual({ value: "", unit: "MB" });
+  });
+
+  it("converts a value + unit back to bytes", () => {
+    expect(uploadSizeToBytes("2", "GB")).toBe(2 * 1024 * 1024 * 1024);
+    expect(uploadSizeToBytes("250", "MB")).toBe(250 * 1024 * 1024);
+  });
+
+  it("returns 0 (no limit) for empty or invalid input", () => {
+    expect(uploadSizeToBytes("", "GB")).toBe(0);
+    expect(uploadSizeToBytes("-1", "MB")).toBe(0);
+    expect(uploadSizeToBytes("abc", "GB")).toBe(0);
+  });
+
+  it("round-trips through bytes -> size -> bytes", () => {
+    const original = 3 * 1024 * 1024 * 1024;
+    const { value, unit } = bytesToUploadSize(original);
+    expect(uploadSizeToBytes(value, unit)).toBe(original);
   });
 });

--- a/src/app/(app)/(admin)/settings/page.tsx
+++ b/src/app/(app)/(admin)/settings/page.tsx
@@ -8,7 +8,6 @@ import { adminApi } from "@/lib/api/admin";
 import { settingsApi } from "@/lib/api/settings";
 import { ADMIN_SETTINGS_QUERY_KEY, useAdminSettings } from "@/hooks/use-admin-settings";
 import { mutationErrorToast } from "@/lib/error-utils";
-import { formatBytes } from "@/lib/utils";
 import { Server, HardDrive, Lock, Info, Mail, Loader2 } from "lucide-react";
 
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
@@ -78,6 +77,126 @@ const STORAGE_BACKEND_LABELS: Record<string, string> = {
 
 function formatStorageBackend(backend: string): string {
   return STORAGE_BACKEND_LABELS[backend] ?? backend;
+}
+
+// -- Upload size limit editor (#189) --
+
+type UploadSizeUnit = "MB" | "GB";
+
+const BYTES_PER_MB = 1024 * 1024;
+const BYTES_PER_GB = 1024 * 1024 * 1024;
+
+/** Convert bytes to a friendly value + unit. 0 means "no limit". */
+export function bytesToUploadSize(bytes: number): { value: string; unit: UploadSizeUnit } {
+  if (!bytes || bytes <= 0) return { value: "", unit: "MB" };
+  if (bytes >= BYTES_PER_GB && bytes % BYTES_PER_GB === 0) {
+    return { value: String(bytes / BYTES_PER_GB), unit: "GB" };
+  }
+  return { value: String(Math.round(bytes / BYTES_PER_MB)), unit: "MB" };
+}
+
+/** Convert a value + unit to bytes. Empty/zero/invalid means "no limit" (0). */
+export function uploadSizeToBytes(value: string, unit: UploadSizeUnit): number {
+  const num = Number(value);
+  if (!num || num <= 0 || !Number.isFinite(num)) return 0;
+  return Math.round(num * (unit === "GB" ? BYTES_PER_GB : BYTES_PER_MB));
+}
+
+function UploadSizeSetting({
+  currentBytes,
+  loading,
+  unavailable,
+}: {
+  currentBytes: number | undefined;
+  loading: boolean;
+  unavailable: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const initial = bytesToUploadSize(currentBytes ?? 0);
+  const [value, setValue] = useState(initial.value);
+  const [unit, setUnit] = useState<UploadSizeUnit>(initial.unit);
+  const [dirty, setDirty] = useState(false);
+
+  const saveMutation = useMutation({
+    mutationFn: (bytes: number) => settingsApi.updateMaxUploadSize(bytes),
+    onSuccess: () => {
+      toast.success("Upload size limit saved");
+      queryClient.invalidateQueries({ queryKey: ADMIN_SETTINGS_QUERY_KEY });
+      setDirty(false);
+    },
+    onError: mutationErrorToast("Failed to save upload size limit"),
+  });
+
+  if (loading) {
+    return (
+      <SettingRow
+        label="Max Upload Size"
+        value="Loading..."
+        description="Maximum allowed size for a single artifact upload."
+      />
+    );
+  }
+
+  if (unavailable) {
+    return (
+      <SettingRow
+        label="Max Upload Size"
+        value="Unavailable"
+        description="Maximum allowed size for a single artifact upload."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor="max-upload-size" className="text-sm">
+        Max Upload Size
+      </Label>
+      <div className="flex gap-2">
+        <Input
+          id="max-upload-size"
+          type="number"
+          min={0}
+          step="any"
+          placeholder="No limit"
+          value={value}
+          onChange={(e) => {
+            setValue(e.target.value);
+            setDirty(true);
+          }}
+          className="flex-1"
+        />
+        <Select
+          value={unit}
+          onValueChange={(v) => {
+            setUnit(v as UploadSizeUnit);
+            setDirty(true);
+          }}
+        >
+          <SelectTrigger className="w-20" aria-label="Upload size unit">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="MB">MB</SelectItem>
+            <SelectItem value="GB">GB</SelectItem>
+          </SelectContent>
+        </Select>
+        <Button
+          onClick={() => saveMutation.mutate(uploadSizeToBytes(value, unit))}
+          disabled={saveMutation.isPending || !dirty}
+        >
+          {saveMutation.isPending && (
+            <Loader2 className="size-4 mr-2 animate-spin" />
+          )}
+          Save
+        </Button>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Maximum allowed size for a single artifact upload. Leave empty for no
+        limit. Applies to every repository.
+      </p>
+    </div>
+  );
 }
 
 // -- SMTP settings tab --
@@ -539,10 +658,10 @@ export default function SettingsPage() {
                 description="The filesystem path where artifact files are stored (when storage backend is local)."
               />
               <Separator />
-              <SettingRow
-                label="Max Upload Size"
-                value={storageValue((s) => formatBytes(s.max_upload_size_bytes))}
-                description="Maximum allowed size for a single artifact upload."
+              <UploadSizeSetting
+                currentBytes={storageSettings?.max_upload_size_bytes}
+                loading={settingsLoading}
+                unavailable={settingsError || !storageSettings}
               />
               <Separator />
               {/* TODO(#334): swap for storageSettings.deduplication once the backend

--- a/src/app/(app)/repositories/_components/repo-settings-tab.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-settings-tab.test.tsx
@@ -37,10 +37,18 @@ vi.mock("sonner", () => ({
 
 // Mock repositories API
 const mockUpdate = vi.fn();
+const mockUpdateAgePolicy = vi.fn();
 vi.mock("@/lib/api/repositories", () => ({
   repositoriesApi: {
     update: (...args: unknown[]) => mockUpdate(...args),
+    updateAgePolicy: (...args: unknown[]) => mockUpdateAgePolicy(...args),
   },
+}));
+
+// Mock the shared admin-settings hook (used for the read-only upload limit, #189)
+const mockUseAdminSettings = vi.fn();
+vi.mock("@/hooks/use-admin-settings", () => ({
+  useAdminSettings: () => mockUseAdminSettings(),
 }));
 
 // Mock lifecycle API
@@ -207,6 +215,19 @@ const baseRepo: Repository = {
   created_at: "2024-01-15T10:00:00Z",
   updated_at: "2024-06-20T14:30:00Z",
 };
+
+// Default admin-settings return: upload limit available. Individual tests can
+// override. clearAllMocks() preserves this implementation (it only clears
+// call history), so it survives the per-describe beforeEach hooks.
+mockUseAdminSettings.mockReturnValue({
+  data: {
+    storageSettings: {
+      storage_backend: "filesystem",
+      storage_path: "/data",
+      max_upload_size_bytes: 1073741824,
+    },
+  },
+});
 
 function createWrapper() {
   const client = new QueryClient({
@@ -749,5 +770,138 @@ describe("RepoSettingsTab - Quota unit switching", () => {
     // Should now show unsaved changes since unit changed
     // (the actual bytes value differs because 10 GB != 10 MB)
     expect(screen.getByText("You have unsaved changes")).toBeTruthy();
+  });
+});
+
+import { ageToMinutes } from "./repo-settings-tab";
+
+describe("ageToMinutes helper", () => {
+  it("converts days to minutes", () => {
+    expect(ageToMinutes("3", "days")).toBe(4320);
+  });
+
+  it("converts hours to minutes", () => {
+    expect(ageToMinutes("12", "hours")).toBe(720);
+  });
+
+  it("returns 0 for empty, zero, or negative input", () => {
+    expect(ageToMinutes("", "days")).toBe(0);
+    expect(ageToMinutes("0", "hours")).toBe(0);
+    expect(ageToMinutes("-5", "days")).toBe(0);
+  });
+
+  it("rounds fractional values to whole minutes", () => {
+    expect(ageToMinutes("1.5", "hours")).toBe(90);
+  });
+});
+
+describe("RepoSettingsTab - Package Age Policy (#265)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListPolicies.mockResolvedValue([]);
+  });
+
+  it("renders the age policy section with an enable toggle", () => {
+    render(<RepoSettingsTab repository={baseRepo} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByText("Package Age Policy")).toBeTruthy();
+    expect(screen.getByLabelText("Enable age policy")).toBeTruthy();
+  });
+
+  it("keeps the cooldown input disabled until the policy is enabled", () => {
+    render(<RepoSettingsTab repository={baseRepo} />, {
+      wrapper: createWrapper(),
+    });
+
+    const duration = screen.getByLabelText("Cooldown period") as HTMLInputElement;
+    expect(duration.disabled).toBe(true);
+  });
+
+  it("saves the age policy with the configured duration in minutes", async () => {
+    mockUpdateAgePolicy.mockResolvedValue(undefined);
+    const user = userEvent.setup();
+
+    render(<RepoSettingsTab repository={baseRepo} />, {
+      wrapper: createWrapper(),
+    });
+
+    await user.click(screen.getByLabelText("Enable age policy"));
+
+    const duration = screen.getByLabelText("Cooldown period");
+    await user.clear(duration);
+    await user.type(duration, "7");
+
+    await user.click(screen.getByRole("button", { name: /save age policy/i }));
+
+    await waitFor(() => {
+      expect(mockUpdateAgePolicy).toHaveBeenCalledWith("maven-releases", {
+        enabled: true,
+        duration_minutes: 10080,
+      });
+    });
+  });
+
+  it("disables save and shows an error when the duration is invalid", async () => {
+    const user = userEvent.setup();
+
+    render(<RepoSettingsTab repository={baseRepo} />, {
+      wrapper: createWrapper(),
+    });
+
+    await user.click(screen.getByLabelText("Enable age policy"));
+
+    const duration = screen.getByLabelText("Cooldown period");
+    await user.clear(duration);
+
+    const saveBtn = screen.getByRole("button", { name: /save age policy/i });
+    expect((saveBtn as HTMLButtonElement).disabled).toBe(true);
+    expect(mockUpdateAgePolicy).not.toHaveBeenCalled();
+  });
+});
+
+describe("RepoSettingsTab - Upload size limit display (#189)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListPolicies.mockResolvedValue([]);
+    mockUseAdminSettings.mockReturnValue({
+      data: {
+        storageSettings: {
+          storage_backend: "filesystem",
+          storage_path: "/data",
+          max_upload_size_bytes: 1073741824,
+        },
+      },
+    });
+  });
+
+  it("shows the effective upload size limit read-only", () => {
+    render(<RepoSettingsTab repository={baseRepo} />, {
+      wrapper: createWrapper(),
+    });
+
+    const limit = screen.getByLabelText("Upload size limit") as HTMLInputElement;
+    expect(limit.value).toBe("1.0 GB");
+    expect(limit.disabled).toBe(true);
+  });
+
+  it("shows 'No limit' when the configured limit is zero", () => {
+    mockUseAdminSettings.mockReturnValue({
+      data: {
+        storageSettings: {
+          storage_backend: "filesystem",
+          storage_path: "/data",
+          max_upload_size_bytes: 0,
+        },
+      },
+    });
+
+    render(<RepoSettingsTab repository={baseRepo} />, {
+      wrapper: createWrapper(),
+    });
+
+    const limit = screen.getByLabelText("Upload size limit") as HTMLInputElement;
+    expect(limit.value).toBe("No limit");
   });
 });

--- a/src/app/(app)/repositories/_components/repo-settings-tab.tsx
+++ b/src/app/(app)/repositories/_components/repo-settings-tab.tsx
@@ -6,6 +6,7 @@ import { Loader2, AlertTriangle, Trash2, Play, Eye } from "lucide-react";
 import { toast } from "sonner";
 
 import { repositoriesApi } from "@/lib/api/repositories";
+import { useAdminSettings } from "@/hooks/use-admin-settings";
 import lifecycleApi from "@/lib/api/lifecycle";
 import { mutationErrorToast } from "@/lib/error-utils";
 import { formatBytes } from "@/lib/utils";
@@ -47,6 +48,19 @@ import {
 } from "@/components/ui/alert-dialog";
 
 type QuotaUnit = "MB" | "GB";
+
+type AgeUnit = "hours" | "days";
+
+const MINUTES_PER_HOUR = 60;
+const MINUTES_PER_DAY = 1440;
+
+/** Convert an age value and unit to whole minutes. Clamps negatives to 0. */
+export function ageToMinutes(value: string, unit: AgeUnit): number {
+  const num = Number(value);
+  if (!num || num <= 0 || !Number.isFinite(num)) return 0;
+  const factor = unit === "days" ? MINUTES_PER_DAY : MINUTES_PER_HOUR;
+  return Math.round(num * factor);
+}
 
 export interface UpdateRepositoryFields {
   key?: string;
@@ -200,6 +214,37 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
     onError: mutationErrorToast("Failed to preview cleanup policy"),
   });
 
+  // -- Package age policy (#265). Quarantine-on-release for remote repos. --
+  const [ageEnabled, setAgeEnabled] = useState(false);
+  const [ageValue, setAgeValue] = useState("3");
+  const [ageUnit, setAgeUnit] = useState<AgeUnit>("days");
+
+  const ageMinutes = ageToMinutes(ageValue, ageUnit);
+  const ageInvalid = ageEnabled && ageMinutes <= 0;
+
+  const ageMutation = useMutation({
+    mutationFn: () =>
+      repositoriesApi.updateAgePolicy(repository.key, {
+        enabled: ageEnabled,
+        duration_minutes: ageMinutes,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["repository", repository.key] });
+      toast.success(
+        ageEnabled
+          ? "Package age policy enabled"
+          : "Package age policy disabled"
+      );
+    },
+    onError: mutationErrorToast("Failed to save package age policy"),
+  });
+
+  // -- Effective upload size limit (#189). Read-only here; configured by an
+  // admin on the global Settings page. Surfaced so repo owners can see the
+  // ceiling that applies to uploads into this repository. --
+  const { data: adminSettings } = useAdminSettings();
+  const maxUploadBytes = adminSettings?.storageSettings.max_upload_size_bytes;
+
   return (
     <div className="max-w-2xl space-y-8">
       {/* -- General Settings Section -- */}
@@ -337,6 +382,114 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
             <p className="text-xs text-muted-foreground">
               Maximum storage for this repository. Leave empty for no limit.
             </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Upload Size Limit</Label>
+            <Input
+              value={
+                maxUploadBytes == null
+                  ? "Loading..."
+                  : maxUploadBytes === 0
+                    ? "No limit"
+                    : formatBytes(maxUploadBytes)
+              }
+              disabled
+              className="bg-muted/50"
+              aria-label="Upload size limit"
+            />
+            <p className="text-xs text-muted-foreground">
+              Maximum size for a single artifact upload. This limit is set
+              instance-wide by an administrator on the Settings page and applies
+              to every repository.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <Separator />
+
+      {/* -- Package Age Policy Section (#265) -- */}
+      <section aria-labelledby="settings-age-heading">
+        <div className="mb-4">
+          <h3 id="settings-age-heading" className="text-base font-semibold">
+            Package Age Policy
+          </h3>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Hold freshly published packages in quarantine for a cooldown period
+            after their release. New releases pulled from upstream are not served
+            until the window passes, giving time to flag a compromised release
+            before it reaches clients.
+          </p>
+        </div>
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label htmlFor="settings-age-enabled">Enable age policy</Label>
+              <p className="text-xs text-muted-foreground">
+                Quarantine packages released within the cooldown window.
+              </p>
+            </div>
+            <Switch
+              id="settings-age-enabled"
+              checked={ageEnabled}
+              onCheckedChange={setAgeEnabled}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="settings-age-duration">Cooldown period</Label>
+            <div className="flex gap-2">
+              <Input
+                id="settings-age-duration"
+                type="number"
+                min="1"
+                step="1"
+                value={ageValue}
+                onChange={(e) => setAgeValue(e.target.value)}
+                disabled={!ageEnabled}
+                className="flex-1"
+                aria-invalid={ageInvalid}
+              />
+              <Select
+                value={ageUnit}
+                onValueChange={(v) => setAgeUnit(v as AgeUnit)}
+                disabled={!ageEnabled}
+              >
+                <SelectTrigger className="w-28">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="hours">Hours</SelectItem>
+                  <SelectItem value="days">Days</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            {ageInvalid ? (
+              <p className="text-sm text-destructive">
+                Enter a cooldown period of at least one {ageUnit === "days" ? "day" : "hour"}.
+              </p>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                Packages released less than this long ago are quarantined.
+              </p>
+            )}
+          </div>
+
+          <div className="flex justify-end">
+            <Button
+              onClick={() => ageMutation.mutate()}
+              disabled={ageMutation.isPending || ageInvalid}
+            >
+              {ageMutation.isPending ? (
+                <>
+                  <Loader2 className="size-4 animate-spin" />
+                  Saving...
+                </>
+              ) : (
+                "Save Age Policy"
+              )}
+            </Button>
           </div>
         </div>
       </section>

--- a/src/lib/api/repositories.ts
+++ b/src/lib/api/repositories.ts
@@ -47,6 +47,25 @@ export interface UpstreamAuthPayload {
   password?: string;
 }
 
+/**
+ * Package age policy for a repository (issue #265, backend
+ * artifact-keeper/artifact-keeper#709).
+ *
+ * When enabled, freshly published artifacts pulled through a remote repository
+ * are held in quarantine for `duration_minutes` after their release. This gives
+ * a window for a compromised upstream release to be flagged before it can be
+ * served, mitigating supply-chain attacks (e.g. the Trivy incident).
+ *
+ * Stored server-side in `repository_config` under `quarantine_enabled` and
+ * `quarantine_duration_minutes`. These fields are written via the repository
+ * update endpoint but are not part of the SDK-generated `UpdateRepositoryRequest`
+ * yet, so this module sends them through `apiFetch` directly.
+ */
+export interface AgePolicyPayload {
+  enabled: boolean;
+  duration_minutes: number;
+}
+
 const REPO_TYPES = new Set<RepositoryType>(['local', 'remote', 'virtual', 'staging']);
 
 const REPO_FORMATS = new Set<RepositoryFormat>([
@@ -252,6 +271,26 @@ export const repositoriesApi = {
   testUpstream: async (repoKey: string): Promise<{ success: boolean; message?: string }> => {
     return apiFetch(`/api/v1/repositories/${encodeURIComponent(repoKey)}/test-upstream`, {
       method: 'POST',
+    });
+  },
+
+  /**
+   * Configure the package age policy (quarantine-on-release) for a repository.
+   *
+   * Sends `quarantine_enabled` and `quarantine_duration_minutes` to the
+   * repository update endpoint. Uses `apiFetch` rather than the SDK because
+   * those fields are not in the generated `UpdateRepositoryRequest` yet.
+   *
+   * When `enabled` is false, the duration is still sent so the stored value is
+   * preserved and re-enabling does not lose the previously configured window.
+   */
+  updateAgePolicy: async (repoKey: string, payload: AgePolicyPayload): Promise<void> => {
+    await apiFetch<void>(`/api/v1/repositories/${encodeURIComponent(repoKey)}`, {
+      method: 'PATCH',
+      body: JSON.stringify({
+        quarantine_enabled: payload.enabled,
+        quarantine_duration_minutes: payload.duration_minutes,
+      }),
     });
   },
 };

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -287,6 +287,32 @@ export const settingsApi = {
   },
 
   /**
+   * Update the maximum upload size (issue #189).
+   *
+   * The backend `POST /api/v1/admin/settings` endpoint replaces the whole
+   * `SystemSettings` object, so this reads the current settings first and
+   * sends them back with only `max_upload_size_bytes` changed. This avoids
+   * resetting sibling values (retention, anonymous download, etc.) that the
+   * caller did not intend to touch.
+   *
+   * `bytes` of 0 means "no limit", matching the backend semantics.
+   */
+  updateMaxUploadSize: async (bytes: number): Promise<void> => {
+    const { data, error } = await getSettings();
+    if (error) {
+      throw new Error(`Failed to load current settings: ${String(error)}`);
+    }
+    if (!isPlainObject(data)) {
+      throw new Error("System settings response was not an object");
+    }
+    const payload = { ...data, max_upload_size_bytes: bytes };
+    await apiFetch<void>("/api/v1/admin/settings", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+  },
+
+  /**
    * Save SMTP configuration. Uses the /api/v1/admin/smtp endpoint which
    * is not yet in the generated SDK.
    */


### PR DESCRIPTION
## Summary

Adds two repository configuration surfaces for v1.2.0.

**Package age policy (#265)** — a "Package Age Policy" section on the repo Settings tab. When enabled, freshly published packages pulled through a remote repository are held in quarantine for a configurable cooldown window (hours or days). This gives time to flag a compromised upstream release before it reaches clients, mitigating supply-chain attacks. The toggle and duration are written to `PATCH /api/v1/repositories/{key}` as `quarantine_enabled` and `quarantine_duration_minutes` (the per-repo keys the backend stores in `repository_config`, per artifact-keeper/artifact-keeper#709). These fields are not in the generated SDK yet, so the call goes through `apiFetch`, matching the existing pattern for upstream-auth and test-upstream.

**Upload size limit (#189)** — the admin Settings -> Storage tab previously showed Max Upload Size read-only. It is now editable (numeric value + MB/GB unit selector + Save), persisted via `POST /api/v1/admin/settings`. Because that endpoint replaces the whole `SystemSettings` object, the save reads current settings first and sends them back with only `max_upload_size_bytes` changed, so sibling values are preserved. The repo Settings tab also surfaces the effective limit read-only so repo owners can see the instance-wide ceiling that applies to uploads.

## Test Checklist
- [x] Unit tests added/updated
- [x] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [x] Playwright E2E spec covers the change
- [x] Responsive layout verified (mobile + desktop)
- [x] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes

Closes #265
Closes #189