### PR TITLE
chore(release): bump web to 1.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-keeper-web",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Closes #536

Web package.json 1.2.3 → 1.2.4 (lockstep with backend for the v1.2.4 release). Tagging v1.2.4 after merge publishes the web image.

(Note: package-lock root version has been drifting since 1.2.1 across releases — pre-existing, non-blocking; left as-is to match the proven 1.2.2/1.2.3 process. Worth a separate cleanup.)