### PR TITLE
chore(release): bump version to 1.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artifact-keeper-web",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artifact-keeper-web",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@artifact-keeper/sdk": "^1.2.1",
         "@hookform/resolvers": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-keeper-web",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Bumps the web app version 1.4.0 → 1.4.1 for the v1.4.1 patch release (package.json + package-lock.json self-references).

Closes #562