### PR TITLE
chore(release): bump version to 1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artifact-keeper-web",
-  "version": "1.1.3",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artifact-keeper-web",
-      "version": "1.1.3",
+      "version": "1.2.1",
       "dependencies": {
         "@artifact-keeper/sdk": "^1.1.6",
         "@hookform/resolvers": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-keeper-web",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Web version bump for **v1.2.1**. `package.json` `1.2.0`→`1.2.1` (drives `NEXT_PUBLIC_APP_VERSION` → the UI sidebar "Web" version); lockfile root synced (was skewed at `1.1.3`). After merge, tag `v1.2.1` here to publish `artifact-keeper-web:1.2.1`.