### PR TITLE
feat(sync-policies): Replication Sync Policies admin UI

### DIFF
--- a/src/app/(app)/(admin)/sync-policies/page.test.tsx
+++ b/src/app/(app)/(admin)/sync-policies/page.test.tsx
@@ -1,0 +1,219 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+  Element.prototype.scrollIntoView = vi.fn();
+  Element.prototype.hasPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+});
+
+interface MutationConfig {
+  mutationFn: (...a: unknown[]) => unknown;
+  onSuccess?: (...a: unknown[]) => void;
+  onError?: (...a: unknown[]) => void;
+}
+const mutationConfigs: MutationConfig[] = [];
+const mutateFns: Array<ReturnType<typeof vi.fn>> = [];
+const mockInvalidate = vi.fn();
+let queryResponse: { data: unknown; isLoading?: boolean; isError?: boolean; error?: unknown } = {
+  data: [],
+  isLoading: false,
+};
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (opts: { queryFn: () => unknown; enabled?: boolean }) => {
+    if (opts.enabled !== false) {
+      try {
+        opts.queryFn();
+      } catch {
+        /* ignore */
+      }
+    }
+    return { refetch: vi.fn(), isFetching: false, ...queryResponse };
+  },
+  useMutation: (config: MutationConfig) => {
+    mutationConfigs.push(config);
+    const mutate = vi.fn();
+    mutateFns.push(mutate);
+    return { mutate, isPending: false };
+  },
+  useQueryClient: () => ({ invalidateQueries: mockInvalidate }),
+}));
+
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({ toast: { success: (...a: unknown[]) => mockToastSuccess(...a), error: vi.fn() } }));
+
+const api = { list: vi.fn(), create: vi.fn(), update: vi.fn(), remove: vi.fn(), toggle: vi.fn() };
+vi.mock("@/lib/api/sync-policies", () => ({
+  default: {
+    list: (...a: unknown[]) => api.list(...a),
+    create: (...a: unknown[]) => api.create(...a),
+    update: (...a: unknown[]) => api.update(...a),
+    remove: (...a: unknown[]) => api.remove(...a),
+    toggle: (...a: unknown[]) => api.toggle(...a),
+  },
+}));
+
+let isAdmin = true;
+vi.mock("@/providers/auth-provider", () => ({
+  useAuth: () => ({ user: isAdmin ? { is_admin: true } : { is_admin: false } }),
+}));
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({ value, onValueChange, children }: { value?: string; onValueChange?: (v: string) => void; children: React.ReactNode }) => {
+    const items: Array<{ value: string; label: string }> = [];
+    React.Children.forEach(children, (c) => {
+      if (!React.isValidElement(c)) return;
+      React.Children.forEach((c as React.ReactElement<{ children?: React.ReactNode }>).props.children, (s) => {
+        if (React.isValidElement(s) && (s.props as Record<string, unknown>).value) {
+          const p = s.props as { value: string; children: React.ReactNode };
+          items.push({ value: p.value, label: String(p.children) });
+        }
+      });
+    });
+    return (
+      <select aria-label="Mode" value={value} onChange={(e) => onValueChange?.(e.target.value)}>
+        {items.map((i) => <option key={i.value} value={i.value}>{i.label}</option>)}
+      </select>
+    );
+  },
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => <option value={value}>{children}</option>,
+}));
+
+vi.mock("@/components/ui/switch", () => ({
+  Switch: ({ checked, onCheckedChange, "aria-label": al }: { checked?: boolean; onCheckedChange?: (v: boolean) => void; "aria-label"?: string }) => (
+    <input type="checkbox" role="switch" aria-label={al} checked={!!checked} onChange={(e) => onCheckedChange?.(e.target.checked)} />
+  ),
+}));
+
+import SyncPoliciesPage from "./page";
+
+const POLICY = {
+  id: "sp1",
+  name: "mirror-releases",
+  description: "release mirror",
+  enabled: true,
+  filter: "*.tar.gz",
+  replication_mode: "mirror",
+  priority: 100,
+  precedence: 0,
+  created_at: "x",
+  updated_at: "y",
+};
+
+const saveMutate = () => mutateFns[mutateFns.length - 3];
+const toggleMutate = () => mutateFns[mutateFns.length - 2];
+const deleteMutate = () => mutateFns[mutateFns.length - 1];
+
+beforeEach(() => {
+  mutationConfigs.length = 0;
+  mutateFns.length = 0;
+  vi.clearAllMocks();
+  isAdmin = true;
+  queryResponse = { data: [], isLoading: false };
+});
+afterEach(() => cleanup());
+
+describe("SyncPoliciesPage", () => {
+  it("gates non-admins", () => {
+    isAdmin = false;
+    render(<SyncPoliciesPage />);
+    expect(screen.getByText(/requires administrator access/i)).toBeInTheDocument();
+  });
+
+  it("shows the empty state", () => {
+    render(<SyncPoliciesPage />);
+    expect(screen.getByText(/No sync policies yet/i)).toBeInTheDocument();
+  });
+
+  it("shows a skeleton while loading", () => {
+    queryResponse = { data: undefined, isLoading: true };
+    render(<SyncPoliciesPage />);
+    expect(screen.queryByText(/No sync policies yet/i)).not.toBeInTheDocument();
+  });
+
+  it("shows an error state with retry", () => {
+    queryResponse = { data: undefined, isLoading: false, isError: true, error: new Error("x") };
+    render(<SyncPoliciesPage />);
+    expect(screen.getByText(/Couldn't load sync policies/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("lists policies with mode + priority", () => {
+    queryResponse = { data: [POLICY], isLoading: false };
+    render(<SyncPoliciesPage />);
+    expect(screen.getByText("mirror-releases")).toBeInTheDocument();
+    expect(screen.getByText("mirror")).toBeInTheDocument();
+    expect(screen.getByText(/priority 100/i)).toBeInTheDocument();
+  });
+
+  it("creates a policy", async () => {
+    const user = userEvent.setup();
+    render(<SyncPoliciesPage />);
+    await user.click(screen.getByRole("button", { name: /new policy/i }));
+    await user.type(screen.getByLabelText("Name"), "  push-all  ");
+    await user.click(screen.getByRole("button", { name: /^Create$/i }));
+    expect(saveMutate()).toHaveBeenCalledWith(
+      expect.objectContaining({ id: null, body: expect.objectContaining({ name: "push-all" }) }),
+    );
+  });
+
+  it("edits an existing policy (prefilled, update with id)", async () => {
+    const user = userEvent.setup();
+    queryResponse = { data: [POLICY], isLoading: false };
+    render(<SyncPoliciesPage />);
+    await user.click(screen.getByRole("button", { name: /Edit mirror-releases/i }));
+    expect((screen.getByLabelText("Name") as HTMLInputElement).value).toBe("mirror-releases");
+    await user.click(screen.getByRole("button", { name: /^Save$/i }));
+    expect(saveMutate()).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "sp1", body: expect.objectContaining({ name: "mirror-releases" }) }),
+    );
+  });
+
+  it("toggles enabled via the switch", async () => {
+    const user = userEvent.setup();
+    queryResponse = { data: [POLICY], isLoading: false };
+    render(<SyncPoliciesPage />);
+    await user.click(screen.getByRole("switch", { name: /Enable mirror-releases/i }));
+    expect(toggleMutate()).toHaveBeenCalledWith({ id: "sp1", enabled: false });
+  });
+
+  it("deletes via the confirm dialog", async () => {
+    const user = userEvent.setup();
+    queryResponse = { data: [POLICY], isLoading: false };
+    render(<SyncPoliciesPage />);
+    await user.click(screen.getByRole("button", { name: /Delete mirror-releases/i }));
+    const dialog = await screen.findByRole("alertdialog");
+    await user.click(within(dialog).getByRole("button", { name: /^Delete$/i }));
+    expect(deleteMutate()).toHaveBeenCalledWith("sp1");
+  });
+
+  it("mutation callbacks invalidate, toast, and call the API", () => {
+    render(<SyncPoliciesPage />);
+    const [save, toggle, del] = mutationConfigs;
+    save.mutationFn({ id: null, body: { name: "x" } });
+    expect(api.create).toHaveBeenCalledWith({ name: "x" });
+    save.mutationFn({ id: "sp1", body: { name: "y" } });
+    expect(api.update).toHaveBeenCalledWith("sp1", { name: "y" });
+    toggle.mutationFn({ id: "sp1", enabled: false });
+    expect(api.toggle).toHaveBeenCalledWith("sp1", false);
+    del.mutationFn("sp1");
+    expect(api.remove).toHaveBeenCalledWith("sp1");
+    save.onSuccess?.({}, { id: null });
+    del.onSuccess?.();
+    expect(mockInvalidate).toHaveBeenCalled();
+    expect(mockToastSuccess).toHaveBeenCalled();
+  });
+});

