### PR TITLE
Replacing Maven detail popup GAV Version by Version

### DIFF
--- a/src/app/(app)/repositories/_components/repo-detail-content.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.tsx
@@ -1138,7 +1138,7 @@ function MavenGavSection({ path }: { path: string }) {
     <div data-testid="maven-gav-section" className="space-y-3">
       <DetailRow label="Group ID" value={gav.groupId} copy mono />
       <DetailRow label="Artifact ID" value={gav.artifactId} copy mono />
-      <DetailRow label="GAV Version" value={gav.version} copy mono />
+      <DetailRow label="Version" value={gav.version} copy mono />
       <div>
         <div className="mb-1 flex items-center justify-between">
           <p className="text-xs font-medium text-muted-foreground">


### PR DESCRIPTION
## Summary
Replacing the label `GAV Version`by `Version` inside the Maven artifact detail popup

## Test Checklist
- [ ] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [ ] Manually tested locally
- [ ] No regressions in existing tests

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes
