### PR TITLE
feat: upgrade to @artifact-keeper/sdk 1.2.1 + PyPI tracks UI (PEP 708)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "artifact-keeper-web",
       "version": "1.2.1",
       "dependencies": {
-        "@artifact-keeper/sdk": "^1.1.6",
+        "@artifact-keeper/sdk": "^1.2.1",
         "@hookform/resolvers": "^5.2.2",
         "@tanstack/react-query": "^5.100.9",
         "class-variance-authority": "^0.7.1",
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@artifact-keeper/sdk": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@artifact-keeper/sdk/-/sdk-1.1.6.tgz",
-      "integrity": "sha512-M/VR0OykERQ7hCjNc7hFicoGn71LcwKMEF0GfwaLtn582oM9yoShXUhm1eFZhXCWTlKA5KuS34ZtSquw8ZvKmw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@artifact-keeper/sdk/-/sdk-1.2.1.tgz",
+      "integrity": "sha512-e7KVOXBKrU2TB3ueX/Lc1sqJEMI5ZnlRKhYs04uKlEkTsKd4CknIIJhPAzpnnTdW0rCQN1BaHSja6pv/GkJdPg==",
       "license": "MIT",
       "dependencies": {
         "@hey-api/client-fetch": "^0.13.0"
@@ -9410,6 +9410,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "tutorial:generate-videos": "npx tsx e2e/tutorials/scripts/generate-videos.ts"
   },
   "dependencies": {
-    "@artifact-keeper/sdk": "^1.1.6",
+    "@artifact-keeper/sdk": "^1.2.1",
     "@hookform/resolvers": "^5.2.2",
     "@tanstack/react-query": "^5.100.9",
     "class-variance-authority": "^0.7.1",

--- a/src/app/(app)/repositories/_components/pypi-tracks-panel.test.tsx
+++ b/src/app/(app)/repositories/_components/pypi-tracks-panel.test.tsx
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+interface MutationConfig {
+  mutationFn: (...args: unknown[]) => unknown;
+  onSuccess?: (...args: unknown[]) => void;
+  onError?: (...args: unknown[]) => void;
+}
+const mutationConfigs: MutationConfig[] = [];
+const mutateFns: Array<ReturnType<typeof vi.fn>> = [];
+const mockInvalidate = vi.fn();
+
+// useQuery response keyed by queryKey[0]
+let queryResponse: unknown = { data: [], isLoading: false };
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (opts: { queryKey: unknown[]; queryFn: () => unknown }) => {
+    // Execute queryFn so its arrow callback is covered.
+    try {
+      opts.queryFn();
+    } catch {
+      /* ignore */
+    }
+    return queryResponse;
+  },
+  useMutation: (config: MutationConfig) => {
+    mutationConfigs.push(config);
+    const mutate = vi.fn();
+    mutateFns.push(mutate);
+    return { mutate, isPending: false };
+  },
+  useQueryClient: () => ({ invalidateQueries: mockInvalidate }),
+}));
+
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...a: unknown[]) => mockToastSuccess(...a),
+    error: (...a: unknown[]) => mockToastError(...a),
+  },
+}));
+
+const mockList = vi.fn();
+const mockUpsert = vi.fn();
+const mockRemove = vi.fn();
+vi.mock("@/lib/api/pypi-tracks", () => ({
+  default: {
+    list: (...a: unknown[]) => mockList(...a),
+    upsert: (...a: unknown[]) => mockUpsert(...a),
+    remove: (...a: unknown[]) => mockRemove(...a),
+  },
+}));
+
+import { PypiTracksPanel } from "./pypi-tracks-panel";
+import type { Repository } from "@/types";
+
+const REPO = { key: "pypi-virt", format: "pypi", repo_type: "virtual" } as unknown as Repository;
+const TRACK = {
+  normalized_name: "acme-sdk",
+  repository_key: "pypi-virt",
+  tracks_url: "https://pypi.org/simple/acme-sdk/",
+};
+
+// The panel registers two mutations per render in a fixed order
+// (upsert, then remove). Re-renders push fresh mutate fns, so read the tail
+// of the array — the latest render's pair — at assertion time. Configs from
+// the initial single render are stable at [0]/[1] for callback tests.
+const upsertMutate = () => mutateFns[mutateFns.length - 2];
+const removeMutate = () => mutateFns[mutateFns.length - 1];
+const upsertCfg = () => mutationConfigs[0];
+const removeCfg = () => mutationConfigs[1];
+
+beforeEach(() => {
+  mutationConfigs.length = 0;
+  mutateFns.length = 0;
+  vi.clearAllMocks();
+  queryResponse = { data: [], isLoading: false };
+});
+afterEach(() => cleanup());
+
+describe("PypiTracksPanel", () => {
+  it("shows the empty state when there are no declarations", () => {
+    queryResponse = { data: [], isLoading: false };
+    render(<PypiTracksPanel repository={REPO} />);
+    expect(screen.getByText(/No tracks declarations/i)).toBeInTheDocument();
+    expect(mockList).toHaveBeenCalledWith("pypi-virt");
+  });
+
+  it("renders a skeleton while loading", () => {
+    queryResponse = { data: undefined, isLoading: true };
+    render(<PypiTracksPanel repository={REPO} />);
+    expect(screen.queryByText(/No tracks declarations/i)).not.toBeInTheDocument();
+  });
+
+  it("lists existing tracks declarations", () => {
+    queryResponse = { data: [TRACK], isLoading: false };
+    render(<PypiTracksPanel repository={REPO} />);
+    expect(screen.getByText("acme-sdk")).toBeInTheDocument();
+    expect(screen.getByText(TRACK.tracks_url)).toBeInTheDocument();
+  });
+
+  it("disables Add until both fields are filled, then submits an upsert", async () => {
+    const user = userEvent.setup();
+    render(<PypiTracksPanel repository={REPO} />);
+
+    const addBtn = screen.getByRole("button", { name: /add/i });
+    expect(addBtn).toBeDisabled();
+
+    await user.type(screen.getByLabelText("Project name"), "  acme-sdk  ");
+    await user.type(
+      screen.getByLabelText("Upstream Simple index URL"),
+      "https://pypi.org/simple/acme-sdk/",
+    );
+    expect(addBtn).toBeEnabled();
+
+    await user.click(addBtn);
+    expect(upsertMutate()).toHaveBeenCalledWith({
+      proj: "acme-sdk", // trimmed
+      url: "https://pypi.org/simple/acme-sdk/",
+    });
+  });
+
+  it("upsert onSuccess resets the form, invalidates, and toasts", () => {
+    render(<PypiTracksPanel repository={REPO} />);
+    upsertCfg().onSuccess?.(TRACK, { proj: "acme-sdk" });
+    expect(mockInvalidate).toHaveBeenCalled();
+    expect(mockToastSuccess).toHaveBeenCalledWith(expect.stringContaining("acme-sdk"));
+  });
+
+  it("upsert/remove mutationFns call the API with repo + project args", () => {
+    render(<PypiTracksPanel repository={REPO} />);
+    upsertCfg().mutationFn({ proj: "acme-sdk", url: "https://u/" });
+    expect(mockUpsert).toHaveBeenCalledWith("pypi-virt", "acme-sdk", "https://u/");
+    removeCfg().mutationFn("acme-sdk");
+    expect(mockRemove).toHaveBeenCalledWith("pypi-virt", "acme-sdk");
+  });
+
+  it("upsert/remove onError surface a toast via mutationErrorToast", () => {
+    render(<PypiTracksPanel repository={REPO} />);
+    upsertCfg().onError?.(new Error("boom"));
+    removeCfg().onError?.(new Error("nope"));
+    expect(mockToastError).toHaveBeenCalledTimes(2);
+  });
+
+  it("removing a track opens the confirm dialog and fires the remove mutation", async () => {
+    const user = userEvent.setup();
+    queryResponse = { data: [TRACK], isLoading: false };
+    render(<PypiTracksPanel repository={REPO} />);
+
+    await user.click(
+      screen.getByRole("button", { name: /Remove tracks declaration for acme-sdk/i }),
+    );
+    const dialog = await screen.findByRole("alertdialog");
+    await user.click(within(dialog).getByRole("button", { name: /^Remove$/i }));
+    expect(removeMutate()).toHaveBeenCalledWith("acme-sdk");
+  });
+
+  it("remove onSuccess clears the pending track, invalidates, and toasts", () => {
+    render(<PypiTracksPanel repository={REPO} />);
+    removeCfg().onSuccess?.();
+    expect(mockInvalidate).toHaveBeenCalled();
+    expect(mockToastSuccess).toHaveBeenCalledWith("Tracks declaration removed");
+  });
+});

