### PR TITLE
fix(repositories): drop /simple suffix from default PyPI upstream URL

### DIFF
--- a/src/app/(app)/repositories/_components/repo-dialogs.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-dialogs.test.tsx
@@ -1454,7 +1454,7 @@ describe('RepoDialogs - Default Upstream URL', () => {
     const latestSelects = within(dialog).getAllByTestId('mock-select');
     fireEvent.change(latestSelects[0], { target: { value: 'pypi' } });
 
-    expect(urlInput.value).toBe('https://pypi.org/simple');
+    expect(urlInput.value).toBe('https://pypi.org');
   });
 
   it('does not overwrite user-modified URL when format changes', async () => {

--- a/src/app/(app)/repositories/_lib/default-upstream-urls.ts
+++ b/src/app/(app)/repositories/_lib/default-upstream-urls.ts
@@ -3,7 +3,7 @@ export const DEFAULT_UPSTREAM_URLS: Record<string, string> = {
   maven: "https://repo.maven.apache.org/maven2",
   gradle: "https://repo.maven.apache.org/maven2",
   npm: "https://registry.npmjs.org",
-  pypi: "https://pypi.org/simple",
+  pypi: "https://pypi.org",
   docker: "https://registry-1.docker.io",
   nuget: "https://api.nuget.org/v3/index.json",
   cargo: "https://index.crates.io",


### PR DESCRIPTION
## Summary
fix(repositories): drop /simple suffix from default PyPI upstream URL                                                                                                                                                             
                                                                                                                                                                                                                                    The backend appends `/simple/<pkg>/` itself when proxying. With the                                                                                                                                                   suffix in the default value, the URL becomes `https://pypi.org/simple/simple/<pkg>/`                                                                                                                                         and the remote can't fetch any packages.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [ ] Manually tested locally
- [ ] No regressions in existing tests

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [x] N/A - no UI changes

Closes #484 
