### PR TITLE
fix: gate HSTS + upgrade-insecure-requests behind AK_ENFORCE_HTTPS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,15 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 ARG GIT_SHA=unknown
 ARG APP_VERSION=dev
+# Enable HSTS + the CSP `upgrade-insecure-requests` directive. Next.js bakes
+# `headers()` into the build output (routes-manifest.json), so this must be set
+# at BUILD time, not container runtime. Leave unset (default) for plain-HTTP
+# deployments; set `--build-arg AK_ENFORCE_HTTPS=true` when building an image
+# that will be served behind TLS. See #2222.
+ARG AK_ENFORCE_HTTPS
 ENV GIT_SHA=${GIT_SHA}
 ENV NEXT_PUBLIC_APP_VERSION=${APP_VERSION}
+ENV AK_ENFORCE_HTTPS=${AK_ENFORCE_HTTPS}
 # Reference APP_VERSION in the RUN to bust Docker build cache when it changes
 RUN echo "Building version: ${APP_VERSION} (${GIT_SHA})" && npm run build
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,31 @@ npm run dev
 
 Runs on http://localhost:3000. Configure `NEXT_PUBLIC_API_URL` to point to the Artifact Keeper backend.
 
+## Deployment
+
+### HTTPS hardening (`AK_ENFORCE_HTTPS`)
+
+By default the web UI ships **without** HSTS and without the CSP
+`upgrade-insecure-requests` directive so that a plain-HTTP deployment (e.g. the
+first-run `http://<IP>:30080`) works out of the box. If those transport-security
+headers were always emitted, the browser would rewrite every same-origin
+request to `https://`, which a plain-HTTP port cannot answer — breaking the UI.
+
+Set `AK_ENFORCE_HTTPS=true` (or `1`) when the UI is served behind TLS to
+re-enable `Strict-Transport-Security` and `upgrade-insecure-requests`. All other
+security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy,
+Permissions-Policy, and the rest of the CSP) are always emitted regardless.
+
+**Important:** Next.js bakes response headers into the build output, so
+`AK_ENFORCE_HTTPS` is read at **build time**, not container runtime. For the
+Docker image, pass it as a build arg:
+
+```bash
+docker build --build-arg AK_ENFORCE_HTTPS=true -t artifact-keeper-web:tls .
+```
+
+Leave it unset to build the default plain-HTTP-safe image.
+
 ## Project Structure
 
 ```

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 import { readFileSync } from "fs";
 import { execSync } from "child_process";
+import { buildSecurityHeaders, isHttpsEnabled } from "./src/lib/security-headers";
 
 const pkg = JSON.parse(readFileSync("./package.json", "utf-8"));
 
@@ -37,44 +38,20 @@ const nextConfig: NextConfig = {
     proxyTimeout: 600_000,
   },
   async headers() {
+    // HSTS and the CSP `upgrade-insecure-requests` directive are only emitted
+    // when the deployment actually terminates TLS (AK_ENFORCE_HTTPS=true|1).
+    // On a plain-HTTP default deploy they would force http->https rewrites the
+    // server can't answer, breaking the whole UI. See #2222.
+    //
+    // NOTE: Next.js serializes `headers()` into the build output
+    // (routes-manifest.json), so AK_ENFORCE_HTTPS is read at BUILD time, not
+    // container runtime. Default (unset) keeps plain-HTTP deploys working out
+    // of the box; build with AK_ENFORCE_HTTPS=true for TLS deployments (see the
+    // Dockerfile build arg and src/lib/security-headers.ts).
     return [
       {
         source: "/(.*)",
-        headers: [
-          {
-            key: "X-Frame-Options",
-            value: "DENY",
-          },
-          {
-            key: "X-Content-Type-Options",
-            value: "nosniff",
-          },
-          {
-            key: "Referrer-Policy",
-            value: "strict-origin-when-cross-origin",
-          },
-          {
-            key: "Permissions-Policy",
-            value: "camera=(), microphone=(), geolocation=()",
-          },
-          {
-            key: "X-DNS-Prefetch-Control",
-            value: "on",
-          },
-          {
-            key: "Strict-Transport-Security",
-            value: "max-age=31536000; includeSubDomains",
-          },
-          {
-            key: "Content-Security-Policy",
-            // 'unsafe-inline' is still required for script-src because Next.js
-            // injects inline <script> tags for page data (__NEXT_DATA__) and
-            // runtime configuration. The long-term fix is to switch to
-            // nonce-based CSP via next.config.ts experimental.serverActions or a
-            // custom Document with per-request nonces.
-            value: "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests",
-          },
-        ],
+        headers: buildSecurityHeaders(isHttpsEnabled()),
       },
     ];
   },

--- a/src/lib/__tests__/security-headers.test.ts
+++ b/src/lib/__tests__/security-headers.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildContentSecurityPolicy,
+  buildSecurityHeaders,
+  isHttpsEnabled,
+} from "../security-headers";
+
+function headerMap(headers: { key: string; value: string }[]) {
+  return Object.fromEntries(headers.map((h) => [h.key, h.value]));
+}
+
+describe("buildContentSecurityPolicy", () => {
+  it("omits upgrade-insecure-requests when HTTPS is disabled (default)", () => {
+    const csp = buildContentSecurityPolicy(false);
+    expect(csp).not.toContain("upgrade-insecure-requests");
+  });
+
+  it("includes upgrade-insecure-requests when HTTPS is enabled", () => {
+    const csp = buildContentSecurityPolicy(true);
+    expect(csp).toContain("upgrade-insecure-requests");
+  });
+
+  it("keeps all transport-agnostic directives in both modes", () => {
+    for (const csp of [
+      buildContentSecurityPolicy(false),
+      buildContentSecurityPolicy(true),
+    ]) {
+      expect(csp).toContain("default-src 'self'");
+      expect(csp).toContain("script-src 'self' 'unsafe-inline'");
+      expect(csp).toContain("style-src 'self' 'unsafe-inline'");
+      expect(csp).toContain("img-src 'self' data: blob:");
+      expect(csp).toContain("font-src 'self' data:");
+      expect(csp).toContain("connect-src 'self'");
+      expect(csp).toContain("frame-ancestors 'none'");
+      expect(csp).toContain("base-uri 'self'");
+      expect(csp).toContain("form-action 'self'");
+    }
+  });
+
+  it("never produces a malformed trailing separator", () => {
+    expect(buildContentSecurityPolicy(false).endsWith(";")).toBe(false);
+    expect(buildContentSecurityPolicy(false)).not.toContain(";;");
+    expect(buildContentSecurityPolicy(false).trimEnd()).toBe(
+      buildContentSecurityPolicy(false),
+    );
+    // form-action is the last directive when HTTPS is off.
+    expect(buildContentSecurityPolicy(false).endsWith("form-action 'self'")).toBe(
+      true,
+    );
+  });
+});
+
+describe("buildSecurityHeaders", () => {
+  it("omits HSTS and upgrade-insecure-requests when HTTPS is disabled", () => {
+    const map = headerMap(buildSecurityHeaders(false));
+    expect(map["Strict-Transport-Security"]).toBeUndefined();
+    expect(map["Content-Security-Policy"]).not.toContain(
+      "upgrade-insecure-requests",
+    );
+  });
+
+  it("emits HSTS and upgrade-insecure-requests when HTTPS is enabled", () => {
+    const map = headerMap(buildSecurityHeaders(true));
+    expect(map["Strict-Transport-Security"]).toBe(
+      "max-age=31536000; includeSubDomains",
+    );
+    expect(map["Content-Security-Policy"]).toContain(
+      "upgrade-insecure-requests",
+    );
+  });
+
+  it("always emits the transport-agnostic hardening headers in both modes", () => {
+    for (const map of [
+      headerMap(buildSecurityHeaders(false)),
+      headerMap(buildSecurityHeaders(true)),
+    ]) {
+      expect(map["X-Frame-Options"]).toBe("DENY");
+      expect(map["X-Content-Type-Options"]).toBe("nosniff");
+      expect(map["Referrer-Policy"]).toBe("strict-origin-when-cross-origin");
+      expect(map["Permissions-Policy"]).toBe(
+        "camera=(), microphone=(), geolocation=()",
+      );
+      expect(map["X-DNS-Prefetch-Control"]).toBe("on");
+      expect(map["Content-Security-Policy"]).toContain("default-src 'self'");
+    }
+  });
+});
+
+describe("isHttpsEnabled", () => {
+  it("defaults to false when the flag is unset", () => {
+    expect(isHttpsEnabled({})).toBe(false);
+  });
+
+  it('is true for "true" and "1"', () => {
+    expect(isHttpsEnabled({ AK_ENFORCE_HTTPS: "true" })).toBe(true);
+    expect(isHttpsEnabled({ AK_ENFORCE_HTTPS: "1" })).toBe(true);
+  });
+
+  it("is false for any other value", () => {
+    expect(isHttpsEnabled({ AK_ENFORCE_HTTPS: "false" })).toBe(false);
+    expect(isHttpsEnabled({ AK_ENFORCE_HTTPS: "0" })).toBe(false);
+    expect(isHttpsEnabled({ AK_ENFORCE_HTTPS: "yes" })).toBe(false);
+    expect(isHttpsEnabled({ AK_ENFORCE_HTTPS: "" })).toBe(false);
+  });
+});

--- a/src/lib/security-headers.ts
+++ b/src/lib/security-headers.ts
@@ -1,0 +1,113 @@
+/**
+ * Security response headers for every route (wired into `next.config.ts`'s
+ * `async headers()`).
+ *
+ * Two of these headers only make sense when the deployment actually terminates
+ * TLS, and are actively harmful on a plain-HTTP deployment:
+ *
+ *   - `Strict-Transport-Security` (HSTS)
+ *   - the `upgrade-insecure-requests` CSP directive
+ *
+ * On the common first-run default deployment (`http://<IP>:30080`, no TLS),
+ * `upgrade-insecure-requests` makes the browser rewrite every same-origin
+ * request from http:// to https://. Port 30080 only serves plain HTTP, so the
+ * upgraded `https://<IP>:30080/*.js` requests fail to connect and the whole UI
+ * becomes inaccessible. See artifact-keeper/artifact-keeper#2222.
+ *
+ * These two are therefore gated behind an explicit opt-in
+ * (`AK_ENFORCE_HTTPS`), default OFF, so a plain-HTTP default deploy works out
+ * of the box while real TLS deployments keep the hardening.
+ */
+
+export interface SecurityHeader {
+  key: string;
+  value: string;
+}
+
+/**
+ * Base CSP directives that are transport-agnostic and always emitted.
+ *
+ * 'unsafe-inline' is still required for script-src because Next.js injects
+ * inline <script> tags for page data (__NEXT_DATA__) and runtime
+ * configuration. The long-term fix is to switch to nonce-based CSP via
+ * next.config.ts experimental.serverActions or a custom Document with
+ * per-request nonces.
+ */
+const BASE_CSP_DIRECTIVES: readonly string[] = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob:",
+  "font-src 'self' data:",
+  "connect-src 'self'",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+];
+
+/**
+ * Build the `Content-Security-Policy` value. The `upgrade-insecure-requests`
+ * directive is only appended when the deployment serves the UI over HTTPS.
+ *
+ * Built programmatically from a directive list so dropping the trailing
+ * directive can never leave a malformed `"; "` suffix.
+ */
+export function buildContentSecurityPolicy(httpsEnabled: boolean): string {
+  const directives = [...BASE_CSP_DIRECTIVES];
+  if (httpsEnabled) {
+    directives.push("upgrade-insecure-requests");
+  }
+  return directives.join("; ");
+}
+
+/**
+ * Build the full list of security headers applied to every route.
+ *
+ * When `httpsEnabled` is false (the default), HSTS is omitted and the CSP
+ * excludes `upgrade-insecure-requests`; every other header is unconditional.
+ */
+export function buildSecurityHeaders(httpsEnabled: boolean): SecurityHeader[] {
+  const headers: SecurityHeader[] = [
+    { key: "X-Frame-Options", value: "DENY" },
+    { key: "X-Content-Type-Options", value: "nosniff" },
+    { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+    {
+      key: "Permissions-Policy",
+      value: "camera=(), microphone=(), geolocation=()",
+    },
+    { key: "X-DNS-Prefetch-Control", value: "on" },
+  ];
+
+  if (httpsEnabled) {
+    headers.push({
+      key: "Strict-Transport-Security",
+      value: "max-age=31536000; includeSubDomains",
+    });
+  }
+
+  headers.push({
+    key: "Content-Security-Policy",
+    value: buildContentSecurityPolicy(httpsEnabled),
+  });
+
+  return headers;
+}
+
+/**
+ * Whether the deployment serves the web UI over HTTPS (TLS terminated),
+ * controlled by the `AK_ENFORCE_HTTPS` env var.
+ *
+ * Set `AK_ENFORCE_HTTPS=true` (or `1`) when the UI is served behind TLS to
+ * enable HSTS + `upgrade-insecure-requests`. Leave unset/false for plain-HTTP
+ * deployments. Any other value is treated as false.
+ *
+ * NOTE: this is consumed from `next.config.ts` `headers()`, which Next.js
+ * serializes into the build output, so the flag is read at BUILD time (e.g. the
+ * Dockerfile `AK_ENFORCE_HTTPS` build arg), not container runtime.
+ */
+export function isHttpsEnabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  const flag = env.AK_ENFORCE_HTTPS;
+  return flag === "true" || flag === "1";
+}


### PR DESCRIPTION
## Summary

On a default plain-HTTP deployment (`http://<IP>:30080`, no TLS), `next.config.ts` applied two transport-security headers to **every** route unconditionally:

- the `upgrade-insecure-requests` directive inside `Content-Security-Policy`
- `Strict-Transport-Security` (HSTS)

`upgrade-insecure-requests` makes the browser rewrite every same-origin request (page navigation and all `.js`/asset loads) from `http://` to `https://`. Port 30080 serves only plain HTTP, so the upgraded `https://<IP>:30080/*.js` requests fail to connect and the whole UI becomes inaccessible.

This gates those two headers behind an explicit `AK_ENFORCE_HTTPS` opt-in (default **off**), so a plain-HTTP default deploy works out of the box while real TLS deployments keep the hardening.

### Changes
- Extract a pure, unit-tested `buildSecurityHeaders(httpsEnabled)` / `buildContentSecurityPolicy(httpsEnabled)` / `isHttpsEnabled(env)` helper in `src/lib/security-headers.ts`.
- When the flag is truthy (`true`/`1`): emit HSTS and include `upgrade-insecure-requests` in the CSP (today's hardening for TLS deploys).
- When the flag is falsy/unset (default): omit HSTS and drop `upgrade-insecure-requests`. The CSP is built from a directive list, so no malformed trailing `"; "` is left behind.
- Every other header (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, X-DNS-Prefetch-Control) and every other CSP directive (default-src/script-src/style-src/img-src/font-src/connect-src/frame-ancestors/base-uri/form-action) stay unconditional and unchanged.

### Build-time vs runtime
Next.js serializes `headers()` into the build output (`routes-manifest.json`), so `AK_ENFORCE_HTTPS` is read at **build time**, not container runtime (verified against `output: standalone` — setting the env at `node server.js` start does not change the emitted headers). The default image build (flag unset) is plain-HTTP-safe. For TLS images, a `AK_ENFORCE_HTTPS` **build arg** is added to the Dockerfile:

```bash
docker build --build-arg AK_ENFORCE_HTTPS=true -t artifact-keeper-web:tls .
```

The new env var / build arg is documented in the README.

## Test Checklist
- [x] Unit tests added/updated — `src/lib/__tests__/security-headers.test.ts` asserts both modes: flag-off ⇒ no HSTS and no `upgrade-insecure-requests` (but all base CSP directives present); flag-on ⇒ HSTS present and `upgrade-insecure-requests` in the CSP; plus `isHttpsEnabled` truthy/falsy parsing and no-malformed-separator checks.
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally — built the standalone server both ways: default build serves a page and its `/_next/static/*.js` over plain HTTP with a CSP that lacks `upgrade-insecure-requests` and no HSTS; `--build-arg AK_ENFORCE_HTTPS=true` build restores both.
- [x] No regressions in existing tests — full unit suite green (2529 passed); `next build` succeeds; new file at 100% line coverage; jscpd 0%.

## UI Changes
- [x] N/A - no UI changes

Closes #546
Ref: artifact-keeper/artifact-keeper#2222
