### PR TITLE
fix(repositories): seed routing rules table from initial server fetch

### DIFF
--- a/src/app/(app)/repositories/_components/routing-rules-settings.test.tsx
+++ b/src/app/(app)/repositories/_components/routing-rules-settings.test.tsx
@@ -86,16 +86,29 @@ describe("RoutingRulesSettings", () => {
     expect(await screen.findByText(/No routing rules configured/i)).toBeInTheDocument();
   });
 
-  // Helper: the editable table is populated from a save response (the
-  // component does not seed it from the initial server fetch while a length
-  // mismatch keeps the local copy "dirty"). Adding a rule via the mutation is
-  // the reliable way to get rows into the table.
+  // Helper: add a rule via the save mutation and assert the returned set
+  // lands in the editable table. The table also seeds from the initial server
+  // fetch (see the dedicated test below); this helper covers the add path.
   async function addRule(pattern: string, rewrite: string, returnedRules: { path_pattern: string; rewrite_to: string }[]) {
     mockSetRoutingRules.mockResolvedValueOnce({ repository_key: "npm-proxy", rules: returnedRules });
     fireEvent.change(screen.getByLabelText("Path pattern"), { target: { value: pattern } });
     fireEvent.change(screen.getByLabelText("Rewrite to"), { target: { value: rewrite } });
     fireEvent.click(screen.getByText("Add rule").closest("button")!);
   }
+
+  it("seeds the editable table from the initial server fetch", async () => {
+    mockGetRoutingRules.mockResolvedValue({
+      repository_key: "npm-proxy",
+      rules: [
+        { path_pattern: "releases/(.+)", rewrite_to: "download/$1" },
+        { path_pattern: "snapshots/(.+)", rewrite_to: "dev/$1" },
+      ],
+    });
+    renderWith();
+    expect(await screen.findByLabelText("Rule 1 path pattern")).toHaveValue("releases/(.+)");
+    expect(screen.getByLabelText("Rule 1 rewrite to")).toHaveValue("download/$1");
+    expect(screen.getByLabelText("Rule 2 path pattern")).toHaveValue("snapshots/(.+)");
+  });
 
   it("populates the editable table from a save response", async () => {
     mockGetRoutingRules.mockResolvedValue({ repository_key: "npm-proxy", rules: [] });

--- a/src/app/(app)/repositories/_components/routing-rules-settings.tsx
+++ b/src/app/(app)/repositories/_components/routing-rules-settings.tsx
@@ -66,13 +66,20 @@ export function RoutingRulesSettings({ repository }: RoutingRulesSettingsProps) 
   // Whether the locally edited rules differ from the server copy. Computed
   // before the resync below so the resync can avoid clobbering unsaved edits.
   const serverRules = data?.rules ?? [];
+  // `dirty` is only meaningful after the first sync. Before the initial seed
+  // (syncedRef === null), local `rules` is still [] while the server may already
+  // have rules, so a raw length/content comparison would report dirty and the
+  // `!dirty` guard below would block the seed, leaving the table empty. Gating
+  // on syncedRef !== null lets the initial seed run, then resumes protecting
+  // unsaved edits once a sync has happened.
   const dirty =
-    serverRules.length !== rules.length ||
-    rules.some(
-      (rule, i) =>
-        rule.path_pattern !== serverRules[i]?.path_pattern ||
-        rule.rewrite_to !== serverRules[i]?.rewrite_to
-    );
+    syncedRef !== null &&
+    (serverRules.length !== rules.length ||
+      rules.some(
+        (rule, i) =>
+          rule.path_pattern !== serverRules[i]?.path_pattern ||
+          rule.rewrite_to !== serverRules[i]?.rewrite_to
+      ));
 
   // Resync only when there are no unsaved edits. React Query hands back a fresh
   // array reference on every refetch (e.g. window focus) even when the content


### PR DESCRIPTION
## Summary

On a repository Settings tab, the Routing Rules table rendered empty on first load even when the server already had rules configured.

The component keeps a local editable copy of the rule list (initial `useState([])`) and resyncs from the server query using the "adjust state during render" pattern, guarded by a `dirty` check so the resync does not clobber unsaved edits. On initial load the server returns a non-empty list while the local copy is still `[]`, so `dirty` reported `true` on the length mismatch alone (as if the user had deleted every rule) and the `!dirty` guard blocked the initial seed.

`dirty` is only meaningful after the first sync. This gates the `dirty` computation on `syncedRef !== null` so the initial seed always runs, then `dirty` resumes protecting unsaved edits exactly as before:

- Initial load (`syncedRef === null`): dirty is false, seed runs.
- After seeding, user empties the list while the server still has rules: `syncedRef !== null` and lengths differ, dirty is true, seed skipped, edits preserved.
- Refetch returning an equal-but-new array reference: dirty is false, resync updates `syncedRef`.

Before the first sync the save bar (`dirty && rules.length > 0`) stays hidden, which is correct.

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [ ] Manually tested locally
- [x] No regressions in existing tests

Added a regression test (`seeds the editable table from the initial server fetch`) that fails against the old logic and passes with the fix. The existing 12 tests in the file still pass. Verified by temporarily reverting the source change: only the new test failed.

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [x] N/A - no UI changes

No markup or styling changes; the fix is purely in the state-seeding logic.

Closes #468