### PR TITLE
feat(sso): expose OIDC "Map groups to local groups" toggle (#534)

### DIFF
--- a/e2e/suites/interactions/admin/sso.spec.ts
+++ b/e2e/suites/interactions/admin/sso.spec.ts
@@ -60,6 +60,21 @@ test.describe('SSO Settings', () => {
     await page.getByRole('button', { name: /cancel/i }).click();
   });
 
+  test('OIDC dialog exposes Map groups to local groups toggle (#534)', async ({ page }) => {
+    await page.goto('/settings/sso');
+    await page.locator('[role="tablist"] >> text=OIDC').first().click();
+    await page.getByRole('button', { name: /create.*provider|add.*provider|create/i }).first().click();
+    const dialog = page.getByRole('dialog').or(page.locator('[role="dialog"]'));
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    // The "Map OIDC groups to local groups" switch surfaces the backend
+    // map_groups_to_groups setting.
+    await expect(
+      dialog.getByText(/map oidc groups to local groups/i).first()
+    ).toBeVisible({ timeout: 5000 });
+    await expect(dialog.getByLabel(/map oidc groups to local groups/i)).toBeVisible({ timeout: 5000 });
+    await page.getByRole('button', { name: /cancel/i }).click();
+  });
+
   test('cancel closes OIDC dialog', async ({ page }) => {
     await page.goto('/settings/sso');
     await page.locator('[role="tablist"] >> text=OIDC').first().click();

--- a/src/app/(app)/(admin)/settings/sso/__tests__/page.test.tsx
+++ b/src/app/(app)/(admin)/settings/sso/__tests__/page.test.tsx
@@ -190,6 +190,7 @@ const OIDC_WITH_EXTRA_MAPPING = {
     custom_claim: "department_code",
   },
   auto_create_users: true,
+  map_groups_to_groups: false,
   is_enabled: true,
   created_at: "2025-01-01T00:00:00Z",
   updated_at: "2025-01-01T00:00:00Z",
@@ -433,6 +434,45 @@ describe("SSO OIDC claim keys match backend (#516)", () => {
 
     // Unrelated keys still round-trip (regression #406).
     expect(mapping.custom_claim).toBe("department_code");
+  });
+});
+
+describe("SSO OIDC map_groups_to_groups toggle (#534)", () => {
+  it("sends map_groups_to_groups=true when the operator enables it", async () => {
+    const user = userEvent.setup();
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Corporate IdP")).toBeTruthy();
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /Edit OIDC provider Corporate IdP/i,
+      }),
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Edit OIDC Provider")).toBeTruthy();
+    });
+
+    const mapGroupsToggle = screen.getByLabelText(
+      /Map OIDC groups to local groups/i,
+    ) as HTMLInputElement;
+    // Sourced from the loaded config (fixture: false).
+    expect(mapGroupsToggle.checked).toBe(false);
+    await user.click(mapGroupsToggle);
+
+    await user.click(screen.getByRole("button", { name: /Save Changes/i }));
+
+    await waitFor(() => {
+      expect(mockSsoApi.updateOidc).toHaveBeenCalledTimes(1);
+    });
+
+    const [, payload] = mockSsoApi.updateOidc.mock.calls[0] as [
+      string,
+      { map_groups_to_groups?: boolean },
+    ];
+    expect(payload.map_groups_to_groups).toBe(true);
   });
 });
 

