### PR TITLE
Gate SBOM/Scan actions on artifact `analyzable` flag

### DIFF
--- a/src/app/(app)/repositories/_components/__tests__/artifact-scans-section.test.tsx
+++ b/src/app/(app)/repositories/_components/__tests__/artifact-scans-section.test.tsx
@@ -143,6 +143,33 @@ describe("ArtifactScansSection (#368)", () => {
     ).toBeDefined();
   });
 
+  it("shows the default 'trigger a scan' guidance when analyzable (absent prop)", () => {
+    mockUseQuery.mockReturnValue({
+      data: { items: [], total: 0 },
+      isLoading: false,
+      isError: false,
+    });
+    render(<ArtifactScansSection artifactId="a1" />);
+    expect(
+      screen.getByText(/Trigger a scan from the artifact actions menu/i),
+    ).toBeDefined();
+  });
+
+  it("shows the honest 'cannot be scanned' guidance for non-analyzable artifacts (#2292)", () => {
+    mockUseQuery.mockReturnValue({
+      data: { items: [], total: 0 },
+      isLoading: false,
+      isError: false,
+    });
+    render(<ArtifactScansSection artifactId="a1" analyzable={false} />);
+    expect(screen.getByText(/cannot be scanned/i)).toBeDefined();
+    expect(screen.getByText(/proxy-cached remote artifacts/i)).toBeDefined();
+    // Must NOT tell the user to trigger a scan they cannot run.
+    expect(
+      screen.queryByText(/Trigger a scan from the artifact actions menu/i),
+    ).toBeNull();
+  });
+
   it("renders a skeleton while loading", () => {
     mockUseQuery.mockReturnValue({
       data: undefined,

--- a/src/app/(app)/repositories/_components/__tests__/docker-tag-list.test.tsx
+++ b/src/app/(app)/repositories/_components/__tests__/docker-tag-list.test.tsx
@@ -277,4 +277,46 @@ describe("DockerTagList", () => {
       screen.getByRole("button", { name: /scan library\/node:14/i }),
     ).toBeDisabled();
   });
+
+  // -------------------------------------------------------------------------
+  // analyzable gating (artifact-keeper#2292)
+  // -------------------------------------------------------------------------
+
+  it("disables the Scan button for a non-analyzable (proxy-cached) manifest", () => {
+    const cached = art({
+      id: "tagcached",
+      path: "library/node/manifests/14",
+      checksum_sha256: FULL_DIGEST,
+      analyzable: false,
+    });
+    render(<DockerTagList artifacts={[cached]} onScan={vi.fn()} />);
+    expect(
+      screen.getByRole("button", { name: /scan library\/node:14/i }),
+    ).toBeDisabled();
+    // The tooltip explains why the action is unavailable.
+    expect(
+      screen.getByText(/proxy-cached remote artifacts/i),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the Scan button enabled when analyzable is true", () => {
+    const analyzableTag = art({
+      id: "taghosted",
+      path: "library/node/manifests/14",
+      checksum_sha256: FULL_DIGEST,
+      analyzable: true,
+    });
+    render(<DockerTagList artifacts={[analyzableTag]} onScan={vi.fn()} />);
+    expect(
+      screen.getByRole("button", { name: /scan library\/node:14/i }),
+    ).not.toBeDisabled();
+  });
+
+  it("keeps the Scan button enabled when analyzable is absent (safe default)", () => {
+    // TAG_14 carries no `analyzable` flag — must default to analyzable.
+    render(<DockerTagList artifacts={[TAG_14]} onScan={vi.fn()} />);
+    expect(
+      screen.getByRole("button", { name: /scan library\/node:14/i }),
+    ).not.toBeDisabled();
+  });
 });

--- a/src/app/(app)/repositories/_components/__tests__/sbom-tab-content.test.tsx
+++ b/src/app/(app)/repositories/_components/__tests__/sbom-tab-content.test.tsx
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import React from "react";
+
+import type { Artifact } from "@/types";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockUseQuery = vi.hoisted(() => vi.fn());
+const mockMutate = vi.hoisted(() => vi.fn());
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (opts: unknown) => mockUseQuery(opts),
+  useMutation: () => ({ mutate: mockMutate, isPending: false }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock("@/lib/api/sbom", () => ({
+  default: {
+    list: vi.fn(),
+    get: vi.fn(),
+    getComponents: vi.fn(),
+    getCveHistory: vi.fn(),
+    generate: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/error-utils", () => ({ mutationErrorToast: () => () => {} }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+vi.mock("lucide-react", () => {
+  const icon = () => null;
+  return {
+    FileText: icon,
+    Download: icon,
+    RefreshCw: icon,
+    Package: icon,
+    Scale: icon,
+    ChevronDown: icon,
+    ChevronRight: icon,
+    ShieldAlert: icon,
+    ShieldCheck: icon,
+    AlertTriangle: icon,
+    Clock: icon,
+  };
+});
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...rest }: React.ComponentProps<"button">) => (
+    <button {...rest}>{children}</button>
+  ),
+}));
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock("@/components/ui/skeleton", () => ({
+  Skeleton: ({ className }: { className?: string }) => (
+    <div data-testid="skeleton" className={className} />
+  ),
+}));
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectValue: () => <span />,
+}));
+
+vi.mock("@/components/ui/collapsible", () => ({
+  Collapsible: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CollapsibleContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CollapsibleTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/common/data-table", () => ({
+  DataTable: () => <div data-testid="data-table" />,
+}));
+
+vi.mock("@/components/common/copy-button", () => ({
+  CopyButton: () => <button>copy</button>,
+}));
+
+vi.mock("@/components/common/vuln-id-link", () => ({
+  VulnIdLink: ({ id }: { id: string }) => <span>{id}</span>,
+}));
+
+// ---------------------------------------------------------------------------
+// Component under test
+// ---------------------------------------------------------------------------
+
+import { SbomTabContent } from "../sbom-tab-content";
+
+function art(overrides: Partial<Artifact> = {}): Artifact {
+  return {
+    id: "a1",
+    repository_key: "pypi-remote",
+    path: "requests/requests-2.31.0-py3-none-any.whl",
+    name: "requests-2.31.0-py3-none-any.whl",
+    size_bytes: 62500,
+    checksum_sha256: "deadbeef",
+    content_type: "application/octet-stream",
+    download_count: 0,
+    created_at: "2026-06-01T10:00:00Z",
+    ...overrides,
+  };
+}
+
+// No SBOMs / components / CVEs — drives the empty state where both Generate
+// buttons render.
+function stubEmptyQueries() {
+  mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+}
+
+describe("SbomTabContent — analyzable gating (artifact-keeper#2292)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubEmptyQueries();
+  });
+  afterEach(() => cleanup());
+
+  it("disables every Generate action and explains why for a non-analyzable artifact", () => {
+    render(<SbomTabContent artifact={art({ analyzable: false })} />);
+    const generateButtons = screen.getAllByRole("button", { name: /generate/i });
+    expect(generateButtons.length).toBeGreaterThan(0);
+    for (const btn of generateButtons) expect(btn).toBeDisabled();
+    expect(screen.getByText(/proxy-cached remote artifacts/i)).toBeInTheDocument();
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it("keeps the Generate action enabled when analyzable is true", () => {
+    render(<SbomTabContent artifact={art({ analyzable: true })} />);
+    for (const btn of screen.getAllByRole("button", { name: /generate/i })) {
+      expect(btn).not.toBeDisabled();
+    }
+  });
+
+  it("keeps the Generate action enabled when analyzable is absent (safe default)", () => {
+    render(<SbomTabContent artifact={art()} />);
+    for (const btn of screen.getAllByRole("button", { name: /generate/i })) {
+      expect(btn).not.toBeDisabled();
+    }
+  });
+});

