### PR TITLE
chore(release): bump version to 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artifact-keeper-web",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artifact-keeper-web",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "dependencies": {
         "@artifact-keeper/sdk": "^1.2.1",
         "@hookform/resolvers": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-keeper-web",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

Mechanical release version bump for the v1.3.0 cut. Version strings only; no dependency changes, no logic changes.

## Changes
- `package.json`: `version` 1.2.5 -> 1.3.0
- `package-lock.json`: root `version` and `packages[""].version` -> 1.3.0 (via `npm version --no-git-tag-version`; the lock root was stale at 1.2.1 and is now aligned to 1.3.0). No dependency versions changed.

## Displayed UI version
The UI version is sourced from `package.json` at build time via `next.config.ts` (`NEXT_PUBLIC_APP_VERSION: pkg.version`) and rendered in the sidebar and admin settings page. Verified in the production build output that the settings page now renders `Web 1.3.0`, so no stale-UI-version. No other hardcoded version constant exists in the web (grep confirmed).

## Validation
- `npm ci` resolves cleanly against the bumped lock
- `next build` succeeds
- `npx tsc --noEmit`: two pre-existing test-file type errors identical on `main` (unrelated to this change)
- No test pinned `1.2.5`, so no test updates required
