### PR TITLE
fix(repositories): refetch on login (#487) and error state on list failure (#478)

### DIFF
--- a/src/app/(app)/repositories/_components/repositories-content.tsx
+++ b/src/app/(app)/repositories/_components/repositories-content.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback, useDeferredValue, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Plus, Search, RefreshCw, Package } from "lucide-react";
+import { Plus, Search, RefreshCw, Package, AlertCircle } from "lucide-react";
 import { toast } from "sonner";
 import { repositoriesApi, type UpstreamAuthPayload } from "@/lib/api/repositories";
 import { searchApi } from "@/lib/api/search";
@@ -76,7 +76,7 @@ export function RepositoriesContent() {
   }>({ state: "idle" });
 
   // --- query ---
-  const { data, isLoading, isFetching } = useQuery({
+  const { data, isLoading, isFetching, isError, error, refetch } = useQuery({
     queryKey: [
       "repositories",
       formatFilter === "__all__" ? undefined : formatFilter,
@@ -336,7 +336,32 @@ export function RepositoriesContent() {
             ))}
           </div>
         )}
-        {!isLoading && filtered.length === 0 && (
+        {/* #478: a failed list request must be visually distinct from a
+            genuinely empty install, otherwise a transient backend outage reads
+            as "all repositories were deleted". */}
+        {!isLoading && isError && filtered.length === 0 && (
+          <div
+            className="flex flex-col items-center justify-center py-12 px-6 text-center text-muted-foreground"
+            role="alert"
+          >
+            <AlertCircle className="size-8 mb-2 text-destructive opacity-80" />
+            <p className="text-sm font-medium text-foreground">Couldn&apos;t load repositories</p>
+            <p className="mt-1 text-xs max-w-sm">
+              {toUserMessage(error, "The server could not be reached. Your repositories are safe.")}
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              className="mt-4"
+              onClick={() => refetch()}
+              disabled={isFetching}
+            >
+              <RefreshCw className={`size-4 ${isFetching ? "animate-spin" : ""}`} />
+              Retry
+            </Button>
+          </div>
+        )}
+        {!isLoading && !isError && filtered.length === 0 && (
           <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
             <Package className="size-8 mb-2 opacity-50" />
             <p className="text-sm">No repositories found.</p>

--- a/src/app/(app)/repositories/page.test.tsx
+++ b/src/app/(app)/repositories/page.test.tsx
@@ -19,12 +19,20 @@ vi.mock('next/navigation', () => ({
 }));
 
 let useQueryCallIndex = 0;
+const DEFAULT_FIRST_QUERY: Record<string, unknown> = {
+  data: { items: [], pagination: { total_pages: 1 } },
+  isLoading: false,
+  isFetching: false,
+};
+// The repositories-list query result (first useQuery call). Overridable per
+// test — e.g. to simulate a failed request (#478).
+let firstQueryResult: Record<string, unknown> = DEFAULT_FIRST_QUERY;
 vi.mock('@tanstack/react-query', () => ({
   useQuery: () => {
     const idx = useQueryCallIndex++;
     if (idx === 0) {
       // repositories list
-      return { data: { items: [], pagination: { total_pages: 1 } }, isLoading: false, isFetching: false };
+      return firstQueryResult;
     }
     // artifact search + extra repos queries return undefined data
     return { data: undefined, isLoading: false, isFetching: false };
@@ -187,6 +195,7 @@ describe('RepositoriesPage - rendering', () => {
     mutationConfigs.length = 0;
     useQueryCallIndex = 0;
     repoListItemCalls = [];
+    firstQueryResult = DEFAULT_FIRST_QUERY;
 
     vi.clearAllMocks();
   });
@@ -215,6 +224,24 @@ describe('RepositoriesPage - rendering', () => {
   it('shows empty state when no repositories', async () => {
     const { container } = await renderPage();
     expect(container.textContent).toContain('No repositories found');
+  });
+
+  // #478: a failed list request must render a distinct error state with a
+  // retry affordance, never the "no repositories" empty state (which reads as
+  // data loss during a backend outage).
+  it('shows an error state, not the empty state, when the list request fails', async () => {
+    firstQueryResult = {
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: true,
+      error: new Error('Network down'),
+      refetch: vi.fn(),
+    };
+    const { container } = await renderPage();
+    expect(container.textContent).toContain("Couldn't load repositories");
+    expect(container.textContent).not.toContain('No repositories found');
+    expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent?.includes('Retry'))).toBe(true);
   });
 
   it('shows detail panel placeholder', async () => {

--- a/src/providers/__tests__/auth-provider.test.tsx
+++ b/src/providers/__tests__/auth-provider.test.tsx
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import { render, screen, cleanup, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
 
 // ---------------------------------------------------------------------------
@@ -70,6 +71,16 @@ function TestConsumer() {
   );
 }
 
+// AuthProvider calls useQueryClient (to invalidate auth-scoped queries on
+// login/logout, #487), so every render must sit under a QueryClientProvider —
+// as it does in production (src/providers/index.tsx).
+function renderWithQuery(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -101,7 +112,7 @@ describe("AuthProvider", () => {
   });
 
   it("starts in loading state and then resolves", async () => {
-    render(
+    renderWithQuery(
       <AuthProvider>
         <TestConsumer />
       </AuthProvider>
@@ -128,7 +139,7 @@ describe("AuthProvider", () => {
       error: null,
     });
 
-    render(
+    renderWithQuery(
       <AuthProvider>
         <TestConsumer />
       </AuthProvider>
@@ -154,7 +165,7 @@ describe("AuthProvider", () => {
       error: null,
     });
 
-    render(
+    renderWithQuery(
       <AuthProvider>
         <TestConsumer />
       </AuthProvider>
@@ -180,7 +191,7 @@ describe("AuthProvider", () => {
       error: null,
     });
 
-    render(
+    renderWithQuery(
       <AuthProvider>
         <TestConsumer />
       </AuthProvider>
@@ -208,7 +219,7 @@ describe("AuthProvider", () => {
       error: null,
     });
 
-    render(
+    renderWithQuery(
       <AuthProvider>
         <TestConsumer />
       </AuthProvider>
@@ -247,7 +258,7 @@ describe("AuthProvider", () => {
     });
     mockSdkLogout.mockResolvedValue({});
 
-    render(
+    renderWithQuery(
       <AuthProvider>
         <TestConsumer />
       </AuthProvider>
@@ -280,7 +291,7 @@ describe("AuthProvider", () => {
     });
     mockSdkChangePassword.mockResolvedValue({ error: null });
 
-    render(
+    renderWithQuery(
       <AuthProvider>
         <TestConsumer />
       </AuthProvider>
@@ -333,7 +344,7 @@ describe("AuthProvider", () => {
       error: null,
     });
 
-    render(
+    renderWithQuery(
       <AuthProvider>
         <TestConsumer />
       </AuthProvider>

--- a/src/providers/auth-provider.tsx
+++ b/src/providers/auth-provider.tsx
@@ -8,6 +8,7 @@ import {
   useCallback,
   type ReactNode,
 } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import '@/lib/sdk-client';
 import {
   login as sdkLogin,
@@ -59,6 +60,7 @@ function clearTokens(): void {
 }
 
 export function AuthProvider({ children }: { children: ReactNode }) {
+  const queryClient = useQueryClient();
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [mustChangePassword, setMustChangePassword] = useState(false);
@@ -99,6 +101,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
       storeTokens(loginData as unknown as LoginResponse);
       await refreshUser();
+      // #487: the anonymous session may have cached auth-scoped queries
+      // (e.g. the repositories list returns only public repos when
+      // unauthenticated). Invalidate so they refetch under the new identity
+      // instead of showing stale/empty data until a manual refresh.
+      await queryClient.invalidateQueries();
 
       if (loginData.must_change_password) {
         setMustChangePassword(true);
@@ -106,7 +113,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
       return false;
     },
-    [refreshUser]
+    [refreshUser, queryClient]
   );
 
   const verifyTotp = useCallback(
@@ -120,11 +127,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setTotpRequired(false);
       setTotpToken(null);
       await refreshUser();
+      // #487: refetch auth-scoped queries under the now-authenticated identity.
+      await queryClient.invalidateQueries();
       if (tokenData.must_change_password) {
         setMustChangePassword(true);
       }
     },
-    [totpToken, refreshUser]
+    [totpToken, refreshUser, queryClient]
   );
 
   const clearTotpRequired = useCallback(() => {
@@ -142,8 +151,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setUser(null);
       setMustChangePassword(false);
       setPasswordExpiresAt(null);
+      // #487 / security: drop every cached query so the next (anonymous or
+      // next-user) session never sees the previous identity's private data.
+      queryClient.clear();
     }
-  }, []);
+  }, [queryClient]);
 
   const changePassword = useCallback(
     async (currentPassword: string, newPassword: string) => {


### PR DESCRIPTION
## Summary

Fixes two repository-list bugs that share a root cause — missing React Query state handling on the repositories page.

### #487 — Repositories don't refresh after login
The `repositories` query caches the **anonymous** result (only public repos are returned when unauthenticated). `AuthProvider` never invalidated the React Query cache when the auth identity changed, so after login the list stayed blank until a manual F5 / Refresh.

**Fix:** `AuthProvider` now invalidates all queries after a successful login and TOTP verification, and `queryClient.clear()`s on logout — which also stops the previous identity's private data from lingering in cache for the next session.

### #478 — Failed list request renders as the empty state
When `GET /api/v1/repositories` failed (backend unreachable, 5xx, connection refused), the page rendered the **"No repositories found"** empty state — visually identical to a healthy install with zero repos. Mid-incident this reads as data loss when the data is intact.

**Fix:** the list now renders a distinct **"Couldn't load repositories"** error state with a **Retry** button when the request fails and there's no data to show. The empty state renders only on a *successful* empty response. A transient refetch error over already-loaded repos keeps showing the list (no jarring blank-out).

## Tests
- Added a `QueryClientProvider` wrapper to the `AuthProvider` test suite (the provider now uses `useQueryClient`, as it does in production).
- New regression test: a failed list request renders the error state with a Retry button and **not** the empty state.
- Full suite green locally (`vitest run`).

## Notes
The two sibling issues filed against the web repo for the same page — **#493** (a user with explicit permission grants can't see a private repo) and **#476** (Composer remote storage shows 0) — are **backend** bugs: the web does no client-side filtering and renders `GET /api/v1/repositories` faithfully. They need fixes in `artifact-keeper` and are tracked separately.

Closes #487
Closes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)