### PR TITLE
test(auth): wait for authenticated state before changePassword

### DIFF
--- a/src/providers/__tests__/auth-provider.test.tsx
+++ b/src/providers/__tests__/auth-provider.test.tsx
@@ -287,6 +287,7 @@ describe("AuthProvider", () => {
     );
 
     await waitFor(() => {
+      expect(screen.getByTestId("authenticated").textContent).toBe("true");
       expect(screen.getByTestId("expires-at").textContent).toBe(expiresAt);
       expect(screen.getByTestId("must-change").textContent).toBe("true");
     });


### PR DESCRIPTION
## Summary
Fixes a flaky unit test in `src/providers/__tests__/auth-provider.test.tsx`. The test `clears passwordExpiresAt after changing password` waited only for `expires-at` and `must-change` to commit before calling `changePassword` on the captured auth context. `changePassword` guards on `user` being set (`if (!user) throw "Not authenticated"`), which is not guaranteed at the moment those test IDs commit, so under CI timing the call intermittently threw "Not authenticated".

This adds one assertion inside the existing `waitFor` to also wait for the authenticated state to settle (`authenticated` === "true") before calling `changePassword`, matching the sibling init test `sets passwordExpiresAt from user data on init when authenticated` that already asserts authenticated state.

Test-only change. No source files were modified; the product guard in `auth-provider.tsx` is correct and unchanged.

Validation (local):
- `eslint` on the file: 0 errors
- `tsc --noEmit`: only the 2 pre-existing errors (docker-grouping.test.ts, security.test.ts), none introduced by this change
- `vitest run` on the file 3 times: 9/9 passing each run

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [x] N/A - no UI changes

Closes #467