### PR TITLE
feat(sso): expose OIDC "Map groups to local groups" toggle

### DIFF
--- a/e2e/suites/interactions/admin/sso.spec.ts
+++ b/e2e/suites/interactions/admin/sso.spec.ts
@@ -67,10 +67,11 @@ test.describe('SSO Settings', () => {
     const dialog = page.getByRole('dialog').or(page.locator('[role="dialog"]'));
     await expect(dialog).toBeVisible({ timeout: 5000 });
     // The "Map OIDC groups to local groups" switch surfaces the backend
-    // map_groups_to_groups setting.
+    // map_groups_to_groups setting, including its help text.
     await expect(
       dialog.getByText(/map oidc groups to local groups/i).first()
     ).toBeVisible({ timeout: 5000 });
+    await expect(dialog.getByText(/group memberships/i).first()).toBeVisible({ timeout: 5000 });
     await expect(dialog.getByLabel(/map oidc groups to local groups/i)).toBeVisible({ timeout: 5000 });
     await page.getByRole('button', { name: /cancel/i }).click();
   });

--- a/src/app/(app)/(admin)/settings/sso/__tests__/page.test.tsx
+++ b/src/app/(app)/(admin)/settings/sso/__tests__/page.test.tsx
@@ -416,8 +416,12 @@ describe("SSO OIDC claim keys match backend (#516)", () => {
 
     const [, payload] = mockSsoApi.updateOidc.mock.calls[0] as [
       string,
-      { attribute_mapping?: Record<string, string> },
+      {
+        map_groups_to_groups?: boolean;
+        attribute_mapping?: Record<string, string>;
+      },
     ];
+    expect(payload.map_groups_to_groups).toBe(false);
     const mapping = payload.attribute_mapping ?? {};
 
     // Backend (sso.rs::resolve_oidc_claim_name) reads the `_claim` keys.
@@ -472,6 +476,47 @@ describe("SSO OIDC map_groups_to_groups toggle (#534)", () => {
       string,
       { map_groups_to_groups?: boolean },
     ];
+    expect(payload.map_groups_to_groups).toBe(true);
+  });
+
+  it("create submits map_groups_to_groups: true when the toggle is switched on", async () => {
+    mockSsoApi.createOidc.mockResolvedValue(OIDC_WITH_EXTRA_MAPPING);
+    const user = userEvent.setup();
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Corporate IdP")).toBeTruthy();
+    });
+
+    // The Tabs mock renders every tab's content inline; the first
+    // "Add Provider" button belongs to the OIDC card.
+    await user.click(screen.getAllByRole("button", { name: "Add Provider" })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText("Add OIDC Provider")).toBeTruthy();
+    });
+
+    await user.type(screen.getByLabelText(/^Name$/i), "New IdP");
+    await user.type(screen.getByLabelText(/issuer url/i), "https://idp.new");
+    await user.type(screen.getByLabelText(/client id/i), "client-new");
+    await user.type(screen.getByLabelText(/client secret/i), "shh");
+
+    // Default is off; toggle it on.
+    const toggle = screen.getByLabelText(
+      /Map OIDC groups to local groups/i,
+    ) as HTMLInputElement;
+    expect(toggle.checked).toBe(false);
+    await user.click(toggle);
+
+    await user.click(screen.getByRole("button", { name: /Create Provider/i }));
+
+    await waitFor(() => {
+      expect(mockSsoApi.createOidc).toHaveBeenCalledTimes(1);
+    });
+
+    const payload = mockSsoApi.createOidc.mock.calls[0][0] as {
+      map_groups_to_groups?: boolean;
+    };
     expect(payload.map_groups_to_groups).toBe(true);
   });
 });

