### PR TITLE
chore(release): bump web to 1.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-keeper-web",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
Bumps the web app version from 1.2.4 to 1.2.5 for the v1.2.5 release, in lockstep with the backend.

## Changes
- `package.json`: `"version"` 1.2.4 -> 1.2.5

## Notes
- Per established release convention this is a package.json-only bump. The root `package-lock.json` `version` field carries pre-existing drift (sits at 1.2.1) and is intentionally not touched, consistent with prior release PRs.
- No other hardcoded `1.2.4` occurrences exist in the web source (verified via grep across ts/tsx/js/jsx/json).

Closes #539