### PR TITLE
feat(repositories): Labels tab for repository key/value labels

### DIFF
--- a/src/app/(app)/repositories/_components/repo-detail-content.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.tsx
@@ -21,6 +21,7 @@ import {
   RotateCcw,
   Link2,
   Upload,
+  Tag,
 } from "lucide-react";
 
 import { repositoriesApi } from "@/lib/api/repositories";
@@ -38,6 +39,7 @@ import { HealthTabContent } from "./health-tab-content";
 import { NotificationsTabContent } from "./notifications-tab-content";
 import { VirtualMembersPanel } from "./virtual-members-panel";
 import { PypiTracksPanel } from "./pypi-tracks-panel";
+import { RepoLabelsPanel } from "./repo-labels-panel";
 import { PackagesTabContent } from "./packages-tab-content";
 import {
   ArtifactBrowserToggle,
@@ -675,6 +677,12 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
               Settings
             </TabsTrigger>
           )}
+          {user?.is_admin && (
+            <TabsTrigger value="labels">
+              <Tag className="size-3.5 mr-1" />
+              Labels
+            </TabsTrigger>
+          )}
         </TabsList>
 
         {/* --- Artifacts Tab --- */}
@@ -923,6 +931,13 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
         {user?.is_admin && (
           <TabsContent value="settings" className="mt-4">
             <RepoSettingsTab repository={repository} />
+          </TabsContent>
+        )}
+
+        {/* --- Labels Tab --- */}
+        {user?.is_admin && (
+          <TabsContent value="labels" className="mt-4">
+            <RepoLabelsPanel repository={repository} />
           </TabsContent>
         )}
       </Tabs>

