### PR TITLE
fix(sso): surface SAML use_absolute_acs_url opt-in on the provider edit form

### DIFF
--- a/src/app/(app)/(admin)/settings/sso/__tests__/page.test.tsx
+++ b/src/app/(app)/(admin)/settings/sso/__tests__/page.test.tsx
@@ -222,6 +222,7 @@ const SAML_WITH_EXTRA_MAPPING = {
   admin_group: "artifact-keeper-admins",
   sign_requests: true,
   require_signed_assertions: true,
+  use_absolute_acs_url: false,
   is_enabled: true,
   created_at: "2025-01-01T00:00:00Z",
   updated_at: "2025-01-01T00:00:00Z",
@@ -387,5 +388,93 @@ describe("SSO SAML update preserves attribute_mapping (regression #406 sibling)"
         custom_claim: "department_code",
       });
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SAML use_absolute_acs_url opt-in (artifact-keeper backend migration 138)
+// ---------------------------------------------------------------------------
+
+describe("SSO SAML use_absolute_acs_url toggle", () => {
+  it("preserves the existing use_absolute_acs_url value on an unrelated edit", async () => {
+    // Regression: an operator editing only the Name must not flip the
+    // ACS-URL mode just because the form remounted. The toggle's initial
+    // state is sourced from the loaded config, and the submit payload
+    // must echo it back.
+    const user = userEvent.setup();
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Corporate SAML IdP")).toBeTruthy();
+    });
+
+    const editBtn = screen.getByRole("button", {
+      name: /Edit SAML provider Corporate SAML IdP/i,
+    });
+    await user.click(editBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Edit SAML Provider")).toBeTruthy();
+    });
+
+    // Change only the Name field. The Use-absolute-ACS-URL toggle stays
+    // at the loaded provider's value (false).
+    const nameInput = screen.getByLabelText(/^Name$/i) as HTMLInputElement;
+    await user.clear(nameInput);
+    await user.type(nameInput, "Corporate SAML IdP (renamed)");
+
+    const saveBtn = screen.getByRole("button", { name: /Save Changes/i });
+    await user.click(saveBtn);
+
+    await waitFor(() => {
+      expect(mockSsoApi.updateSaml).toHaveBeenCalledTimes(1);
+    });
+
+    const [, payload] = mockSsoApi.updateSaml.mock.calls[0] as [
+      string,
+      { use_absolute_acs_url?: boolean },
+    ];
+    expect(payload.use_absolute_acs_url).toBe(false);
+  });
+
+  it("propagates the toggled value into the update payload", async () => {
+    // The toggle starts off (as in the fixture); the operator turns it
+    // on and saves. The outbound payload must carry `true`.
+    const user = userEvent.setup();
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Corporate SAML IdP")).toBeTruthy();
+    });
+
+    const editBtn = screen.getByRole("button", {
+      name: /Edit SAML provider Corporate SAML IdP/i,
+    });
+    await user.click(editBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Edit SAML Provider")).toBeTruthy();
+    });
+
+    // Flip the new switch on. The mocked `Switch` is rendered as a
+    // native checkbox by the test harness, so we can address it by its
+    // label and click it directly.
+    const toggle = screen.getByLabelText(/Use absolute ACS URL/i) as HTMLInputElement;
+    expect(toggle.checked).toBe(false);
+    await user.click(toggle);
+    expect(toggle.checked).toBe(true);
+
+    const saveBtn = screen.getByRole("button", { name: /Save Changes/i });
+    await user.click(saveBtn);
+
+    await waitFor(() => {
+      expect(mockSsoApi.updateSaml).toHaveBeenCalledTimes(1);
+    });
+
+    const [, payload] = mockSsoApi.updateSaml.mock.calls[0] as [
+      string,
+      { use_absolute_acs_url?: boolean },
+    ];
+    expect(payload.use_absolute_acs_url).toBe(true);
   });
 });

