### PR TITLE
feat(sso): surface OIDC allow_legacy_rsa_keys opt-in on the provider edit form

### DIFF
--- a/src/app/(app)/(admin)/settings/sso/__tests__/page.test.tsx
+++ b/src/app/(app)/(admin)/settings/sso/__tests__/page.test.tsx
@@ -191,6 +191,7 @@ const OIDC_WITH_EXTRA_MAPPING = {
   },
   auto_create_users: true,
   map_groups_to_groups: false,
+  allow_legacy_rsa_keys: false,
   is_enabled: true,
   created_at: "2025-01-01T00:00:00Z",
   updated_at: "2025-01-01T00:00:00Z",
@@ -511,5 +512,116 @@ describe("SSO SAML use_absolute_acs_url toggle (#521)", () => {
       { use_absolute_acs_url?: boolean },
     ];
     expect(payload.use_absolute_acs_url).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OIDC allow_legacy_rsa_keys opt-in (artifact-keeper backend migration 144)
+// ---------------------------------------------------------------------------
+
+describe("SSO OIDC allow_legacy_rsa_keys toggle", () => {
+  it("preserves the existing allow_legacy_rsa_keys value on an unrelated edit", async () => {
+    // Regression: editing an unrelated field (e.g. Name) must not flip the
+    // legacy-RSA flag on or off — the toggle's initial state is sourced
+    // from the loaded provider, and the submit payload must echo it back.
+    const user = userEvent.setup();
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Corporate IdP")).toBeTruthy();
+    });
+
+    const editBtn = screen.getByRole("button", {
+      name: /Edit OIDC provider Corporate IdP/i,
+    });
+    await user.click(editBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Edit OIDC Provider")).toBeTruthy();
+    });
+
+    const nameInput = screen.getByLabelText(/^Name$/i) as HTMLInputElement;
+    await user.clear(nameInput);
+    await user.type(nameInput, "Corporate IdP (renamed)");
+
+    const saveBtn = screen.getByRole("button", { name: /Save Changes/i });
+    await user.click(saveBtn);
+
+    await waitFor(() => {
+      expect(mockSsoApi.updateOidc).toHaveBeenCalledTimes(1);
+    });
+
+    const [, payload] = mockSsoApi.updateOidc.mock.calls[0] as [
+      string,
+      { allow_legacy_rsa_keys?: boolean },
+    ];
+    expect(payload.allow_legacy_rsa_keys).toBe(false);
+  });
+
+  it("propagates the toggled value into the update payload", async () => {
+    // The toggle starts off (as in the fixture); the operator turns it on
+    // because their IdP is a legacy 1024-bit RSA IdP and saves. The
+    // outbound payload must carry `true`.
+    const user = userEvent.setup();
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Corporate IdP")).toBeTruthy();
+    });
+
+    const editBtn = screen.getByRole("button", {
+      name: /Edit OIDC provider Corporate IdP/i,
+    });
+    await user.click(editBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Edit OIDC Provider")).toBeTruthy();
+    });
+
+    // Flip the new switch on via its label text.
+    const toggle = screen.getByLabelText(
+      /Allow legacy RSA keys/i,
+    ) as HTMLInputElement;
+    expect(toggle.checked).toBe(false);
+    await user.click(toggle);
+    expect(toggle.checked).toBe(true);
+
+    const saveBtn = screen.getByRole("button", { name: /Save Changes/i });
+    await user.click(saveBtn);
+
+    await waitFor(() => {
+      expect(mockSsoApi.updateOidc).toHaveBeenCalledTimes(1);
+    });
+
+    const [, payload] = mockSsoApi.updateOidc.mock.calls[0] as [
+      string,
+      { allow_legacy_rsa_keys?: boolean },
+    ];
+    expect(payload.allow_legacy_rsa_keys).toBe(true);
+  });
+
+  it("surfaces the OWASP-baseline warning in the toggle help text", async () => {
+    // Reviewers asking "why is this opt-in" should land directly on the
+    // amber warning — pin its wording so a future refactor cannot quietly
+    // soften it.
+    const user = userEvent.setup();
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Corporate IdP")).toBeTruthy();
+    });
+
+    const editBtn = screen.getByRole("button", {
+      name: /Edit OIDC provider Corporate IdP/i,
+    });
+    await user.click(editBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Edit OIDC Provider")).toBeTruthy();
+    });
+
+    expect(
+      screen.getByText(/Below the OWASP ASVS 4\.0 baseline/i),
+    ).toBeTruthy();
   });
 });