--- a/src/app/(app)/repositories/_components/repo-labels-panel.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-labels-panel.test.tsx
@@ -68,6 +68,7 @@ describe("RepoLabelsPanel", () => {
   it("renders a skeleton while loading", () => {
     queryResponse = { data: undefined, isLoading: true };
     render(<RepoLabelsPanel repository={REPO} />);
+    expect(screen.getByRole("status")).toHaveAttribute("aria-busy", "true");
     expect(screen.queryByText(/No labels yet/i)).not.toBeInTheDocument();
   });
 

--- a/src/app/(app)/repositories/_components/repo-labels-panel.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-labels-panel.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+interface MutationConfig {
+  mutationFn: (...a: unknown[]) => unknown;
+  onSuccess?: (...a: unknown[]) => void;
+  onError?: (...a: unknown[]) => void;
+}
+const mutationConfigs: MutationConfig[] = [];
+const mutateFns: Array<ReturnType<typeof vi.fn>> = [];
+const mockInvalidate = vi.fn();
+let queryResponse: unknown = { data: [], isLoading: false };
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (opts: { queryFn: () => unknown }) => {
+    try {
+      opts.queryFn();
+    } catch {
+      /* ignore */
+    }
+    return queryResponse;
+  },
+  useMutation: (config: MutationConfig) => {
+    mutationConfigs.push(config);
+    const mutate = vi.fn();
+    mutateFns.push(mutate);
+    return { mutate, isPending: false };
+  },
+  useQueryClient: () => ({ invalidateQueries: mockInvalidate }),
+}));
+
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({ toast: { success: (...a: unknown[]) => mockToastSuccess(...a), error: vi.fn() } }));
+
+const api = { list: vi.fn(), add: vi.fn(), remove: vi.fn() };
+vi.mock("@/lib/api/repo-labels", () => ({
+  default: { list: (...a: unknown[]) => api.list(...a), add: (...a: unknown[]) => api.add(...a), remove: (...a: unknown[]) => api.remove(...a) },
+}));
+
+import { RepoLabelsPanel } from "./repo-labels-panel";
+import type { Repository } from "@/types";
+
+const REPO = { key: "my-repo" } as unknown as Repository;
+const LABEL = { id: "l1", key: "team", value: "platform", created_at: "x" };
+
+const addMutate = () => mutateFns[mutateFns.length - 2];
+const removeMutate = () => mutateFns[mutateFns.length - 1];
+
+beforeEach(() => {
+  mutationConfigs.length = 0;
+  mutateFns.length = 0;
+  vi.clearAllMocks();
+  queryResponse = { data: [], isLoading: false };
+});
+afterEach(() => cleanup());
+
+describe("RepoLabelsPanel", () => {
+  it("shows the empty state and queries by repo key", () => {
+    render(<RepoLabelsPanel repository={REPO} />);
+    expect(screen.getByText(/No labels yet/i)).toBeInTheDocument();
+    expect(api.list).toHaveBeenCalledWith("my-repo");
+  });
+
+  it("renders a skeleton while loading", () => {
+    queryResponse = { data: undefined, isLoading: true };
+    render(<RepoLabelsPanel repository={REPO} />);
+    expect(screen.queryByText(/No labels yet/i)).not.toBeInTheDocument();
+  });
+
+  it("lists labels as key = value", () => {
+    queryResponse = { data: [LABEL], isLoading: false };
+    render(<RepoLabelsPanel repository={REPO} />);
+    expect(screen.getByText("team")).toBeInTheDocument();
+    expect(screen.getByText(/= platform/)).toBeInTheDocument();
+  });
+
+  it("disables Add until a key is entered, then submits add", async () => {
+    const user = userEvent.setup();
+    render(<RepoLabelsPanel repository={REPO} />);
+    const add = screen.getByRole("button", { name: /add/i });
+    expect(add).toBeDisabled();
+    await user.type(screen.getByLabelText("Label key"), "  env  ");
+    await user.type(screen.getByLabelText("Label value"), " prod ");
+    expect(add).toBeEnabled();
+    await user.click(add);
+    expect(addMutate()).toHaveBeenCalledWith({ k: "env", v: "prod" });
+  });
+
+  it("removes a label by key", async () => {
+    const user = userEvent.setup();
+    queryResponse = { data: [LABEL], isLoading: false };
+    render(<RepoLabelsPanel repository={REPO} />);
+    await user.click(screen.getByRole("button", { name: /Remove label team/i }));
+    expect(removeMutate()).toHaveBeenCalledWith("team");
+  });
+
+  it("mutation callbacks reset/invalidate/toast and call the API", () => {
+    render(<RepoLabelsPanel repository={REPO} />);
+    const [add, remove] = mutationConfigs;
+    add.mutationFn({ k: "team", v: "platform" });
+    expect(api.add).toHaveBeenCalledWith("my-repo", "team", "platform");
+    add.onSuccess?.(LABEL, { k: "team" });
+    remove.mutationFn("team");
+    expect(api.remove).toHaveBeenCalledWith("my-repo", "team");
+    remove.onSuccess?.();
+    expect(mockInvalidate).toHaveBeenCalled();
+    expect(mockToastSuccess).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/app/(app)/repositories/_components/repo-labels-panel.tsx
+++ b/src/app/(app)/repositories/_components/repo-labels-panel.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Plus, Trash2, Loader2, Tag } from "lucide-react";
+
+import repoLabelsApi, { type RepoLabel } from "@/lib/api/repo-labels";
+import { mutationErrorToast } from "@/lib/error-utils";
+import type { Repository } from "@/types";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface RepoLabelsPanelProps {
+  repository: Repository;
+}
+
+const LABELS_KEY = (key: string) => ["repo-labels", key];
+
+/** Manage a repository's key/value labels (artifact-keeper#... labels API). */
+export function RepoLabelsPanel({ repository }: RepoLabelsPanelProps) {
+  const queryClient = useQueryClient();
+  const [labelKey, setLabelKey] = useState("");
+  const [labelValue, setLabelValue] = useState("");
+
+  const { data: labels, isLoading } = useQuery({
+    queryKey: LABELS_KEY(repository.key),
+    queryFn: () => repoLabelsApi.list(repository.key),
+  });
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: LABELS_KEY(repository.key) });
+
+  const addMutation = useMutation({
+    mutationFn: ({ k, v }: { k: string; v: string }) => repoLabelsApi.add(repository.key, k, v),
+    onSuccess: (_l, { k }) => {
+      invalidate();
+      setLabelKey("");
+      setLabelValue("");
+      toast.success(`Label "${k}" saved`);
+    },
+    onError: mutationErrorToast("Failed to save label"),
+  });
+
+  const removeMutation = useMutation({
+    mutationFn: (k: string) => repoLabelsApi.remove(repository.key, k),
+    onSuccess: () => {
+      invalidate();
+      toast.success("Label removed");
+    },
+    onError: mutationErrorToast("Failed to remove label"),
+  });
+
+  const trimmedKey = labelKey.trim();
+  const canAdd = trimmedKey !== "" && !addMutation.isPending;
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canAdd) return;
+    addMutation.mutate({ k: trimmedKey, v: labelValue.trim() });
+  }
+
+  const rows = labels ?? [];
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        Key/value labels for organizing and filtering repositories.
+      </p>
+
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2 sm:flex-row sm:items-center" aria-label="Add a label">
+        <Input placeholder="key (e.g. team)" value={labelKey} onChange={(e) => setLabelKey(e.target.value)} aria-label="Label key" className="sm:max-w-xs" />
+        <Input placeholder="value (e.g. platform)" value={labelValue} onChange={(e) => setLabelValue(e.target.value)} aria-label="Label value" />
+        <Button type="submit" disabled={!canAdd}>
+          {addMutation.isPending ? <Loader2 className="size-4 animate-spin" /> : <Plus className="size-4" />}
+          Add
+        </Button>
+      </form>
+
+      {isLoading && (
+        <div className="space-y-2" role="status" aria-busy="true">
+          <Skeleton className="h-9 w-full" />
+          <Skeleton className="h-9 w-full" />
+        </div>
+      )}
+
+      {!isLoading && rows.length === 0 && (
+        <div className="flex flex-col items-center justify-center rounded-md border border-dashed py-10 text-center text-muted-foreground">
+          <Tag className="size-6 mb-2 opacity-50" />
+          <p className="text-sm">No labels yet.</p>
+        </div>
+      )}
+
+      {!isLoading && rows.length > 0 && (
+        <ul className="divide-y rounded-md border">
+          {rows.map((l: RepoLabel) => (
+            <li key={l.id} className="flex items-center justify-between gap-3 px-3 py-2">
+              <span className="truncate text-sm">
+                <span className="font-medium">{l.key}</span>
+                {l.value && <span className="text-muted-foreground"> = {l.value}</span>}
+              </span>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label={`Remove label ${l.key}`}
+                disabled={removeMutation.isPending}
+                onClick={() => removeMutation.mutate(l.key)}
+              >
+                <Trash2 className="size-4 text-destructive" />
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/lib/api/__tests__/repo-labels.test.ts
+++ b/src/lib/api/__tests__/repo-labels.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../fetch", () => ({ assertData: <T,>(d: T) => d }));
+vi.mock("@/lib/sdk-client", () => ({}));
+
+const m = { listRepoLabels: vi.fn(), addRepoLabel: vi.fn(), deleteRepoLabel: vi.fn() };
+vi.mock("@artifact-keeper/sdk", () => ({
+  listRepoLabels: (...a: unknown[]) => m.listRepoLabels(...a),
+  addRepoLabel: (...a: unknown[]) => m.addRepoLabel(...a),
+  deleteRepoLabel: (...a: unknown[]) => m.deleteRepoLabel(...a),
+}));
+
+import repoLabelsApi from "../repo-labels";
+
+const LABEL = { id: "l1", key: "team", value: "platform", repository_id: "r1", created_at: "x" };
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("repoLabelsApi", () => {
+  it("list maps LabelsListResponse.items", async () => {
+    m.listRepoLabels.mockResolvedValue({ data: { items: [LABEL], total: 1 }, error: undefined });
+    const out = await repoLabelsApi.list("my-repo");
+    expect(m.listRepoLabels).toHaveBeenCalledWith({ path: { key: "my-repo" } });
+    expect(out).toEqual([{ id: "l1", key: "team", value: "platform", created_at: "x" }]);
+  });
+
+  it("list throws on error", async () => {
+    m.listRepoLabels.mockResolvedValue({ data: undefined, error: { status: 500 } });
+    await expect(repoLabelsApi.list("r")).rejects.toEqual({ status: 500 });
+  });
+
+  it("add sends key + label_key path and {value} body", async () => {
+    m.addRepoLabel.mockResolvedValue({ data: LABEL, error: undefined });
+    const out = await repoLabelsApi.add("my-repo", "team", "platform");
+    expect(m.addRepoLabel).toHaveBeenCalledWith({ path: { key: "my-repo", label_key: "team" }, body: { value: "platform" } });
+    expect(out.key).toBe("team");
+  });
+
+  it("add throws on error", async () => {
+    m.addRepoLabel.mockResolvedValue({ data: undefined, error: { status: 400 } });
+    await expect(repoLabelsApi.add("r", "k", "v")).rejects.toEqual({ status: 400 });
+  });
+
+  it("remove deletes by key and resolves void", async () => {
+    m.deleteRepoLabel.mockResolvedValue({ error: undefined });
+    await expect(repoLabelsApi.remove("my-repo", "team")).resolves.toBeUndefined();
+    expect(m.deleteRepoLabel).toHaveBeenCalledWith({ path: { key: "my-repo", label_key: "team" } });
+  });
+
+  it("remove throws on error", async () => {
+    m.deleteRepoLabel.mockResolvedValue({ error: { status: 404 } });
+    await expect(repoLabelsApi.remove("r", "missing")).rejects.toEqual({ status: 404 });
+  });
+});

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -33,6 +33,8 @@ export { default as formatHandlersApi } from './format-handlers';
 export type { FormatHandler } from './format-handlers';
 export { default as qualityChecksApi } from './quality-checks';
 export type { QualityCheck, QualityIssue } from './quality-checks';
+export { default as repoLabelsApi } from './repo-labels';
+export type { RepoLabel } from './repo-labels';
 
 export type { LoginCredentials } from './auth';
 export type { ListRepositoriesParams } from './repositories';

--- a/src/lib/api/repo-labels.ts
+++ b/src/lib/api/repo-labels.ts
@@ -1,0 +1,45 @@
+import '@/lib/sdk-client';
+import {
+  listRepoLabels,
+  addRepoLabel,
+  deleteRepoLabel,
+} from '@artifact-keeper/sdk';
+import type { LabelResponse, LabelsListResponse } from '@artifact-keeper/sdk';
+import { assertData } from '@/lib/api/fetch';
+
+/** A key/value label on a repository. */
+export interface RepoLabel {
+  id: string;
+  key: string;
+  value: string;
+  created_at: string;
+}
+
+function adapt(sdk: LabelResponse): RepoLabel {
+  return { id: sdk.id, key: sdk.key, value: sdk.value, created_at: sdk.created_at };
+}
+
+const repoLabelsApi = {
+  list: async (repoKey: string): Promise<RepoLabel[]> => {
+    const { data, error } = await listRepoLabels({ path: { key: repoKey } });
+    if (error) throw error;
+    return (assertData(data, 'repoLabelsApi.list') as LabelsListResponse).items.map(adapt);
+  },
+
+  /** Add or update a single label (`label_key` = the label's key). */
+  add: async (repoKey: string, labelKey: string, value: string): Promise<RepoLabel> => {
+    const { data, error } = await addRepoLabel({
+      path: { key: repoKey, label_key: labelKey },
+      body: { value },
+    });
+    if (error) throw error;
+    return adapt(assertData(data, 'repoLabelsApi.add'));
+  },
+
+  remove: async (repoKey: string, labelKey: string): Promise<void> => {
+    const { error } = await deleteRepoLabel({ path: { key: repoKey, label_key: labelKey } });
+    if (error) throw error;
+  },
+};
+
+export default repoLabelsApi;


### PR DESCRIPTION
## Summary

**Final** feature of the 1.2.1 endpoint build-out. The backend repo-labels API (`/api/v1/repositories/{key}/labels*`) had no web UI; this adds a **Labels** tab on the repository detail view (admin) — labels are entity-scoped, so the repo detail is their natural home (same pattern as the PyPI-tracks tab).

### Repo detail → Labels tab (admin)
- List a repository's **key/value labels**
- **Add / update** a label (key + value)
- **Remove** a label
- Loading / empty states

### Code
- `src/lib/api/repo-labels.ts` — typed adapter over `listRepoLabels` (maps `LabelsListResponse.items`) / `addRepoLabel` (`{key}`+`{label_key}` path, `{value}` body) / `deleteRepoLabel`.
- `RepoLabelsPanel` component + Labels `TabsTrigger`/`TabsContent` wired into `repo-detail-content.tsx` (admin-gated).
- Barrel export.

## Tests
- API adapter: 6 cases (list mapping, add path+body, remove delete, error paths).
- Panel: 6 cases — empty/loading, list render (`key = value`), add (trim + disabled-until-key), remove, mutation callbacks.
- `npm run build` ✅, 12 tests green.

## Scope note
**Artifact labels** and **peer labels** (same `setLabels`/`addLabel`/`deleteLabel` shape, applied per-artifact / per-peer) are tracked as follow-ups — they belong on the artifact-detail and peer views respectively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)