--- a/src/app/(app)/repositories/_components/pypi-tracks-panel.tsx
+++ b/src/app/(app)/repositories/_components/pypi-tracks-panel.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Plus, Trash2, Loader2, Link2, ShieldCheck } from "lucide-react";
+
+import pypiTracksApi, { type PypiTrack } from "@/lib/api/pypi-tracks";
+import { mutationErrorToast } from "@/lib/error-utils";
+import type { Repository } from "@/types";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ConfirmDialog } from "@/components/common/confirm-dialog";
+
+interface PypiTracksPanelProps {
+  repository: Repository;
+}
+
+const TRACKS_QUERY_KEY = (key: string) => ["pypi-tracks", key];
+
+/**
+ * Admin panel for managing PEP 708 `tracks` declarations on a PyPI virtual
+ * repository (artifact-keeper#1600). By default a virtual isolates a
+ * locally-owned project name from the same name upstream; declaring a track
+ * re-unions that project with a named upstream Simple index.
+ */
+export function PypiTracksPanel({ repository }: PypiTracksPanelProps) {
+  const queryClient = useQueryClient();
+  const [project, setProject] = useState("");
+  const [tracksUrl, setTracksUrl] = useState("");
+  const [trackToRemove, setTrackToRemove] = useState<PypiTrack | null>(null);
+
+  const { data: tracks, isLoading } = useQuery({
+    queryKey: TRACKS_QUERY_KEY(repository.key),
+    queryFn: () => pypiTracksApi.list(repository.key),
+  });
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: TRACKS_QUERY_KEY(repository.key) });
+
+  const upsertMutation = useMutation({
+    mutationFn: ({ proj, url }: { proj: string; url: string }) =>
+      pypiTracksApi.upsert(repository.key, proj, url),
+    onSuccess: (_data, { proj }) => {
+      invalidate();
+      setProject("");
+      setTracksUrl("");
+      toast.success(`Tracking declared for "${proj}"`);
+    },
+    onError: mutationErrorToast("Failed to declare tracks relationship"),
+  });
+
+  const removeMutation = useMutation({
+    mutationFn: (proj: string) => pypiTracksApi.remove(repository.key, proj),
+    onSuccess: () => {
+      invalidate();
+      setTrackToRemove(null);
+      toast.success("Tracks declaration removed");
+    },
+    onError: mutationErrorToast("Failed to remove tracks relationship"),
+  });
+
+  const trimmedProject = project.trim();
+  const trimmedUrl = tracksUrl.trim();
+  const canSubmit = trimmedProject !== "" && trimmedUrl !== "" && !upsertMutation.isPending;
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    upsertMutation.mutate({ proj: trimmedProject, url: trimmedUrl });
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start gap-2 text-sm text-muted-foreground">
+        <ShieldCheck className="size-4 mt-0.5 shrink-0 text-emerald-500" />
+        <p>
+          PyPI virtual repositories isolate locally-owned project names from the same name
+          upstream by default (PEP 708, dependency-confusion mitigation). Declare a{" "}
+          <span className="font-medium text-foreground">tracks</span> relationship to re-union a
+          local project&apos;s versions with a named upstream Simple index.
+        </p>
+      </div>
+
+      {/* Add form */}
+      <form
+        onSubmit={handleSubmit}
+        className="flex flex-col gap-2 sm:flex-row sm:items-center"
+        aria-label="Declare a tracks relationship"
+      >
+        <Input
+          placeholder="Project name (e.g. acme-sdk)"
+          value={project}
+          onChange={(e) => setProject(e.target.value)}
+          aria-label="Project name"
+          className="sm:max-w-xs"
+        />
+        <Input
+          placeholder="https://pypi.org/simple/acme-sdk/"
+          value={tracksUrl}
+          onChange={(e) => setTracksUrl(e.target.value)}
+          aria-label="Upstream Simple index URL"
+          inputMode="url"
+        />
+        <Button type="submit" disabled={!canSubmit}>
+          {upsertMutation.isPending ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            <Plus className="size-4" />
+          )}
+          Add
+        </Button>
+      </form>
+
+      {/* List */}
+      {isLoading && (
+        <div className="space-y-2" role="status" aria-busy="true">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+      )}
+
+      {!isLoading && (tracks?.length ?? 0) === 0 && (
+        <div className="flex flex-col items-center justify-center rounded-md border border-dashed py-10 text-center text-muted-foreground">
+          <Link2 className="size-7 mb-2 opacity-50" />
+          <p className="text-sm">No tracks declarations.</p>
+          <p className="text-xs">Locally-owned project names are fully isolated from upstream.</p>
+        </div>
+      )}
+
+      {!isLoading && (tracks?.length ?? 0) > 0 && (
+        <ul className="divide-y rounded-md border">
+          {tracks!.map((t) => (
+            <li
+              key={t.normalized_name}
+              className="flex items-center justify-between gap-3 px-3 py-2.5"
+            >
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium">{t.normalized_name}</p>
+                <p className="truncate text-xs text-muted-foreground">{t.tracks_url}</p>
+              </div>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label={`Remove tracks declaration for ${t.normalized_name}`}
+                onClick={() => setTrackToRemove(t)}
+              >
+                <Trash2 className="size-4 text-destructive" />
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <ConfirmDialog
+        open={trackToRemove !== null}
+        onOpenChange={(open) => !open && setTrackToRemove(null)}
+        title="Remove tracks declaration?"
+        description={
+          trackToRemove
+            ? `"${trackToRemove.normalized_name}" will be isolated from upstream again. Unpinned installs will resolve only the local project's versions.`
+            : ""
+        }
+        confirmText="Remove"
+        danger
+        loading={removeMutation.isPending}
+        onConfirm={() => {
+          if (trackToRemove) removeMutation.mutate(trackToRemove.normalized_name);
+        }}
+      />
+    </div>
+  );
+}

--- a/src/app/(app)/repositories/_components/repo-detail-content.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.tsx
@@ -18,6 +18,7 @@ import {
   Package as PackageIcon,
   Settings,
   RotateCcw,
+  Link2,
 } from "lucide-react";
 
 import { repositoriesApi } from "@/lib/api/repositories";
@@ -34,6 +35,7 @@ import { SecurityTabContent } from "./security-tab-content";
 import { HealthTabContent } from "./health-tab-content";
 import { NotificationsTabContent } from "./notifications-tab-content";
 import { VirtualMembersPanel } from "./virtual-members-panel";
+import { PypiTracksPanel } from "./pypi-tracks-panel";
 import { PackagesTabContent } from "./packages-tab-content";
 import {
   ArtifactBrowserToggle,
@@ -637,6 +639,14 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
               Members
             </TabsTrigger>
           )}
+          {user?.is_admin &&
+            repository.format === "pypi" &&
+            repository.repo_type === "virtual" && (
+              <TabsTrigger value="pypi-tracks">
+                <Link2 className="size-3.5 mr-1" />
+                Tracks
+              </TabsTrigger>
+            )}
           {user?.is_admin && (
             <TabsTrigger value="security">
               <Shield className="size-3.5 mr-1" />
@@ -790,6 +800,15 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
             <VirtualMembersPanel repository={repository} />
           </TabsContent>
         )}
+
+        {/* --- PyPI Tracks Tab (PEP 708, virtual PyPI repos) --- */}
+        {user?.is_admin &&
+          repository.format === "pypi" &&
+          repository.repo_type === "virtual" && (
+            <TabsContent value="pypi-tracks" className="mt-4">
+              <PypiTracksPanel repository={repository} />
+            </TabsContent>
+          )}
 
         {/* --- Security Tab --- */}
         {user?.is_admin && (

--- a/src/lib/api/__tests__/promotion.test.ts
+++ b/src/lib/api/__tests__/promotion.test.ts
@@ -40,6 +40,8 @@ const SDK_REPO: SdkRepositoryResponse = {
   upstream_url: null,
   upstream_auth_type: null,
   upstream_auth_configured: false,
+  allow_anonymous_access: false,
+  promotion_only: false,
   created_at: "2026-04-01T00:00:00Z",
   updated_at: "2026-05-01T00:00:00Z",
 };

--- a/src/lib/api/__tests__/pypi-tracks.test.ts
+++ b/src/lib/api/__tests__/pypi-tracks.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockAssertData = vi.fn(<T,>(d: T) => d);
+vi.mock("../fetch", () => ({
+  assertData: <T,>(d: T) => mockAssertData(d),
+}));
+
+vi.mock("@/lib/sdk-client", () => ({}));
+
+const mockListPypiTracks = vi.fn();
+const mockPutPypiTrack = vi.fn();
+const mockDeletePypiTrack = vi.fn();
+vi.mock("@artifact-keeper/sdk", () => ({
+  listPypiTracks: (...args: unknown[]) => mockListPypiTracks(...args),
+  putPypiTrack: (...args: unknown[]) => mockPutPypiTrack(...args),
+  deletePypiTrack: (...args: unknown[]) => mockDeletePypiTrack(...args),
+}));
+
+import pypiTracksApi from "../pypi-tracks";
+
+describe("pypiTracksApi", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("list() maps the SDK list response to PypiTrack[]", async () => {
+    mockListPypiTracks.mockResolvedValue({
+      data: {
+        items: [
+          { normalized_name: "acme-sdk", repository_key: "pypi-virt", tracks_url: "https://pypi.org/simple/acme-sdk/" },
+        ],
+      },
+      error: undefined,
+    });
+
+    const result = await pypiTracksApi.list("pypi-virt");
+
+    expect(mockListPypiTracks).toHaveBeenCalledWith({ path: { key: "pypi-virt" } });
+    expect(result).toEqual([
+      { normalized_name: "acme-sdk", repository_key: "pypi-virt", tracks_url: "https://pypi.org/simple/acme-sdk/" },
+    ]);
+  });
+
+  it("list() throws on SDK error", async () => {
+    mockListPypiTracks.mockResolvedValue({ data: undefined, error: { status: 500 } });
+    await expect(pypiTracksApi.list("pypi-virt")).rejects.toEqual({ status: 500 });
+  });
+
+  it("upsert() sends the project path and tracks_url body", async () => {
+    mockPutPypiTrack.mockResolvedValue({
+      data: { normalized_name: "acme-sdk", repository_key: "pypi-virt", tracks_url: "https://pypi.org/simple/acme-sdk/" },
+      error: undefined,
+    });
+
+    const result = await pypiTracksApi.upsert("pypi-virt", "acme-sdk", "https://pypi.org/simple/acme-sdk/");
+
+    expect(mockPutPypiTrack).toHaveBeenCalledWith({
+      path: { key: "pypi-virt", project: "acme-sdk" },
+      body: { tracks_url: "https://pypi.org/simple/acme-sdk/" },
+    });
+    expect(result.normalized_name).toBe("acme-sdk");
+  });
+
+  it("upsert() throws on SDK error", async () => {
+    mockPutPypiTrack.mockResolvedValue({ data: undefined, error: { status: 400 } });
+    await expect(
+      pypiTracksApi.upsert("pypi-virt", "acme-sdk", "bad-url"),
+    ).rejects.toEqual({ status: 400 });
+  });
+
+  it("remove() deletes by project and resolves void on success", async () => {
+    mockDeletePypiTrack.mockResolvedValue({ data: undefined, error: undefined });
+
+    await expect(pypiTracksApi.remove("pypi-virt", "acme-sdk")).resolves.toBeUndefined();
+    expect(mockDeletePypiTrack).toHaveBeenCalledWith({ path: { key: "pypi-virt", project: "acme-sdk" } });
+  });
+
+  it("remove() throws on SDK error", async () => {
+    mockDeletePypiTrack.mockResolvedValue({ error: { status: 404 } });
+    await expect(pypiTracksApi.remove("pypi-virt", "missing")).rejects.toEqual({ status: 404 });
+  });
+});

--- a/src/lib/api/__tests__/replication.test.ts
+++ b/src/lib/api/__tests__/replication.test.ts
@@ -272,6 +272,8 @@ describe("peersApi", () => {
         sync_enabled: true,
         replication_mode: "push",
         replication_schedule: "0 * * * *",
+        // 1.2.1 requires replication_filter; empty = replicate everything.
+        replication_filter: {},
       },
     });
   });