--- a/src/app/(app)/(admin)/sync-policies/page.test.tsx
+++ b/src/app/(app)/(admin)/sync-policies/page.test.tsx
@@ -61,6 +61,11 @@ vi.mock("@/lib/api/sync-policies", () => ({
     remove: (...a: unknown[]) => api.remove(...a),
     toggle: (...a: unknown[]) => api.toggle(...a),
   },
+  // real implementation so the filter->artifact_filter translation is exercised
+  filterToArtifactFilter: (glob: string) => {
+    const t = glob.trim();
+    return t ? { include_paths: [t] } : {};
+  },
 }));
 
 let isAdmin = true;
@@ -166,20 +171,35 @@ describe("SyncPoliciesPage", () => {
     await user.type(screen.getByLabelText("Name"), "  push-all  ");
     await user.click(screen.getByRole("button", { name: /^Create$/i }));
     expect(saveMutate()).toHaveBeenCalledWith(
-      expect.objectContaining({ id: null, body: expect.objectContaining({ name: "push-all" }) }),
+      expect.objectContaining({ id: null, form: expect.objectContaining({ name: "push-all" }) }),
     );
   });
 
-  it("edits an existing policy (prefilled, update with id)", async () => {
+  it("edits an existing policy (filter + name prefilled, update with id)", async () => {
     const user = userEvent.setup();
     queryResponse = { data: [POLICY], isLoading: false };
     render(<SyncPoliciesPage />);
     await user.click(screen.getByRole("button", { name: /Edit mirror-releases/i }));
     expect((screen.getByLabelText("Name") as HTMLInputElement).value).toBe("mirror-releases");
+    expect((screen.getByLabelText(/Filter glob/i) as HTMLInputElement).value).toBe("*.tar.gz");
     await user.click(screen.getByRole("button", { name: /^Save$/i }));
     expect(saveMutate()).toHaveBeenCalledWith(
-      expect.objectContaining({ id: "sp1", body: expect.objectContaining({ name: "mirror-releases" }) }),
+      expect.objectContaining({
+        id: "sp1",
+        form: expect.objectContaining({ name: "mirror-releases", filter: "*.tar.gz" }),
+      }),
     );
+  });
+
+  it("clearing Priority yields undefined (not 0/NaN)", async () => {
+    const user = userEvent.setup();
+    render(<SyncPoliciesPage />);
+    await user.click(screen.getByRole("button", { name: /new policy/i }));
+    await user.type(screen.getByLabelText("Name"), "p");
+    await user.clear(screen.getByLabelText("Priority"));
+    await user.click(screen.getByRole("button", { name: /^Create$/i }));
+    const arg = saveMutate().mock.calls[0][0] as { form: { priority?: number } };
+    expect(arg.form.priority).toBeUndefined();
   });
 
   it("toggles enabled via the switch", async () => {
@@ -203,10 +223,17 @@ describe("SyncPoliciesPage", () => {
   it("mutation callbacks invalidate, toast, and call the API", () => {
     render(<SyncPoliciesPage />);
     const [save, toggle, del] = mutationConfigs;
-    save.mutationFn({ id: null, body: { name: "x" } });
-    expect(api.create).toHaveBeenCalledWith({ name: "x" });
-    save.mutationFn({ id: "sp1", body: { name: "y" } });
-    expect(api.update).toHaveBeenCalledWith("sp1", { name: "y" });
+    save.mutationFn({ id: null, form: { name: "x", filter: "*.tgz" } });
+    expect(api.create).toHaveBeenCalledWith({ name: "x", filter: "*.tgz" });
+    // update must translate the glob filter into artifact_filter (UpdateSyncPolicyPayload has no `filter`)
+    save.mutationFn({ id: "sp1", form: { name: "y", filter: "*.whl", replication_mode: "pull", priority: 5 } });
+    expect(api.update).toHaveBeenCalledWith("sp1", {
+      name: "y",
+      description: undefined,
+      replication_mode: "pull",
+      priority: 5,
+      artifact_filter: { include_paths: ["*.whl"] },
+    });
     toggle.mutationFn({ id: "sp1", enabled: false });
     expect(api.toggle).toHaveBeenCalledWith("sp1", false);
     del.mutationFn("sp1");

--- a/src/app/(app)/(admin)/sync-policies/page.tsx
+++ b/src/app/(app)/(admin)/sync-policies/page.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Workflow, Plus, Trash2, Pencil, AlertCircle, RotateCcw, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import syncPoliciesApi, {
+  type SyncPolicy,
+  type CreateSyncPolicyRequest,
+} from "@/lib/api/sync-policies";
+import { mutationErrorToast, toUserMessage } from "@/lib/error-utils";
+import { useAuth } from "@/providers/auth-provider";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Switch } from "@/components/ui/switch";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ConfirmDialog } from "@/components/common/confirm-dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+
+const QUERY_KEY = ["sync-policies"];
+const MODES = ["push", "pull", "mirror"] as const;
+
+const emptyForm: CreateSyncPolicyRequest = {
+  name: "",
+  description: "",
+  filter: "",
+  replication_mode: "push",
+  priority: 100,
+};
+
+export default function SyncPoliciesPage() {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<SyncPolicy | null>(null);
+  const [form, setForm] = useState<CreateSyncPolicyRequest>(emptyForm);
+  const [deleteTarget, setDeleteTarget] = useState<SyncPolicy | null>(null);
+
+  const { data: policies, isLoading, isError, error, refetch, isFetching } = useQuery({
+    queryKey: QUERY_KEY,
+    queryFn: () => syncPoliciesApi.list(),
+    enabled: !!user?.is_admin,
+  });
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+
+  const saveMutation = useMutation({
+    mutationFn: (vars: { id: string | null; body: CreateSyncPolicyRequest }) =>
+      vars.id ? syncPoliciesApi.update(vars.id, vars.body) : syncPoliciesApi.create(vars.body),
+    onSuccess: (_p, vars) => {
+      invalidate();
+      setDialogOpen(false);
+      setEditing(null);
+      setForm(emptyForm);
+      toast.success(vars.id ? "Sync policy updated" : "Sync policy created");
+    },
+    onError: mutationErrorToast("Failed to save sync policy"),
+  });
+
+  const toggleMutation = useMutation({
+    mutationFn: (vars: { id: string; enabled: boolean }) =>
+      syncPoliciesApi.toggle(vars.id, vars.enabled),
+    onSuccess: () => invalidate(),
+    onError: mutationErrorToast("Failed to toggle sync policy"),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => syncPoliciesApi.remove(id),
+    onSuccess: () => {
+      invalidate();
+      setDeleteTarget(null);
+      toast.success("Sync policy deleted");
+    },
+    onError: mutationErrorToast("Failed to delete sync policy"),
+  });
+
+  if (!user?.is_admin) {
+    return (
+      <div className="p-8 text-center text-muted-foreground" role="alert">
+        <Workflow className="mx-auto mb-2 size-8 opacity-50" />
+        <p className="text-sm">Sync policy management requires administrator access.</p>
+      </div>
+    );
+  }
+
+  function openCreate() {
+    setEditing(null);
+    setForm(emptyForm);
+    setDialogOpen(true);
+  }
+  function openEdit(p: SyncPolicy) {
+    setEditing(p);
+    setForm({
+      name: p.name,
+      description: p.description,
+      filter: p.filter,
+      replication_mode: p.replication_mode,
+      priority: p.priority,
+    });
+    setDialogOpen(true);
+  }
+
+  const canSave = form.name.trim() !== "" && !saveMutation.isPending;
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSave) return;
+    saveMutation.mutate({ id: editing?.id ?? null, body: { ...form, name: form.name.trim() } });
+  }
+
+  const rows = policies ?? [];
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Workflow className="size-6" />
+          <div>
+            <h1 className="text-xl font-semibold">Sync Policies</h1>
+            <p className="text-sm text-muted-foreground">
+              Rules deciding which artifacts replicate to which peers, and how.
+            </p>
+          </div>
+        </div>
+        <Button onClick={openCreate}>
+          <Plus className="size-4" />
+          New Policy
+        </Button>
+      </div>
+
+      {isLoading && (
+        <div className="space-y-2" role="status" aria-busy="true">
+          <Skeleton className="h-12 w-full" />
+          <Skeleton className="h-12 w-full" />
+        </div>
+      )}
+
+      {!isLoading && isError && (
+        <div className="flex flex-col items-center justify-center py-12 text-center" role="alert">
+          <AlertCircle className="size-8 mb-2 text-destructive opacity-80" />
+          <p className="text-sm font-medium">Couldn&apos;t load sync policies</p>
+          <p className="mt-1 text-xs text-muted-foreground">{toUserMessage(error, "Unknown error")}</p>
+          <Button variant="outline" size="sm" className="mt-4" onClick={() => refetch()} disabled={isFetching}>
+            <RotateCcw className={`size-4 ${isFetching ? "animate-spin" : ""}`} />
+            Retry
+          </Button>
+        </div>
+      )}
+
+      {!isLoading && !isError && rows.length === 0 && (
+        <div className="flex flex-col items-center justify-center rounded-md border border-dashed py-12 text-center text-muted-foreground">
+          <Workflow className="size-8 mb-2 opacity-50" />
+          <p className="text-sm">No sync policies yet.</p>
+          <p className="text-xs">Create one to control what replicates and where.</p>
+        </div>
+      )}
+
+      {!isLoading && !isError && rows.length > 0 && (
+        <ul className="divide-y rounded-md border">
+          {rows.map((p) => (
+            <li key={p.id} className="flex items-center justify-between gap-4 px-4 py-3">
+              <div className="flex items-center gap-3">
+                <Switch
+                  checked={p.enabled}
+                  onCheckedChange={(v) => toggleMutation.mutate({ id: p.id, enabled: v })}
+                  aria-label={`Enable ${p.name}`}
+                />
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate font-medium">{p.name}</span>
+                    <Badge variant="outline" className="capitalize">{p.replication_mode}</Badge>
+                    <span className="text-xs text-muted-foreground">priority {p.priority}</span>
+                  </div>
+                  <p className="truncate text-xs text-muted-foreground">
+                    {p.filter ? `filter: ${p.filter}` : p.description || "all artifacts"}
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center gap-1">
+                <Button variant="ghost" size="icon-sm" aria-label={`Edit ${p.name}`} onClick={() => openEdit(p)}>
+                  <Pencil className="size-4" />
+                </Button>
+                <Button variant="ghost" size="icon-sm" aria-label={`Delete ${p.name}`} onClick={() => setDeleteTarget(p)}>
+                  <Trash2 className="size-4 text-destructive" />
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* Create / edit dialog */}
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <form onSubmit={submit}>
+            <DialogHeader>
+              <DialogTitle>{editing ? "Edit sync policy" : "New sync policy"}</DialogTitle>
+              <DialogDescription>
+                A higher priority wins when multiple policies match an artifact.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-4 py-4">
+              <div className="space-y-1.5">
+                <Label htmlFor="sp-name">Name</Label>
+                <Input id="sp-name" value={form.name} onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))} placeholder="mirror-releases" />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="sp-desc">Description</Label>
+                <Input id="sp-desc" value={form.description ?? ""} onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))} />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <Label htmlFor="sp-mode">Mode</Label>
+                  <Select value={form.replication_mode} onValueChange={(v) => setForm((f) => ({ ...f, replication_mode: v }))}>
+                    <SelectTrigger id="sp-mode"><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      {MODES.map((mode) => (
+                        <SelectItem key={mode} value={mode} className="capitalize">{mode}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="sp-priority">Priority</Label>
+                  <Input
+                    id="sp-priority"
+                    type="number"
+                    value={form.priority ?? 100}
+                    onChange={(e) => setForm((f) => ({ ...f, priority: Number(e.target.value) }))}
+                  />
+                </div>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="sp-filter">Filter glob (optional)</Label>
+                <Input id="sp-filter" value={form.filter ?? ""} onChange={(e) => setForm((f) => ({ ...f, filter: e.target.value }))} placeholder="*.tar.gz" />
+              </div>
+            </div>
+            <DialogFooter>
+              <Button type="button" variant="ghost" onClick={() => setDialogOpen(false)}>Cancel</Button>
+              <Button type="submit" disabled={!canSave}>
+                {saveMutation.isPending ? <Loader2 className="size-4 animate-spin" /> : null}
+                {editing ? "Save" : "Create"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        onOpenChange={(o) => !o && setDeleteTarget(null)}
+        title="Delete sync policy?"
+        description={`"${deleteTarget?.name ?? ""}" will be permanently deleted. Replication stops following this rule.`}
+        confirmText="Delete"
+        danger
+        loading={deleteMutation.isPending}
+        onConfirm={() => deleteTarget && deleteMutation.mutate(deleteTarget.id)}
+      />
+    </div>
+  );
+}

--- a/src/app/(app)/(admin)/sync-policies/page.tsx
+++ b/src/app/(app)/(admin)/sync-policies/page.tsx
@@ -6,6 +6,7 @@ import { Workflow, Plus, Trash2, Pencil, AlertCircle, RotateCcw, Loader2 } from 
 import { toast } from "sonner";
 
 import syncPoliciesApi, {
+  filterToArtifactFilter,
   type SyncPolicy,
   type CreateSyncPolicyRequest,
 } from "@/lib/api/sync-policies";
@@ -64,8 +65,20 @@ export default function SyncPoliciesPage() {
   const invalidate = () => queryClient.invalidateQueries({ queryKey: QUERY_KEY });
 
   const saveMutation = useMutation({
-    mutationFn: (vars: { id: string | null; body: CreateSyncPolicyRequest }) =>
-      vars.id ? syncPoliciesApi.update(vars.id, vars.body) : syncPoliciesApi.create(vars.body),
+    mutationFn: (vars: { id: string | null; form: CreateSyncPolicyRequest }) => {
+      if (vars.id) {
+        // UpdateSyncPolicyPayload has no `filter` shorthand — translate the glob
+        // into the structured artifact_filter the update endpoint accepts.
+        return syncPoliciesApi.update(vars.id, {
+          name: vars.form.name,
+          description: vars.form.description,
+          replication_mode: vars.form.replication_mode,
+          priority: vars.form.priority,
+          artifact_filter: filterToArtifactFilter(vars.form.filter ?? ""),
+        });
+      }
+      return syncPoliciesApi.create(vars.form);
+    },
     onSuccess: (_p, vars) => {
       invalidate();
       setDialogOpen(false);
@@ -123,7 +136,7 @@ export default function SyncPoliciesPage() {
   function submit(e: React.FormEvent) {
     e.preventDefault();
     if (!canSave) return;
-    saveMutation.mutate({ id: editing?.id ?? null, body: { ...form, name: form.name.trim() } });
+    saveMutation.mutate({ id: editing?.id ?? null, form: { ...form, name: form.name.trim() } });
   }
 
   const rows = policies ?? [];
@@ -243,8 +256,14 @@ export default function SyncPoliciesPage() {
                   <Input
                     id="sp-priority"
                     type="number"
-                    value={form.priority ?? 100}
-                    onChange={(e) => setForm((f) => ({ ...f, priority: Number(e.target.value) }))}
+                    min={0}
+                    value={form.priority ?? ""}
+                    onChange={(e) => {
+                      // Empty/invalid input -> undefined (omitted, backend default)
+                      // rather than 0 (Number("") === 0) or NaN (serializes to null).
+                      const n = e.target.valueAsNumber;
+                      setForm((f) => ({ ...f, priority: Number.isNaN(n) ? undefined : n }));
+                    }}
                   />
                 </div>
               </div>

--- a/src/components/layout/__tests__/app-sidebar.test.tsx
+++ b/src/components/layout/__tests__/app-sidebar.test.tsx
@@ -70,6 +70,7 @@ vi.mock("lucide-react", () => {
     Hammer: icon,
     Globe: icon,
     RefreshCw: icon,
+    Workflow: icon,
     Puzzle: icon,
     Webhook: icon,
     ArrowRightLeft: icon,

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -16,6 +16,7 @@ import {
   Bot,
   BookOpen,
   GitPullRequestArrow,
+  Workflow,
   Key,
   FileSignature,
   Shield,
@@ -76,6 +77,7 @@ const artifactItems: NavItem[] = [
 const integrationItems: NavItem[] = [
   { title: "Peers", href: "/peers", icon: Globe },
   { title: "Replication", href: "/replication", icon: RefreshCw },
+  { title: "Sync Policies", href: "/sync-policies", icon: Workflow },
   { title: "Plugins", href: "/plugins", icon: Puzzle },
   { title: "Webhooks", href: "/webhooks", icon: Webhook },
   { title: "Access Tokens", href: "/access-tokens", icon: Key },

--- a/src/lib/api/__tests__/sync-policies.test.ts
+++ b/src/lib/api/__tests__/sync-policies.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../fetch", () => ({ assertData: <T,>(d: T) => d }));
+vi.mock("@/lib/sdk-client", () => ({}));
+
+const m = {
+  listSyncPolicies: vi.fn(),
+  getSyncPolicy: vi.fn(),
+  createSyncPolicy: vi.fn(),
+  updateSyncPolicy: vi.fn(),
+  deleteSyncPolicy: vi.fn(),
+  togglePolicy: vi.fn(),
+};
+vi.mock("@artifact-keeper/sdk", () => ({
+  listSyncPolicies: (...a: unknown[]) => m.listSyncPolicies(...a),
+  getSyncPolicy: (...a: unknown[]) => m.getSyncPolicy(...a),
+  createSyncPolicy: (...a: unknown[]) => m.createSyncPolicy(...a),
+  updateSyncPolicy: (...a: unknown[]) => m.updateSyncPolicy(...a),
+  deleteSyncPolicy: (...a: unknown[]) => m.deleteSyncPolicy(...a),
+  togglePolicy: (...a: unknown[]) => m.togglePolicy(...a),
+}));
+
+import syncPoliciesApi from "../sync-policies";
+
+const SDK = {
+  id: "sp1",
+  name: "mirror-releases",
+  description: "",
+  enabled: true,
+  filter: "*.tar.gz",
+  replication_mode: "mirror",
+  priority: 100,
+  precedence: 0,
+  artifact_filter: {},
+  peer_selector: {},
+  repo_selector: {},
+  created_at: "x",
+  updated_at: "y",
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("syncPoliciesApi", () => {
+  it("list maps SyncPolicyListResponse.items", async () => {
+    m.listSyncPolicies.mockResolvedValue({ data: { items: [SDK], total: 1 }, error: undefined });
+    const out = await syncPoliciesApi.list();
+    expect(out[0]).toMatchObject({ id: "sp1", replication_mode: "mirror", priority: 100, filter: "*.tar.gz" });
+  });
+
+  it("list throws on error", async () => {
+    m.listSyncPolicies.mockResolvedValue({ data: undefined, error: { status: 500 } });
+    await expect(syncPoliciesApi.list()).rejects.toEqual({ status: 500 });
+  });
+
+  it("get passes the id path", async () => {
+    m.getSyncPolicy.mockResolvedValue({ data: SDK, error: undefined });
+    await syncPoliciesApi.get("sp1");
+    expect(m.getSyncPolicy).toHaveBeenCalledWith({ path: { id: "sp1" } });
+  });
+
+  it("create posts the body", async () => {
+    m.createSyncPolicy.mockResolvedValue({ data: SDK, error: undefined });
+    await syncPoliciesApi.create({ name: "x", replication_mode: "push", priority: 5 });
+    expect(m.createSyncPolicy).toHaveBeenCalledWith({ body: { name: "x", replication_mode: "push", priority: 5 } });
+  });
+
+  it("update sends id path + body", async () => {
+    m.updateSyncPolicy.mockResolvedValue({ data: SDK, error: undefined });
+    await syncPoliciesApi.update("sp1", { priority: 9 });
+    expect(m.updateSyncPolicy).toHaveBeenCalledWith({ path: { id: "sp1" }, body: { priority: 9 } });
+  });
+
+  it("remove resolves void and passes id", async () => {
+    m.deleteSyncPolicy.mockResolvedValue({ error: undefined });
+    await expect(syncPoliciesApi.remove("sp1")).resolves.toBeUndefined();
+    expect(m.deleteSyncPolicy).toHaveBeenCalledWith({ path: { id: "sp1" } });
+  });
+
+  it("toggle sends the explicit enabled body (not a blind flip)", async () => {
+    m.togglePolicy.mockResolvedValue({ data: { ...SDK, enabled: false }, error: undefined });
+    const out = await syncPoliciesApi.toggle("sp1", false);
+    expect(m.togglePolicy).toHaveBeenCalledWith({ path: { id: "sp1" }, body: { enabled: false } });
+    expect(out.enabled).toBe(false);
+  });
+
+  it("toggle throws on error", async () => {
+    m.togglePolicy.mockResolvedValue({ data: undefined, error: { status: 404 } });
+    await expect(syncPoliciesApi.toggle("x", true)).rejects.toEqual({ status: 404 });
+  });
+});

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -23,6 +23,8 @@ export { default as pypiTracksApi } from './pypi-tracks';
 export type { PypiTrack } from './pypi-tracks';
 export { default as signingApi } from './signing';
 export type { SigningKey, SigningConfig, CreateSigningKeyRequest } from './signing';
+export { default as syncPoliciesApi } from './sync-policies';
+export type { SyncPolicy, CreateSyncPolicyRequest } from './sync-policies';
 
 export type { LoginCredentials } from './auth';
 export type { ListRepositoriesParams } from './repositories';

--- a/src/lib/api/sync-policies.ts
+++ b/src/lib/api/sync-policies.ts
@@ -37,15 +37,35 @@ export interface CreateSyncPolicyRequest {
   enabled?: boolean;
 }
 
-export type UpdateSyncPolicyRequest = Partial<CreateSyncPolicyRequest>;
+/**
+ * Update payload. Note the SDK's `UpdateSyncPolicyPayload` has **no `filter`
+ * convenience field** (unlike create) — the glob only exists as the
+ * `artifact_filter.include_paths` shorthand, which the backend mirrors back to
+ * `filter` on read. So callers updating the filter must set `artifact_filter`,
+ * not `filter`; this type omits `filter` to make that impossible to get wrong.
+ */
+export interface UpdateSyncPolicyRequest {
+  name?: string;
+  description?: string;
+  enabled?: boolean;
+  replication_mode?: string;
+  priority?: number;
+  artifact_filter?: Record<string, unknown>;
+}
+
+/** Build the structured `artifact_filter` from the single-glob shorthand. */
+export function filterToArtifactFilter(glob: string): Record<string, unknown> {
+  const trimmed = glob.trim();
+  return trimmed ? { include_paths: [trimmed] } : {};
+}
 
 function adapt(sdk: SyncPolicyResponse): SyncPolicy {
   return {
     id: sdk.id,
     name: sdk.name,
-    description: sdk.description,
+    description: sdk.description ?? "",
     enabled: sdk.enabled,
-    filter: sdk.filter,
+    filter: sdk.filter ?? "",
     replication_mode: sdk.replication_mode,
     priority: sdk.priority,
     precedence: sdk.precedence,

--- a/src/lib/api/sync-policies.ts
+++ b/src/lib/api/sync-policies.ts
@@ -1,0 +1,95 @@
+import '@/lib/sdk-client';
+import {
+  listSyncPolicies,
+  getSyncPolicy,
+  createSyncPolicy,
+  updateSyncPolicy,
+  deleteSyncPolicy,
+  togglePolicy,
+} from '@artifact-keeper/sdk';
+import type { SyncPolicyResponse } from '@artifact-keeper/sdk';
+import { assertData } from '@/lib/api/fetch';
+
+/**
+ * A replication sync policy: declarative rule deciding which artifacts get
+ * replicated to which peers, in what mode, at what priority.
+ */
+export interface SyncPolicy {
+  id: string;
+  name: string;
+  description: string;
+  enabled: boolean;
+  /** Convenience glob (mirrors `artifact_filter.include_paths`), e.g. `*.tar.gz`. */
+  filter: string;
+  replication_mode: string;
+  priority: number;
+  precedence: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateSyncPolicyRequest {
+  name: string;
+  description?: string;
+  filter?: string;
+  replication_mode?: string;
+  priority?: number;
+  enabled?: boolean;
+}
+
+export type UpdateSyncPolicyRequest = Partial<CreateSyncPolicyRequest>;
+
+function adapt(sdk: SyncPolicyResponse): SyncPolicy {
+  return {
+    id: sdk.id,
+    name: sdk.name,
+    description: sdk.description,
+    enabled: sdk.enabled,
+    filter: sdk.filter,
+    replication_mode: sdk.replication_mode,
+    priority: sdk.priority,
+    precedence: sdk.precedence,
+    created_at: sdk.created_at,
+    updated_at: sdk.updated_at,
+  };
+}
+
+const syncPoliciesApi = {
+  list: async (): Promise<SyncPolicy[]> => {
+    const { data, error } = await listSyncPolicies();
+    if (error) throw error;
+    return assertData(data, 'syncPoliciesApi.list').items.map(adapt);
+  },
+
+  get: async (id: string): Promise<SyncPolicy> => {
+    const { data, error } = await getSyncPolicy({ path: { id } });
+    if (error) throw error;
+    return adapt(assertData(data, 'syncPoliciesApi.get'));
+  },
+
+  create: async (req: CreateSyncPolicyRequest): Promise<SyncPolicy> => {
+    const { data, error } = await createSyncPolicy({ body: req });
+    if (error) throw error;
+    return adapt(assertData(data, 'syncPoliciesApi.create'));
+  },
+
+  update: async (id: string, req: UpdateSyncPolicyRequest): Promise<SyncPolicy> => {
+    const { data, error } = await updateSyncPolicy({ path: { id }, body: req });
+    if (error) throw error;
+    return adapt(assertData(data, 'syncPoliciesApi.update'));
+  },
+
+  remove: async (id: string): Promise<void> => {
+    const { error } = await deleteSyncPolicy({ path: { id } });
+    if (error) throw error;
+  },
+
+  /** Set a policy's enabled state; returns the updated policy. */
+  toggle: async (id: string, enabled: boolean): Promise<SyncPolicy> => {
+    const { data, error } = await togglePolicy({ path: { id }, body: { enabled } });
+    if (error) throw error;
+    return adapt(assertData(data, 'syncPoliciesApi.toggle'));
+  },
+};
+
+export default syncPoliciesApi;


### PR DESCRIPTION
## Summary

Third of the **1.2.1 endpoint build-out**. The backend sync-policies API (`/api/v1/sync-policies*`) had no web UI; this adds a **Sync Policies** admin page.

### `/sync-policies` (admin)
- List policies — name, replication **mode**, priority, inline **enabled** toggle
- **Create / edit** — name, description, filter glob, mode (push/pull/mirror), priority
- Enable/disable inline (explicit `{ enabled }` toggle — not a blind flip)
- **Delete** with confirm
- Loading / empty / error (retry) / non-admin states

### Code
- `src/lib/api/sync-policies.ts` — typed adapter over `listSyncPolicies` / `getSyncPolicy` / `createSyncPolicy` / `updateSyncPolicy` / `deleteSyncPolicy` / `togglePolicy`. (`togglePolicy` requires a `{ enabled }` body, so the adapter is `toggle(id, enabled)`.)
- "Sync Policies" entry in the Integration nav + barrel export.

## Tests
- API adapter: 8 cases (list mapping, id paths, create/update bodies, the explicit-enabled toggle, error paths).
- Page: 9 cases — admin gate, empty/loading/error, list, create, edit-prefilled-with-id, switch toggle, delete confirm, mutation callbacks.
- `npm run build` ✅ (`/sync-policies` route), all tests green.

## Scope note (deferred)
Policy **preview/evaluate** and the JSONB `peer_selector` / `repo_selector` / `artifact_filter` selectors are deferred — the selectors need a structured editor; basic CRUD + the glob `filter` shorthand covers the common case. Tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)