--- a/src/app/(app)/(admin)/settings/sso/page.tsx
+++ b/src/app/(app)/(admin)/settings/sso/page.tsx
@@ -1080,6 +1080,7 @@ function SamlTab() {
   const [nameIdFormat, setNameIdFormat] = useState("urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress");
   const [signRequests, setSignRequests] = useState(false);
   const [requireSignedAssertions, setRequireSignedAssertions] = useState(true);
+  const [useAbsoluteAcsUrl, setUseAbsoluteAcsUrl] = useState(false);
   const [usernameClaim, setUsernameClaim] = useState("username");
   const [emailClaim, setEmailClaim] = useState("email");
   const [displayNameClaim, setDisplayNameClaim] = useState("displayName");
@@ -1142,6 +1143,7 @@ function SamlTab() {
     setNameIdFormat("urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress");
     setSignRequests(false);
     setRequireSignedAssertions(true);
+    setUseAbsoluteAcsUrl(false);
     setUsernameClaim("username");
     setEmailClaim("email");
     setDisplayNameClaim("displayName");
@@ -1172,6 +1174,7 @@ function SamlTab() {
     setNameIdFormat(config.name_id_format);
     setSignRequests(config.sign_requests);
     setRequireSignedAssertions(config.require_signed_assertions);
+    setUseAbsoluteAcsUrl(config.use_absolute_acs_url);
     setUsernameClaim(config.attribute_mapping?.username || "username");
     setEmailClaim(config.attribute_mapping?.email || "email");
     setDisplayNameClaim(config.attribute_mapping?.display_name || "displayName");
@@ -1207,6 +1210,7 @@ function SamlTab() {
         sign_requests: signRequests,
         require_signed_assertions: requireSignedAssertions,
         admin_group: adminGroup || undefined,
+        use_absolute_acs_url: useAbsoluteAcsUrl,
       };
       if (certificate) {
         data.certificate = certificate;
@@ -1225,6 +1229,7 @@ function SamlTab() {
         sign_requests: signRequests,
         require_signed_assertions: requireSignedAssertions,
         admin_group: adminGroup || undefined,
+        use_absolute_acs_url: useAbsoluteAcsUrl,
       });
     }
   }
@@ -1472,6 +1477,22 @@ function SamlTab() {
                 id="saml-require-signed-assertions"
                 checked={requireSignedAssertions}
                 onCheckedChange={setRequireSignedAssertions}
+              />
+            </div>
+
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label htmlFor="saml-use-absolute-acs-url">Use absolute ACS URL</Label>
+                <p className="text-xs text-muted-foreground">
+                  Emit a full <code>{`{base_url}/api/v1/auth/sso/saml/<id>/acs`}</code> URL in the
+                  AuthnRequest instead of the historical relative path. Required by stricter
+                  SAML 2.0 IdPs that reject relative AssertionConsumerServiceURLs.
+                </p>
+              </div>
+              <Switch
+                id="saml-use-absolute-acs-url"
+                checked={useAbsoluteAcsUrl}
+                onCheckedChange={setUseAbsoluteAcsUrl}
               />
             </div>
 

--- a/src/lib/api/sso.ts
+++ b/src/lib/api/sso.ts
@@ -126,6 +126,11 @@ function adaptLdapConfig(sdk: SdkLdapConfigResponse): LdapConfig {
 }
 
 function adaptSamlConfig(sdk: SdkSamlConfigResponse): SamlConfig {
+  // The `use_absolute_acs_url` field arrives once the backend release that
+  // ships migration 138 has been deployed and the regenerated
+  // @artifact-keeper/sdk picks the new field up. Until then, treat absent
+  // as `false` so older backends keep their pre-138 wire format.
+  const sdkAny = sdk as unknown as { use_absolute_acs_url?: boolean };
   return {
     id: sdk.id,
     name: sdk.name,
@@ -140,6 +145,7 @@ function adaptSamlConfig(sdk: SdkSamlConfigResponse): SamlConfig {
     require_signed_assertions: sdk.require_signed_assertions,
     admin_group: sdk.admin_group ?? null,
     is_enabled: sdk.is_enabled,
+    use_absolute_acs_url: sdkAny.use_absolute_acs_url ?? false,
     created_at: sdk.created_at,
     updated_at: sdk.updated_at,
   };

--- a/src/types/sso.ts
+++ b/src/types/sso.ts
@@ -55,6 +55,10 @@ export interface SamlConfig {
   require_signed_assertions: boolean;
   admin_group: string | null;
   is_enabled: boolean;
+  // Backend migration 138 (artifact-keeper PR #TBD). When true, the SAML
+  // AuthnRequest emits an absolute AssertionConsumerServiceURL instead of
+  // the historical relative path. Default false on existing rows.
+  use_absolute_acs_url: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -133,6 +137,7 @@ export interface CreateSamlConfigRequest {
   sign_requests?: boolean;
   require_signed_assertions?: boolean;
   admin_group?: string;
+  use_absolute_acs_url?: boolean;
 }
 
 export interface UpdateSamlConfigRequest {
@@ -147,4 +152,5 @@ export interface UpdateSamlConfigRequest {
   sign_requests?: boolean;
   require_signed_assertions?: boolean;
   admin_group?: string;
+  use_absolute_acs_url?: boolean;
 }


### PR DESCRIPTION
## Summary

Companion to the artifact-keeper backend change that adds a per-provider `use_absolute_acs_url` flag (tracked in artifact-keeper/artifact-keeper#2038, migration 138). The flag toggles whether the SAML AuthnRequest emits an absolute `AssertionConsumerServiceURL` or the historical relative path; stricter SAML 2.0 IdPs (notably Lark AnyCross and certain enterprise deployments) reject a relative ACS URL outright.

UI changes (Admin → Settings → SSO → SAML Providers, edit dialog):

- New **Use absolute ACS URL** Switch sits below "Require Signed Assertions" in the same opt-in group. Off by default — existing providers keep their pre-138 wire format.
- The switch help text spells out what the IdP receives and why an operator would flip it on so the change is self-explanatory at the edit screen without diving into release notes.
- Initial state on edit is sourced from `config.use_absolute_acs_url`; the submit payload echoes the toggle's value back to the backend on both create and update.

Type / adapter changes:

- `SamlConfig` (response shape) gains `use_absolute_acs_url: boolean`. `CreateSamlConfigRequest` / `UpdateSamlConfigRequest` gain `use_absolute_acs_url?: boolean` so the toggle round-trips. Mirrors the backend's `Option<bool>` convention on the request side and the always-present `bool` on the response side.
- `adaptSamlConfig` defensively reads the field via a narrowed cast and defaults to `false` when absent. The regenerated `@artifact-keeper/sdk` drops in automatically on the next backend release tag (the `sync-openapi-spec` workflow pushes the new schema to `artifact-keeper-api` and that repo's release pipeline republishes the TS SDK); until then, talking to an older backend that doesn't return the field simply means the form starts at `false`, which is exactly the pre-138 behaviour.

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

Two new Vitest cases in `SSO SAML use_absolute_acs_url toggle`:

- `preserves the existing use_absolute_acs_url value on an unrelated edit` — opens the edit dialog on a provider with the flag off, changes only Name, asserts the outbound `updateSaml` payload still carries `use_absolute_acs_url: false`. Pins the no-accidental-flip contract.
- `propagates the toggled value into the update payload` — clicks the new switch, saves, asserts `use_absolute_acs_url: true` reaches the update call.

The existing `SAML_WITH_EXTRA_MAPPING` fixture is extended with `use_absolute_acs_url: false` so the prior #406 attribute_mapping regression test continues to model the realistic response shape.

Verification:

- `npm run lint` clean on changed files (0 errors; the 36 warnings are pre-existing in unrelated files).
- `npm test -- 'src/app/(app)/(admin)/settings/sso'`: 4/4 passed, including the two new cases.

## UI Changes
- [ ] Playwright E2E spec covers the change
- [x] Responsive layout verified (mobile + desktop) — the new switch sits inside the existing `flex items-center justify-between` row pattern reused from Sign Requests / Require Signed Assertions, so responsive behaviour matches the surrounding controls.
- [x] Dark mode verified — uses default `text-muted-foreground` for help copy; no custom colours that would diverge between themes.
- [x] Accessibility checked (keyboard navigation, screen reader) — Switch has `id="saml-use-absolute-acs-url"` with the matching Label so screen readers announce the toggle and its help text correctly; tab order follows the surrounding controls.
- [ ] N/A - no UI changes

Playwright spec is intentionally not added here — the dependent backend change has to land first so an end-to-end browser test against a fresh stack can exercise the full opt-in flow. Happy to add one in a follow-up PR once the backend PR is in.

Fixes #521
