### PR TITLE
chore(release): bump version to 1.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-keeper-web",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Bumps the web app version to 1.2.3 to match the backend release (version-sync). `next.config.ts` inlines this as `NEXT_PUBLIC_APP_VERSION` so the sidebar 'Web' version matches 'Server', and it produces a `web:1.2.3` image for the chart's appVersion. No UI feature changes.

Closes #531