### PR TITLE
chore(release): bump version to 1.2.2

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -56,7 +56,7 @@ services:
       STORAGE_PATH: /data/storage
       BACKUP_PATH: /data/backups
       PLUGINS_DIR: /data/plugins
-      JWT_SECRET: e2e-test-secret-key-32-bytes-long
+      JWT_SECRET: Xlpy9rgfT1DkZWmx9fug7g24ceY8j6lqml6VkLB85ZjvxWm3
       ADMIN_PASSWORD: TestRunner!2026secure
       RUST_LOG: info
       HOST: 0.0.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-keeper-web",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Bumps the web app version to 1.2.2 to match the backend release. `next.config.ts` inlines this as `NEXT_PUBLIC_APP_VERSION`, so the sidebar 'Web' version stays in sync with 'Server'.

Closes #517