--- a/src/lib/api/__tests__/security.test.ts
+++ b/src/lib/api/__tests__/security.test.ts
@@ -77,6 +77,7 @@ const SDK_SCORE: SdkScoreResponse = {
 
 const SDK_SCAN: SdkScanResponse = {
   id: "s1",
+  is_reused: false,
   artifact_id: "a1",
   artifact_name: "lib.jar",
   artifact_version: "1.0",

--- a/src/lib/api/__tests__/sso.test.ts
+++ b/src/lib/api/__tests__/sso.test.ts
@@ -74,6 +74,8 @@ const SDK_OIDC: SdkOidcConfigResponse = {
   scopes: ["openid", "email"],
   attribute_mapping: { email: "email", name: "name" },
   auto_create_users: true,
+  map_groups_to_groups: false,
+  pkce_enabled: false,
   is_enabled: true,
   created_at: "2026-04-01T00:00:00Z",
   updated_at: "2026-05-01T00:00:00Z",

--- a/src/lib/api/__tests__/webhooks.test.ts
+++ b/src/lib/api/__tests__/webhooks.test.ts
@@ -40,6 +40,8 @@ const SDK_WEBHOOK: SdkWebhookResponse = {
   is_enabled: true,
   repository_id: "repo-a",
   headers: { Authorization: "Bearer xyz" },
+  event_schema_version: "1",
+  payload_template: "generic",
   last_triggered_at: "2026-05-01T00:00:00Z",
   created_at: "2026-04-01T00:00:00Z",
 };

--- a/src/lib/api/admin.ts
+++ b/src/lib/api/admin.ts
@@ -57,15 +57,16 @@ function isSdkHealthResponse(value: unknown): value is SdkHealthResponse {
 function adaptHealth(sdk: SdkHealthResponse): HealthResponse {
   const database = adaptCheck(sdk.checks.database) ?? { status: 'unknown' };
   const storage = adaptCheck(sdk.checks.storage) ?? { status: 'unknown' };
-  // Backend 1.2.0 renamed the search-engine health check from `meilisearch`
-  // to `opensearch`. The pinned SDK types only model `meilisearch`, so read
-  // the new field via passthrough and prefer it when present. Either field
-  // maps onto the single local `opensearch` check so the dashboard "Search
-  // Engine" card keeps rendering across both backend versions.
-  const checks = sdk.checks as typeof sdk.checks & {
-    opensearch?: CheckStatus | null;
+  // Backend 1.2.x renamed the search-engine health check from `meilisearch`
+  // to `opensearch`, and the 1.2.x SDK types now model `opensearch` natively.
+  // Older backends still report `meilisearch` at runtime, so read that legacy
+  // field via passthrough and fall back to it. Either field maps onto the
+  // single local `opensearch` check so the dashboard "Search Engine" card
+  // keeps rendering across both backend versions.
+  const legacyChecks = sdk.checks as typeof sdk.checks & {
+    meilisearch?: CheckStatus | null;
   };
-  const searchEngine = adaptCheck(checks.opensearch ?? checks.meilisearch);
+  const searchEngine = adaptCheck(sdk.checks.opensearch ?? legacyChecks.meilisearch);
   return {
     status: sdk.status,
     version: sdk.version,

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -19,6 +19,8 @@ export { default as lifecycleApi } from './lifecycle';
 export { default as telemetryApi } from './telemetry';
 export { default as monitoringApi } from './monitoring';
 export { default as qualityGatesApi } from './quality-gates';
+export { default as pypiTracksApi } from './pypi-tracks';
+export type { PypiTrack } from './pypi-tracks';
 
 export type { LoginCredentials } from './auth';
 export type { ListRepositoriesParams } from './repositories';

--- a/src/lib/api/pypi-tracks.ts
+++ b/src/lib/api/pypi-tracks.ts
@@ -1,0 +1,63 @@
+import '@/lib/sdk-client';
+import {
+  listPypiTracks,
+  putPypiTrack,
+  deletePypiTrack,
+} from '@artifact-keeper/sdk';
+import type { PypiTrackResponse, PypiTracksListResponse } from '@artifact-keeper/sdk';
+import { assertData } from '@/lib/api/fetch';
+
+/**
+ * A PEP 708 `tracks` declaration on a PyPI virtual repository.
+ *
+ * By default a PyPI virtual isolates a locally-owned project name from the
+ * same name upstream (dependency-confusion mitigation, artifact-keeper#1600).
+ * Declaring a `tracks` relationship re-unions the local project's versions
+ * with the named upstream Simple index for that project.
+ */
+export interface PypiTrack {
+  /** PEP 503 normalized project name. */
+  normalized_name: string;
+  repository_key: string;
+  /** Upstream Simple index URL this local project tracks. */
+  tracks_url: string;
+}
+
+function adaptPypiTrack(sdk: PypiTrackResponse): PypiTrack {
+  return {
+    normalized_name: sdk.normalized_name,
+    repository_key: sdk.repository_key,
+    tracks_url: sdk.tracks_url,
+  };
+}
+
+function adaptPypiTracksList(sdk: PypiTracksListResponse): PypiTrack[] {
+  return sdk.items.map(adaptPypiTrack);
+}
+
+const pypiTracksApi = {
+  /** List every `tracks` declaration on a repository. */
+  list: async (key: string): Promise<PypiTrack[]> => {
+    const { data, error } = await listPypiTracks({ path: { key } });
+    if (error) throw error;
+    return adaptPypiTracksList(assertData(data, 'pypiTracksApi.list'));
+  },
+
+  /** Declare (upsert) that `project` tracks `tracksUrl`. */
+  upsert: async (key: string, project: string, tracksUrl: string): Promise<PypiTrack> => {
+    const { data, error } = await putPypiTrack({
+      path: { key, project },
+      body: { tracks_url: tracksUrl },
+    });
+    if (error) throw error;
+    return adaptPypiTrack(assertData(data, 'pypiTracksApi.upsert'));
+  },
+
+  /** Remove a `tracks` declaration, restoring default isolation for `project`. */
+  remove: async (key: string, project: string): Promise<void> => {
+    const { error } = await deletePypiTrack({ path: { key, project } });
+    if (error) throw error;
+  },
+};
+
+export default pypiTracksApi;

--- a/src/lib/api/replication.ts
+++ b/src/lib/api/replication.ts
@@ -165,6 +165,9 @@ function adaptAssignRequest(req: AssignRepoRequest): SdkAssignRepoRequest {
     sync_enabled: req.sync_enabled,
     replication_mode: req.replication_mode,
     replication_schedule: req.replication_schedule,
+    // 1.2.1 made replication_filter required; an empty filter means
+    // "replicate everything" (the web doesn't expose per-artifact filters yet).
+    replication_filter: {},
   };
 }
 

--- a/src/lib/api/sbom.ts
+++ b/src/lib/api/sbom.ts
@@ -326,7 +326,9 @@ const sbomApi = {
   // CVE history operations
   getCveHistory: async (artifactId: string): Promise<CveHistoryEntry[]> => {
     const { data, error } = await sdkGetCveHistory({
-      path: { artifact_id: artifactId },
+      // 1.2.1 renamed the path param artifact_id -> id (accepts an artifact
+      // UUID or a CVE id); the route is /api/v1/sbom/cve/history/{id}.
+      path: { id: artifactId },
     });
     if (error) throw error;
     return assertData(data, 'sbomApi.getCveHistory').map(adaptCveHistory);


### PR DESCRIPTION
> **Draft — blocked on `@artifact-keeper/sdk@1.2.1` being published to npm.** The code is complete and green locally; CI's `npm ci` can't resolve `1.2.1` until the api-repo publishes it (which happens automatically when backend 1.2.1 releases). At that point: regenerate `package-lock.json`, un-draft, merge.

## Summary

Bumps `@artifact-keeper/sdk` `^1.1.6` → `^1.2.1` and brings the web up to the 1.2.1 backend contract, **plus** the flagship 1.2.1 PyPI feature. Built and validated against a 1.2.1 SDK generated **locally** from the backend's exported OpenAPI using the same `@hey-api/openapi-ts` generator CI uses — so every new line is fully typed, no raw-`fetch` workarounds.

## New feature — PyPI tracks (PEP 708, artifact-keeper#1600)

PyPI virtual repos isolate a locally-owned project name from the same name upstream by default (dependency-confusion mitigation). 1.2.1 adds endpoints to declare a `tracks` relationship that re-unions them.

- **`src/lib/api/pypi-tracks.ts`** — typed `pypiTracksApi` (`list` / `upsert` / `remove`) over the new `listPypiTracks` / `putPypiTrack` / `deletePypiTrack` SDK ops, adapter-pattern per #206/#359.
- **`PypiTracksPanel`** — admin-only **Tracks** tab on PyPI *virtual* repositories: declare a project + upstream Simple-index URL, list existing declarations, remove with a confirm dialog. Explains the isolation/union behavior inline.
- 6 API-adapter unit tests.

## SDK-bump migration (breaking type changes in 1.2.1)

| File | Change |
|---|---|
| `admin.ts` | Search-engine health check is now natively `opensearch` in the SDK; flipped the legacy `meilisearch` runtime fallback to a passthrough cast (older backends still report it). |
| `replication.ts` | `AssignRepoRequest.replication_filter` is now **required** → send `{}` (replicate everything; no per-artifact filter UI yet). |
| `sbom.ts` | `getCveHistory` path param renamed `artifact_id` → `id` (`/api/v1/sbom/cve/history/{id}`). |
| test fixtures | New required fields: `RepositoryResponse` (`allow_anonymous_access`, `promotion_only`), `ScanResponse` (`is_reused`), `OidcConfigResponse` (`map_groups_to_groups`, `pkce_enabled`), `WebhookResponse` (`event_schema_version`, `payload_template`). |

## Validation (local, against the 1.2.1 SDK)
- `npm run build` ✅
- **2357 unit tests pass** ✅
- typecheck clean (only 2 unrelated pre-existing test-fixture errors that also exist on `main`)

## Note
The 1.2.1 contract delta is exactly these surfaces + `cache/invalidate` and `admin/storage-gc/oci-blob-report` (separate follow-ups). SBOM `completeness` and `security/.../rescan` from the changelog are **not** in the generated 1.2.1 spec, so they're out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)