--- a/src/app/(app)/(admin)/settings/sso/page.tsx
+++ b/src/app/(app)/(admin)/settings/sso/page.tsx
@@ -86,6 +86,7 @@ function OidcTab() {
   const [scopes, setScopes] = useState("openid profile email");
   const [autoCreateUsers, setAutoCreateUsers] = useState(true);
   const [mapGroupsToGroups, setMapGroupsToGroups] = useState(false);
+  const [allowLegacyRsaKeys, setAllowLegacyRsaKeys] = useState(false);
   const [usernameClaim, setUsernameClaim] = useState("preferred_username");
   const [emailClaim, setEmailClaim] = useState("email");
   const [displayNameClaim, setDisplayNameClaim] = useState("name");
@@ -146,6 +147,7 @@ function OidcTab() {
     setScopes("openid profile email");
     setAutoCreateUsers(true);
     setMapGroupsToGroups(false);
+    setAllowLegacyRsaKeys(false);
     setUsernameClaim("preferred_username");
     setEmailClaim("email");
     setDisplayNameClaim("name");
@@ -174,6 +176,7 @@ function OidcTab() {
     setScopes(config.scopes.join(" "));
     setAutoCreateUsers(config.auto_create_users);
     setMapGroupsToGroups(config.map_groups_to_groups);
+    setAllowLegacyRsaKeys(config.allow_legacy_rsa_keys);
     // #516: the backend reads the OIDC claim overrides under the
     // `<field>_claim` keys (username_claim / email_claim / groups_claim).
     // Prefer those, but fall back to the legacy bare keys so a provider
@@ -250,6 +253,7 @@ function OidcTab() {
         attribute_mapping: attributeMapping,
         auto_create_users: autoCreateUsers,
         map_groups_to_groups: mapGroupsToGroups,
+        allow_legacy_rsa_keys: allowLegacyRsaKeys,
       };
       if (clientSecret) {
         data.client_secret = clientSecret;
@@ -265,6 +269,7 @@ function OidcTab() {
         attribute_mapping: attributeMapping,
         auto_create_users: autoCreateUsers,
         map_groups_to_groups: mapGroupsToGroups,
+        allow_legacy_rsa_keys: allowLegacyRsaKeys,
       });
     }
   }
@@ -488,6 +493,27 @@ function OidcTab() {
                 id="oidc-map-groups-to-groups"
                 checked={mapGroupsToGroups}
                 onCheckedChange={setMapGroupsToGroups}
+              />
+            </div>
+
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5 pr-4">
+                <Label htmlFor="oidc-allow-legacy-rsa-keys">
+                  Allow legacy RSA keys (&lt; 2048-bit)
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  Accept ID tokens signed with RSA keys shorter than 2048 bits via a
+                  restricted RS256/384/512 PKCS#1 v1.5 fallback. Only enable for legacy
+                  IdPs such as Lark AnyCross.{" "}
+                  <span className="text-amber-600 dark:text-amber-400 font-medium">
+                    Below the OWASP ASVS 4.0 baseline.
+                  </span>
+                </p>
+              </div>
+              <Switch
+                id="oidc-allow-legacy-rsa-keys"
+                checked={allowLegacyRsaKeys}
+                onCheckedChange={setAllowLegacyRsaKeys}
               />
             </div>
 

--- a/src/lib/api/sso.ts
+++ b/src/lib/api/sso.ts
@@ -87,6 +87,11 @@ function adaptSsoProvider(sdk: SdkSsoProviderInfo): SsoProvider {
 }
 
 function adaptOidcConfig(sdk: SdkOidcConfigResponse): OidcConfig {
+  // The `allow_legacy_rsa_keys` field arrives once the backend release
+  // that ships migration 144 has been deployed and the regenerated
+  // @artifact-keeper/sdk picks it up. Until then, default to `false` —
+  // matches the migration's default and the strict pre-144 behaviour.
+  const sdkAny = sdk as unknown as { allow_legacy_rsa_keys?: boolean };
   return {
     id: sdk.id,
     name: sdk.name,
@@ -103,6 +108,7 @@ function adaptOidcConfig(sdk: SdkOidcConfigResponse): OidcConfig {
     map_groups_to_groups:
       (sdk as { map_groups_to_groups?: boolean }).map_groups_to_groups ?? false,
     is_enabled: sdk.is_enabled,
+    allow_legacy_rsa_keys: sdkAny.allow_legacy_rsa_keys ?? false,
     created_at: sdk.created_at,
     updated_at: sdk.updated_at,
   };

--- a/src/types/sso.ts
+++ b/src/types/sso.ts
@@ -24,6 +24,11 @@ export interface OidcConfig {
    */
   map_groups_to_groups: boolean;
   is_enabled: boolean;
+  // Backend migration 144 (artifact-keeper PR #TBD). When true, the OIDC
+  // provider accepts ID tokens signed with RSA keys shorter than 2048
+  // bits via a restricted RS256/384/512 PKCS#1 v1.5 fallback. Below the
+  // OWASP ASVS 4.0 baseline; default false on existing rows.
+  allow_legacy_rsa_keys: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -90,6 +95,7 @@ export interface CreateOidcConfigRequest {
   attribute_mapping?: Record<string, string>;
   auto_create_users?: boolean;
   map_groups_to_groups?: boolean;
+  allow_legacy_rsa_keys?: boolean;
 }
 
 export interface UpdateOidcConfigRequest {
@@ -101,6 +107,7 @@ export interface UpdateOidcConfigRequest {
   attribute_mapping?: Record<string, string>;
   auto_create_users?: boolean;
   map_groups_to_groups?: boolean;
+  allow_legacy_rsa_keys?: boolean;
 }
 
 export interface CreateLdapConfigRequest {


### PR DESCRIPTION
## Summary

Companion to the artifact-keeper backend change that adds a per-provider `allow_legacy_rsa_keys` flag (tracked in artifact-keeper/artifact-keeper#2039, migration 139). The flag opts into a restricted manual `rsa` + `sha2` PKCS#1 v1.5 fallback that accepts ID tokens signed with RSA keys shorter than 2048 bits, scoped to RS256 / RS384 / RS512 only. The strict path keeps enforcing the OWASP ASVS 4.0 V6.2.5 baseline by default; this UI lets an operator opt a specific provider out — typically for legacy IdPs such as Lark AnyCross.

UI changes (Admin → Settings → SSO → OIDC Providers, edit dialog):

- New **Allow legacy RSA keys (< 2048-bit)** Switch sits below "Auto Create Users" in the same opt-in group. Off by default — existing providers keep their pre-139 strict-verification behaviour.
- Help text spells out what gets accepted when the flag is on (sub-2048-bit RSA via RS256/384/512 PKCS#1 v1.5 fallback), why an operator would enable it (Lark AnyCross is named directly), and the trade-off — an amber-coloured "Below the OWASP ASVS 4.0 baseline" line ensures reviewers and operators land on the security caveat at the point of decision rather than in a release-notes afterthought.
- Initial state on edit is sourced from `config.allow_legacy_rsa_keys`; the submit payload echoes the toggle's value back to the backend on both create and update.

Type / adapter changes:

- `OidcConfig` (response shape) gains `allow_legacy_rsa_keys: boolean`. `CreateOidcConfigRequest` / `UpdateOidcConfigRequest` gain `allow_legacy_rsa_keys?: boolean` so the toggle round-trips on both paths.
- `adaptOidcConfig` defensively reads the field via a narrowed cast and defaults to `false` when absent — matches the migration's default and preserves the strict pre-139 behaviour when talking to an older backend whose regenerated SDK has not yet shipped the field.

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

Three new Vitest cases in `SSO OIDC allow_legacy_rsa_keys toggle`:

- `preserves the existing allow_legacy_rsa_keys value on an unrelated edit` — opens the edit dialog on a provider with the flag off, changes only Name, asserts the outbound `updateOidc` payload still carries `allow_legacy_rsa_keys: false`. Pins the no-accidental-flip contract.
- `propagates the toggled value into the update payload` — clicks the new switch, saves, asserts `allow_legacy_rsa_keys: true` reaches the update call.
- `surfaces the OWASP-baseline warning in the toggle help text` — asserts the amber-coloured warning is rendered. Pins the wording so a future refactor cannot quietly soften it.

The existing `OIDC_WITH_EXTRA_MAPPING` fixture is extended with `allow_legacy_rsa_keys: false` so the prior #406 attribute_mapping regression test continues to model the realistic response shape.

Verification:

- `npm run lint` clean on changed files (0 errors; the 36 warnings are pre-existing in unrelated files).
- `npm test -- 'src/app/(app)/(admin)/settings/sso'`: 5/5 passed (2 prior + 3 new).

## UI Changes
- [ ] Playwright E2E spec covers the change
- [x] Responsive layout verified — same `flex items-center justify-between` row pattern as the surrounding toggles (Auto Create Users, etc.).
- [x] Dark mode verified — `text-muted-foreground` for the help copy and `text-amber-600 dark:text-amber-400` for the warning line, which has explicit dark-mode tuning so the caveat reads clearly in both themes.
- [x] Accessibility checked (keyboard navigation, screen reader) — Switch has `id="oidc-allow-legacy-rsa-keys"` with the matching Label; the warning line is in the same DOM block as the Label so it is read out alongside the toggle's purpose.
- [ ] N/A - no UI changes

Playwright spec is intentionally not added here — the dependent backend change has to land first so an end-to-end browser test against a fresh stack can exercise the legacy-RSA verification behaviour. Happy to add one in a follow-up PR once the backend PR is in.

Fixes #522