--- a/src/app/(app)/repositories/_components/artifact-scans-section.tsx
+++ b/src/app/(app)/repositories/_components/artifact-scans-section.tsx
@@ -32,7 +32,20 @@ const SEVERITY_BADGE: Record<string, string> = {
  * `securityApi.listArtifactScans(artifactId)` already existed but had no
  * consumer; this component is the consumer.
  */
-export function ArtifactScansSection({ artifactId }: { artifactId: string }) {
+export function ArtifactScansSection({
+  artifactId,
+  analyzable = true,
+}: {
+  artifactId: string;
+  /**
+   * Whether the artifact supports scanning. Proxy-cached remote artifacts are
+   * `analyzable: false` (artifact-keeper#2292) — no scan can be triggered for
+   * them, so the empty state must not tell the user to "trigger a scan".
+   * Defaults to `true` so hosted artifacts and existing callers are
+   * unaffected.
+   */
+  analyzable?: boolean;
+}) {
   const { data, isLoading, isError, error } = useQuery({
     queryKey: ["security", "artifact-scans", artifactId],
     queryFn: () => securityApi.listArtifactScans(artifactId),
@@ -139,10 +152,14 @@ export function ArtifactScansSection({ artifactId }: { artifactId: string }) {
         <div className="flex flex-col items-center justify-center py-8 text-center">
           <Clock className="size-10 text-muted-foreground/50 mb-3" />
           <p className="text-sm text-muted-foreground">
-            No security scans have been run against this artifact yet.
+            {analyzable
+              ? "No security scans have been run against this artifact yet."
+              : "This artifact cannot be scanned."}
           </p>
           <p className="text-xs text-muted-foreground mt-1">
-            Trigger a scan from the artifact actions menu to populate this section.
+            {analyzable
+              ? "Trigger a scan from the artifact actions menu to populate this section."
+              : "SBOM and scanning are available only for artifacts hosted in this registry, not proxy-cached remote artifacts."}
           </p>
         </div>
       ) : (

--- a/src/app/(app)/repositories/_components/docker-tag-list.tsx
+++ b/src/app/(app)/repositories/_components/docker-tag-list.tsx
@@ -14,6 +14,10 @@ import {
 import { CopyButton } from "@/components/common/copy-button";
 import { QuarantineBadge } from "@/components/common/quarantine-badge";
 import { isActivelyQuarantined } from "@/lib/quarantine";
+import {
+  ANALYZABLE_DISABLED_REASON,
+  isArtifactAnalyzable,
+} from "@/lib/artifact-analyzable";
 import { formatBytes } from "@/lib/utils";
 import type { Artifact } from "@/types";
 
@@ -225,22 +229,31 @@ export function DockerTagList({
                 </td>
                 <td className="px-3 py-2">
                   <div className="flex items-center justify-end gap-1">
-                    {onScan && (
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="icon-xs"
-                            onClick={() => onScan(group.manifest)}
-                            disabled={scanPending}
-                            aria-label={`Scan ${group.image}:${group.tag}`}
-                          >
-                            <Shield className="size-3.5" />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent>Scan</TooltipContent>
-                      </Tooltip>
-                    )}
+                    {onScan &&
+                      (() => {
+                        // Proxy-cached remote manifests can't be scanned
+                        // (artifact-keeper#2292) — keep the affordance visible
+                        // but disabled with an explanatory tooltip.
+                        const analyzable = isArtifactAnalyzable(group.manifest);
+                        return (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                variant="ghost"
+                                size="icon-xs"
+                                onClick={() => onScan(group.manifest)}
+                                disabled={scanPending || !analyzable}
+                                aria-label={`Scan ${group.image}:${group.tag}`}
+                              >
+                                <Shield className="size-3.5" />
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              {analyzable ? "Scan" : ANALYZABLE_DISABLED_REASON}
+                            </TooltipContent>
+                          </Tooltip>
+                        );
+                      })()}
                   </div>
                 </td>
               </tr>

--- a/src/app/(app)/repositories/_components/repo-detail-content.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.tsx
@@ -29,6 +29,10 @@ import { artifactsApi } from "@/lib/api/artifacts";
 import securityApi from "@/lib/api/security";
 import { mutationErrorToast } from "@/lib/error-utils";
 import { isActivelyQuarantined } from "@/lib/quarantine";
+import {
+  ANALYZABLE_DISABLED_REASON,
+  isArtifactAnalyzable,
+} from "@/lib/artifact-analyzable";
 import { buildPomDependencySnippet, parseMavenGav } from "@/lib/maven";
 import { formatRelativeTimestamp, formatCacheExpiry } from "@/lib/cache-time";
 import type { Artifact } from "@/types";
@@ -469,12 +473,16 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
                   variant="ghost"
                   size="icon-xs"
                   onClick={() => scanArtifactMutation.mutate(a.id)}
-                  disabled={scanArtifactMutation.isPending}
+                  disabled={
+                    scanArtifactMutation.isPending || !isArtifactAnalyzable(a)
+                  }
                 >
                   <Shield className="size-3.5" />
                 </Button>
               </TooltipTrigger>
-              <TooltipContent>Scan</TooltipContent>
+              <TooltipContent>
+                {isArtifactAnalyzable(a) ? "Scan" : ANALYZABLE_DISABLED_REASON}
+              </TooltipContent>
             </Tooltip>
           )}
           {isAuthenticated && (
@@ -1094,7 +1102,15 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
                   <Button
                     variant="outline"
                     onClick={() => scanArtifactMutation.mutate(selectedArtifact.id)}
-                    disabled={scanArtifactMutation.isPending}
+                    disabled={
+                      scanArtifactMutation.isPending ||
+                      !isArtifactAnalyzable(selectedArtifact)
+                    }
+                    title={
+                      isArtifactAnalyzable(selectedArtifact)
+                        ? undefined
+                        : ANALYZABLE_DISABLED_REASON
+                    }
                   >
                     <Shield className="size-4" />
                     {scanArtifactMutation.isPending ? "Scanning..." : "Scan"}

--- a/src/app/(app)/repositories/_components/sbom-tab-content.tsx
+++ b/src/app/(app)/repositories/_components/sbom-tab-content.tsx
@@ -19,6 +19,10 @@ import { toast } from "sonner";
 
 import sbomApi from "@/lib/api/sbom";
 import { mutationErrorToast } from "@/lib/error-utils";
+import {
+  ANALYZABLE_DISABLED_REASON,
+  isArtifactAnalyzable,
+} from "@/lib/artifact-analyzable";
 import type { SbomComponent, SbomFormat, CveHistoryEntry } from "@/types/sbom";
 import type { Artifact } from "@/types";
 
@@ -47,6 +51,10 @@ interface SbomTabContentProps {
 
 export function SbomTabContent({ artifact }: SbomTabContentProps) {
   const queryClient = useQueryClient();
+  // Proxy-cached remote artifacts have no artifacts row on the backend, so
+  // SBOM generation returns 404 (artifact-keeper#2292). Gate the Generate /
+  // Regenerate actions on the artifact's `analyzable` flag.
+  const analyzable = isArtifactAnalyzable(artifact);
   const [selectedFormat, setSelectedFormat] = useState<SbomFormat>("cyclonedx");
   const [jsonExpanded, setJsonExpanded] = useState(false);
   const [componentsPage, setComponentsPage] = useState(1);
@@ -216,7 +224,8 @@ export function SbomTabContent({ artifact }: SbomTabContentProps) {
             variant="outline"
             size="sm"
             onClick={() => generateMutation.mutate(selectedFormat)}
-            disabled={generateMutation.isPending}
+            disabled={generateMutation.isPending || !analyzable}
+            title={analyzable ? undefined : ANALYZABLE_DISABLED_REASON}
           >
             <RefreshCw
               className={`size-4 ${generateMutation.isPending ? "animate-spin" : ""}`}
@@ -346,11 +355,14 @@ export function SbomTabContent({ artifact }: SbomTabContentProps) {
         <div className="flex flex-col items-center justify-center py-12 text-center">
           <FileText className="size-12 text-muted-foreground/50 mb-4" />
           <p className="text-sm text-muted-foreground mb-4">
-            No SBOM generated for this artifact yet.
+            {analyzable
+              ? "No SBOM generated for this artifact yet."
+              : ANALYZABLE_DISABLED_REASON}
           </p>
           <Button
             onClick={() => generateMutation.mutate(selectedFormat)}
-            disabled={generateMutation.isPending}
+            disabled={generateMutation.isPending || !analyzable}
+            title={analyzable ? undefined : ANALYZABLE_DISABLED_REASON}
           >
             <FileText className="size-4" />
             Generate {selectedFormat.toUpperCase()} SBOM

--- a/src/app/(app)/repositories/_components/security-tab-content.tsx
+++ b/src/app/(app)/repositories/_components/security-tab-content.tsx
@@ -20,6 +20,7 @@ import { toast } from "sonner";
 import sbomApi from "@/lib/api/sbom";
 import dtApi from "@/lib/api/dependency-track";
 import { mutationErrorToast } from "@/lib/error-utils";
+import { isArtifactAnalyzable } from "@/lib/artifact-analyzable";
 import { ArtifactScansSection } from "./artifact-scans-section";
 import type { CveHistoryEntry, CveStatus } from "@/types/sbom";
 import type { Artifact } from "@/types";
@@ -120,6 +121,9 @@ function resolveDtProjectUuid(
 
 export function SecurityTabContent({ artifact }: SecurityTabContentProps) {
   const queryClient = useQueryClient();
+  // Proxy-cached remote artifacts can't be scanned (artifact-keeper#2292);
+  // used below to give honest guidance instead of "run a scan".
+  const analyzable = isArtifactAnalyzable(artifact);
   const [page, setPage] = useState(1);
   const [dtFindingsPage, setDtFindingsPage] = useState(1);
 
@@ -527,7 +531,9 @@ export function SecurityTabContent({ artifact }: SecurityTabContentProps) {
             No vulnerabilities detected for this artifact.
           </p>
           <p className="text-xs text-muted-foreground mt-1">
-            Generate an SBOM and run a security scan to check for CVEs.
+            {analyzable
+              ? "Generate an SBOM and run a security scan to check for CVEs."
+              : "SBOM and scanning are available only for artifacts hosted in this registry, not proxy-cached remote artifacts."}
           </p>
         </div>
       ) : (
@@ -596,7 +602,7 @@ export function SecurityTabContent({ artifact }: SecurityTabContentProps) {
           had to navigate to /security/scans to find it. Mounting the
           dedicated section here makes the tab a true single-pane-of-glass. */}
       <Separator />
-      <ArtifactScansSection artifactId={artifact.id} />
+      <ArtifactScansSection artifactId={artifact.id} analyzable={analyzable} />
 
       {/* ----------------------------------------------------------------- */}
       {/* Dependency-Track Findings Section */}

--- a/src/lib/__tests__/artifact-analyzable.test.ts
+++ b/src/lib/__tests__/artifact-analyzable.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  ANALYZABLE_DISABLED_REASON,
+  isArtifactAnalyzable,
+} from "@/lib/artifact-analyzable";
+import type { Artifact } from "@/types";
+
+// Minimal artifact factory — only `analyzable` matters for these tests.
+function art(analyzable?: boolean): Pick<Artifact, "analyzable"> {
+  return { analyzable };
+}
+
+describe("isArtifactAnalyzable (artifact-keeper#2292)", () => {
+  it("returns false only for an explicit analyzable: false (proxy-cached remote)", () => {
+    expect(isArtifactAnalyzable(art(false))).toBe(false);
+  });
+
+  it("returns true when analyzable is explicitly true (hosted artifact)", () => {
+    expect(isArtifactAnalyzable(art(true))).toBe(true);
+  });
+
+  it("defaults to true when the field is absent (older / pre-upgrade responses)", () => {
+    expect(isArtifactAnalyzable(art(undefined))).toBe(true);
+    expect(isArtifactAnalyzable({})).toBe(true);
+  });
+
+  it("treats null / undefined artifacts as analyzable (safe default)", () => {
+    expect(isArtifactAnalyzable(null)).toBe(true);
+    expect(isArtifactAnalyzable(undefined)).toBe(true);
+  });
+
+  it("exposes a user-facing disabled reason mentioning proxy-cached remote artifacts", () => {
+    expect(ANALYZABLE_DISABLED_REASON).toMatch(/proxy-cached remote/i);
+  });
+});

--- a/src/lib/api/__tests__/artifacts.test.ts
+++ b/src/lib/api/__tests__/artifacts.test.ts
@@ -23,7 +23,12 @@ describe("artifactsApi", () => {
     const data = { items: [{ id: "a1" }], pagination: { total: 1 } };
     mockListArtifacts.mockResolvedValue({ data, error: undefined });
     const { artifactsApi } = await import("../artifacts");
-    expect(await artifactsApi.list("repo-key")).toEqual(data);
+    const result = await artifactsApi.list("repo-key");
+    // adaptArtifact defaults the new `analyzable` flag to true when the
+    // backend omits it (artifact-keeper#2292); other unset fields ride
+    // through as `undefined`, which toEqual ignores.
+    expect(result.items).toEqual([{ id: "a1", analyzable: true }]);
+    expect(result.pagination).toEqual({ total: 1 });
   });
 
   it("list throws on error", async () => {
@@ -146,6 +151,95 @@ describe("artifactsApi", () => {
     const result = await artifactsApi.list("pypi-remote");
     expect(result.items[0].cache_cached_at).toBeUndefined();
     expect(result.items[0].cache_expires_at).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // adaptArtifact: analyzable flag (artifact-keeper#2292 / backend #2291)
+  //
+  // The backend marks proxy-cached remote artifacts `analyzable: false` (no
+  // artifacts row → SBOM/scan 404). The wrapper must pass an explicit `false`
+  // through and default a missing/true field to `true` so hosted artifacts and
+  // pre-upgrade responses stay analyzable.
+  // -------------------------------------------------------------------------
+
+  it("passes analyzable: false through adaptArtifact for proxy-cached artifacts", async () => {
+    mockListArtifacts.mockResolvedValue({
+      data: {
+        items: [
+          {
+            id: "cached-1",
+            repository_key: "pypi-remote",
+            path: "requests/requests-2.31.0-py3-none-any.whl",
+            name: "requests-2.31.0-py3-none-any.whl",
+            size_bytes: 62500,
+            checksum_sha256: "deadbeef",
+            content_type: "application/octet-stream",
+            download_count: 0,
+            created_at: "2026-06-01T10:00:00Z",
+            analyzable: false,
+          },
+        ],
+        pagination: { page: 1, per_page: 20, total: 1, total_pages: 1 },
+      },
+      error: undefined,
+    });
+    const { artifactsApi } = await import("../artifacts");
+    const result = await artifactsApi.list("pypi-remote");
+    expect(result.items[0].analyzable).toBe(false);
+  });
+
+  it("preserves analyzable: true through adaptArtifact for hosted artifacts", async () => {
+    mockListArtifacts.mockResolvedValue({
+      data: {
+        items: [
+          {
+            id: "hosted-1",
+            repository_key: "local-repo",
+            path: "lib.jar",
+            name: "lib.jar",
+            size_bytes: 100,
+            checksum_sha256: "x",
+            content_type: "application/octet-stream",
+            download_count: 0,
+            created_at: "2026-06-01T10:00:00Z",
+            analyzable: true,
+          },
+        ],
+        pagination: { page: 1, per_page: 20, total: 1, total_pages: 1 },
+      },
+      error: undefined,
+    });
+    const { artifactsApi } = await import("../artifacts");
+    const result = await artifactsApi.list("local-repo");
+    expect(result.items[0].analyzable).toBe(true);
+  });
+
+  it("defaults analyzable to true on adaptArtifact when the backend omits the field", async () => {
+    // Older backends / not-yet-regenerated SDK responses have no `analyzable`
+    // key; the wrapper must treat that as analyzable so hosted artifacts keep
+    // offering SBOM/scan (safe default matching the backend).
+    mockListArtifacts.mockResolvedValue({
+      data: {
+        items: [
+          {
+            id: "legacy-1",
+            repository_key: "local-repo",
+            path: "old.jar",
+            name: "old.jar",
+            size_bytes: 100,
+            checksum_sha256: "x",
+            content_type: "application/octet-stream",
+            download_count: 0,
+            created_at: "2026-06-01T10:00:00Z",
+          },
+        ],
+        pagination: { page: 1, per_page: 20, total: 1, total_pages: 1 },
+      },
+      error: undefined,
+    });
+    const { artifactsApi } = await import("../artifacts");
+    const result = await artifactsApi.list("local-repo");
+    expect(result.items[0].analyzable).toBe(true);
   });
 
   // -------------------------------------------------------------------------

--- a/src/lib/api/artifacts.ts
+++ b/src/lib/api/artifacts.ts
@@ -47,6 +47,7 @@ function adaptArtifact(sdk: ArtifactResponse): Artifact {
   const sdkAny = sdk as ArtifactResponse & {
     cache_cached_at?: string | null;
     cache_expires_at?: string | null;
+    analyzable?: boolean;
   };
   return {
     id: sdk.id,
@@ -62,6 +63,11 @@ function adaptArtifact(sdk: ArtifactResponse): Artifact {
     metadata: sdk.metadata ?? undefined,
     cache_cached_at: sdkAny.cache_cached_at ?? undefined,
     cache_expires_at: sdkAny.cache_expires_at ?? undefined,
+    // Default to `true` when the backend omits the field (older responses /
+    // not-yet-regenerated SDK): only an explicit `false` disables SBOM/scan
+    // for an artifact (artifact-keeper#2292). Matches the backend's safe
+    // default so hosted artifacts always stay analyzable.
+    analyzable: sdkAny.analyzable ?? true,
   };
 }
 

--- a/src/lib/artifact-analyzable.ts
+++ b/src/lib/artifact-analyzable.ts
@@ -1,0 +1,27 @@
+import type { Artifact } from "@/types";
+
+/**
+ * User-facing explanation shown when SBOM generation / security scanning is
+ * offered for an artifact that the backend cannot analyze. Proxy-cached remote
+ * artifacts have synthetic ids and no `artifacts` row, so the backend returns
+ * 404 for SBOM/scan requests against them (artifact-keeper#2292, backend PR
+ * #2291). Surfacing this as a disabled affordance with this reason keeps the
+ * action discoverable while making the limitation honest.
+ */
+export const ANALYZABLE_DISABLED_REASON =
+  "SBOM and scanning are available only for artifacts hosted in this registry, not proxy-cached remote artifacts.";
+
+/**
+ * Whether SBOM generation and security scanning are supported for an artifact.
+ *
+ * The backend marks proxy-cached remote artifacts with `analyzable: false`
+ * (artifact-keeper#2292). Treat a missing or `true` flag as analyzable: the
+ * generated SDK type and older/hosted-artifact responses may not carry the
+ * field, and those must keep working. Only an explicit `false` disables the
+ * SBOM/scan actions, matching the backend's safe default.
+ */
+export function isArtifactAnalyzable(
+  artifact: Pick<Artifact, "analyzable"> | null | undefined,
+): boolean {
+  return artifact?.analyzable !== false;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -192,6 +192,16 @@ export interface Artifact {
    * present.
    */
   cache_expires_at?: string | null;
+  /**
+   * Whether this artifact supports SBOM generation and security scanning.
+   * `false` for proxy-cached remote artifacts (synthetic ids, no `artifacts`
+   * row → the backend returns 404 for SBOM/scan), `true` for hosted
+   * artifacts (artifact-keeper#2292, backend PR #2291). Optional: the
+   * generated SDK type and older/pre-upgrade responses may omit it, in which
+   * case callers must treat the artifact as analyzable — see
+   * `isArtifactAnalyzable` in `@/lib/artifact-analyzable`.
+   */
+  analyzable?: boolean;
 }
 
 export interface PaginatedResponse<T> {


### PR DESCRIPTION
## Summary

The artifact response now carries an `analyzable: boolean` field. It is `true`
for artifacts hosted in this registry and `false` for proxy-cached remote
artifacts, which have synthetic ids and no `artifacts` row — requesting an SBOM
or a security scan for them returns HTTP 404.

Previously the web UI still offered **Request/Generate SBOM** and **Scan**
actions for those cached remote artifacts, so a user would click a button that
fails. This change reads the new flag and disables those actions (with an
explanatory tooltip) when `analyzable === false`.

## Changes

- **Type + adapter**: added an optional `analyzable?: boolean` to the `Artifact`
  type and mapped it in the artifact adapter. It is read defensively off the raw
  response and **defaults to `true` when the field is absent** (older responses /
  not-yet-regenerated SDK), so hosted and pre-upgrade artifacts stay analyzable.
- **Shared helper** (`src/lib/artifact-analyzable.ts`): `isArtifactAnalyzable`
  (only an explicit `false` disables) + a single user-facing reason string, used
  consistently at every action site.
- **Gated action sites** (disabled + tooltip/title, action kept visible so the
  affordance stays discoverable):
  - `repo-detail-content.tsx` — row-level Scan button and the artifact-details
    dialog Scan button.
  - `docker-tag-list.tsx` — per-tag Scan button.
  - `sbom-tab-content.tsx` — Generate / Regenerate SBOM buttons (header + empty
    state).
  - `security-tab-content.tsx` / `artifact-scans-section.tsx` — honest empty-state
    guidance instead of "run a scan" for non-analyzable artifacts.

The repo-wide **Scan All** action is intentionally left unchanged (it is not
scoped to a single artifact).

## Ordering

This is the web half of already-merged backend behavior (the backend added the
`analyzable` field and the honest 404). Because the adapter defaults a missing
field to `true`, this change is safe to ship against any backend and does **not**
lead the backend.

## Tests

- `isArtifactAnalyzable`: `false` → false; `true`/absent/null → true.
- Adapter: passes `false` through, preserves `true`, and defaults a missing
  field to `true`.
- `DockerTagList`: Scan disabled for non-analyzable manifests; enabled when
  `analyzable` is true or absent.
- `ArtifactScansSection`: honest guidance for non-analyzable artifacts.
- `SbomTabContent`: Generate actions disabled + reason shown when not analyzable;
  enabled otherwise.

Lint, typecheck/build, and the full test suite (2545 tests) are green.

Closes #2292

Closes #551
(backend tracking: artifact-keeper#2292)