--- a/src/app/(app)/(admin)/settings/sso/page.tsx
+++ b/src/app/(app)/(admin)/settings/sso/page.tsx
@@ -85,6 +85,7 @@ function OidcTab() {
   const [clientSecret, setClientSecret] = useState("");
   const [scopes, setScopes] = useState("openid profile email");
   const [autoCreateUsers, setAutoCreateUsers] = useState(true);
+  const [mapGroupsToGroups, setMapGroupsToGroups] = useState(false);
   const [usernameClaim, setUsernameClaim] = useState("preferred_username");
   const [emailClaim, setEmailClaim] = useState("email");
   const [displayNameClaim, setDisplayNameClaim] = useState("name");
@@ -144,6 +145,7 @@ function OidcTab() {
     setClientSecret("");
     setScopes("openid profile email");
     setAutoCreateUsers(true);
+    setMapGroupsToGroups(false);
     setUsernameClaim("preferred_username");
     setEmailClaim("email");
     setDisplayNameClaim("name");
@@ -171,6 +173,7 @@ function OidcTab() {
     setClientSecret("");
     setScopes(config.scopes.join(" "));
     setAutoCreateUsers(config.auto_create_users);
+    setMapGroupsToGroups(config.map_groups_to_groups);
     // #516: the backend reads the OIDC claim overrides under the
     // `<field>_claim` keys (username_claim / email_claim / groups_claim).
     // Prefer those, but fall back to the legacy bare keys so a provider
@@ -246,6 +249,7 @@ function OidcTab() {
         scopes: scopeList,
         attribute_mapping: attributeMapping,
         auto_create_users: autoCreateUsers,
+        map_groups_to_groups: mapGroupsToGroups,
       };
       if (clientSecret) {
         data.client_secret = clientSecret;
@@ -260,6 +264,7 @@ function OidcTab() {
         scopes: scopeList,
         attribute_mapping: attributeMapping,
         auto_create_users: autoCreateUsers,
+        map_groups_to_groups: mapGroupsToGroups,
       });
     }
   }
@@ -464,6 +469,25 @@ function OidcTab() {
                 id="oidc-auto-create-users"
                 checked={autoCreateUsers}
                 onCheckedChange={setAutoCreateUsers}
+              />
+            </div>
+
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5 pr-4">
+                <Label htmlFor="oidc-map-groups-to-groups">
+                  Map OIDC groups to local groups
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  Reflect values from the OIDC groups claim into Artifact Keeper
+                  group memberships on login. Matching groups are auto-created
+                  for this provider; operator-managed groups are left unchanged.
+                  Off keeps the legacy role-mapping behavior.
+                </p>
+              </div>
+              <Switch
+                id="oidc-map-groups-to-groups"
+                checked={mapGroupsToGroups}
+                onCheckedChange={setMapGroupsToGroups}
               />
             </div>
 

--- a/src/lib/api/__tests__/sso.test.ts
+++ b/src/lib/api/__tests__/sso.test.ts
@@ -193,6 +193,54 @@ describe("ssoApi", () => {
     await expect(ssoApi.listOidc()).rejects.toBe("fail");
   });
 
+  it("adaptOidc propagates map_groups_to_groups when present (#534)", async () => {
+    mockListOidc.mockResolvedValue({
+      data: [{ ...SDK_OIDC, map_groups_to_groups: true }],
+      error: undefined,
+    });
+    const { ssoApi } = await import("../sso");
+    const out = await ssoApi.listOidc();
+    expect(out[0].map_groups_to_groups).toBe(true);
+  });
+
+  it("adaptOidc defaults map_groups_to_groups to false when absent (#534)", async () => {
+    // Older backends (pre artifact-keeper#1879) never emit the field.
+    const { map_groups_to_groups: _omit, ...withoutField } = SDK_OIDC;
+    void _omit;
+    mockListOidc.mockResolvedValue({
+      data: [withoutField],
+      error: undefined,
+    });
+    const { ssoApi } = await import("../sso");
+    const out = await ssoApi.listOidc();
+    expect(out[0].map_groups_to_groups).toBe(false);
+  });
+
+  it("createOidc forwards map_groups_to_groups (#534)", async () => {
+    mockCreateOidc.mockResolvedValue({ data: SDK_OIDC, error: undefined });
+    const { ssoApi } = await import("../sso");
+    await ssoApi.createOidc({
+      name: "Corp OIDC",
+      issuer_url: "https://accounts.example.com",
+      client_id: "client-1",
+      client_secret: "secret",
+      map_groups_to_groups: true,
+    });
+    expect(mockCreateOidc).toHaveBeenCalledWith({
+      body: expect.objectContaining({ map_groups_to_groups: true }),
+    });
+  });
+
+  it("updateOidc forwards map_groups_to_groups (#534)", async () => {
+    mockUpdateOidc.mockResolvedValue({ data: SDK_OIDC, error: undefined });
+    const { ssoApi } = await import("../sso");
+    await ssoApi.updateOidc("o1", { map_groups_to_groups: false });
+    expect(mockUpdateOidc).toHaveBeenCalledWith({
+      path: { id: "o1" },
+      body: expect.objectContaining({ map_groups_to_groups: false }),
+    });
+  });
+
   it("getOidc returns config", async () => {
     mockGetOidc.mockResolvedValue({ data: SDK_OIDC, error: undefined });
     const { ssoApi } = await import("../sso");

--- a/src/lib/api/sso.ts
+++ b/src/lib/api/sso.ts
@@ -95,6 +95,12 @@ function adaptOidcConfig(sdk: SdkOidcConfigResponse): OidcConfig {
     scopes: sdk.scopes,
     attribute_mapping: adaptAttributeMapping(sdk.attribute_mapping),
     auto_create_users: sdk.auto_create_users,
+    // Defensive default: older backends (pre artifact-keeper#1879) may not
+    // emit `map_groups_to_groups`. Read through a cast and fall back to
+    // `false` (legacy role-mapping behavior) so the UI is safe against a
+    // backend that never returns the field.
+    map_groups_to_groups:
+      (sdk as { map_groups_to_groups?: boolean }).map_groups_to_groups ?? false,
     is_enabled: sdk.is_enabled,
     created_at: sdk.created_at,
     updated_at: sdk.updated_at,

--- a/src/types/sso.ts
+++ b/src/types/sso.ts
@@ -14,6 +14,15 @@ export interface OidcConfig {
   scopes: string[];
   attribute_mapping: Record<string, string>;
   auto_create_users: boolean;
+  /**
+   * When true, values from the OIDC `groups` claim are reflected into
+   * Artifact Keeper group memberships on login (auto-creating matching
+   * groups for this provider); operator-managed groups are left unchanged.
+   * When false, legacy role mapping is used. Backend field
+   * `oidc_configs.map_groups_to_groups` (artifact-keeper#1879). Defensive
+   * default `false` on backends that predate the field.
+   */
+  map_groups_to_groups: boolean;
   is_enabled: boolean;
   created_at: string;
   updated_at: string;
@@ -80,6 +89,7 @@ export interface CreateOidcConfigRequest {
   scopes?: string[];
   attribute_mapping?: Record<string, string>;
   auto_create_users?: boolean;
+  map_groups_to_groups?: boolean;
 }
 
 export interface UpdateOidcConfigRequest {
@@ -90,6 +100,7 @@ export interface UpdateOidcConfigRequest {
   scopes?: string[];
   attribute_mapping?: Record<string, string>;
   auto_create_users?: boolean;
+  map_groups_to_groups?: boolean;
 }
 
 export interface CreateLdapConfigRequest {


### PR DESCRIPTION
Closes #534

## Summary
Exposes the backend OIDC `map_groups_to_groups` setting in the SSO admin UI (Admin → Settings → SSO → OIDC Providers). Operators can now enable/view/change it from the provider create/edit dialog instead of issuing a raw `PUT /api/v1/admin/sso/oidc/<id>`.

Backend already supports this (confirmed against `backend/src/services/auth_config_service.rs`):
- `OidcConfigResponse.map_groups_to_groups: bool`
- `CreateOidcConfigRequest.map_groups_to_groups: Option<bool>` (defaults false)
- `UpdateOidcConfigRequest.map_groups_to_groups: Option<bool>`
- login path reflects the OIDC groups claim into local group memberships when enabled (`sso.rs`, issue #1094)

The web SDK (`@artifact-keeper/sdk` 1.2.1) already types the field on all three OIDC shapes, so no drift. UI-name matched exactly to the backend field `map_groups_to_groups`.

Implements the web portion of artifact-keeper/artifact-keeper#1879.

## Changes
- `src/types/sso.ts`: add `map_groups_to_groups` to `OidcConfig`, `CreateOidcConfigRequest`, `UpdateOidcConfigRequest`.
- `src/lib/api/sso.ts`: `adaptOidcConfig` reads the field with a defensive `false` default (mirrors the SAML `use_absolute_acs_url` pattern from #521).
- `src/app/(app)/(admin)/settings/sso/page.tsx`: "Map OIDC groups to local groups" Switch in the OIDC dialog (same opt-in group as Auto Create Users), initial value from the loaded config, echoed into create/update payloads, with help text describing the reflect/auto-create/leave-unchanged behavior.

## Test Checklist
- [x] Unit tests added/updated
- [x] E2E Playwright tests added/updated
- [x] Manually tested locally (`npm run build`, `npm run lint`, `vitest`)
- [x] No regressions in existing tests

## UI Changes
- [x] Playwright E2E spec covers the change
- [x] Responsive layout verified (reuses existing dialog Switch row layout)
- [x] Dark mode verified (reuses existing themed components)
- [x] Accessibility checked (labeled Switch, keyboard-operable)
- [ ] N/A - no UI changes