--- a/src/lib/api/__tests__/sso.test.ts
+++ b/src/lib/api/__tests__/sso.test.ts
@@ -174,6 +174,17 @@ describe("ssoApi", () => {
     const out = await ssoApi.listOidc();
     expect(out[0].id).toBe("o1");
     expect(out[0].attribute_mapping).toEqual({ email: "email", name: "name" });
+    expect(out[0].map_groups_to_groups).toBe(false);
+  });
+
+  it("listOidc maps map_groups_to_groups through (#1879)", async () => {
+    mockListOidc.mockResolvedValue({
+      data: [{ ...SDK_OIDC, map_groups_to_groups: true }],
+      error: undefined,
+    });
+    const { ssoApi } = await import("../sso");
+    const out = await ssoApi.listOidc();
+    expect(out[0].map_groups_to_groups).toBe(true);
   });
 
   it("listOidc coerces non-string attribute_mapping values (#359)", async () => {
@@ -264,6 +275,7 @@ describe("ssoApi", () => {
       client_secret: "secret",
       scopes: ["openid"],
       auto_create_users: true,
+      map_groups_to_groups: true,
     });
     expect(mockCreateOidc).toHaveBeenCalledWith({
       body: {
@@ -274,6 +286,7 @@ describe("ssoApi", () => {
         scopes: ["openid"],
         attribute_mapping: undefined,
         auto_create_users: true,
+        map_groups_to_groups: true,
       },
     });
   });
@@ -291,11 +304,18 @@ describe("ssoApi", () => {
     ).rejects.toBe("fail");
   });
 
-  it("updateOidc returns config", async () => {
+  it("updateOidc returns config and forwards body (#1879)", async () => {
     mockUpdateOidc.mockResolvedValue({ data: SDK_OIDC, error: undefined });
     const { ssoApi } = await import("../sso");
-    const out = await ssoApi.updateOidc("o1", { name: "renamed" });
+    const out = await ssoApi.updateOidc("o1", {
+      name: "renamed",
+      map_groups_to_groups: true,
+    });
     expect(out.id).toBe("o1");
+    expect(mockUpdateOidc).toHaveBeenCalledWith({
+      path: { id: "o1" },
+      body: { name: "renamed", map_groups_to_groups: true },
+    });
   });
 
   it("updateOidc throws on error", async () => {


### PR DESCRIPTION
## Summary

Exposes the backend-supported `map_groups_to_groups` OIDC setting in the SSO
admin UI. Previously there was no way to enable or view this from the web
admin, even though the backend fully supports it.

- Add `map_groups_to_groups` to the local `OidcConfig` type and to the OIDC
  create/update request types, and map `sdk.map_groups_to_groups` in
  `adaptOidcConfig`.
- Add a **"Map OIDC groups to local groups"** `Switch` to the OIDC
  create/edit dialog (default off), placed with the group controls. It is
  initialized from the provider on edit, reset on create, and carries help
  text: the groups claim is reflected into Artifact Keeper group
  memberships, matching groups may be auto-created for the provider, and
  groups you manage manually are left unchanged.
- Include `map_groups_to_groups` in the OIDC create and update payloads.

Closes #534
Implements artifact-keeper/artifact-keeper#1879

### Manual testing

Verified end-to-end against a local Keycloak IdP (realm with a `groups`
claim mapper and a user in two groups): created the OIDC provider through
this new dialog with the toggle on, logged in via OIDC, and confirmed the
group-claim values were reflected into local group memberships. With the
toggle off, memberships were not synced.

## Test Checklist
- [x] Unit tests added/updated
- [x] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [x] Playwright E2E spec covers the change
- [x] Responsive layout verified (mobile + desktop)
- [x] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)

<details><summary>Click to see screenshots</summary>

Mobile Light
<img width="780" height="2380" alt="oidc-dialog-mobile-light" src="https://github.com/user-attachments/assets/25f592f6-3d45-4d96-a186-f3b18f98d65b" />

Desktop Dark
<img width="1024" height="2220" alt="oidc-dialog-desktop-dark" src="https://github.com/user-attachments/assets/5ea6898f-44e8-4389-b4f9-b93c9734c1c8" />


</details>
