### PR TITLE
chore: bump version to 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artifact-keeper-web",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artifact-keeper-web",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@artifact-keeper/sdk": "^1.2.1",
         "@hookform/resolvers": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-keeper-web",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
Bump the web app version from 1.3.0 to 1.4.0 for the v1.4.0 release cut.

- `package.json` `version` 1.3.0 -> 1.4.0 (surfaced in the UI as `NEXT_PUBLIC_APP_VERSION` via `next.config.ts`).
- `package-lock.json` top-level and root-package `version` fields updated to match; lockfile verified in sync.

No dependency versions changed. `npm ci` + `npm run lint` pass (0 errors).

Closes #552

## Test Checklist
- [ ] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [x] N/A - no UI changes
