### PR TITLE
chore(release): bump version to 1.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artifact-keeper-web",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artifact-keeper-web",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "dependencies": {
         "@artifact-keeper/sdk": "^1.2.1",
         "@hookform/resolvers": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-keeper-web",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Bumps version 1.4.1 -> 1.4.2 in package.json and package-lock.json for the v1.4.2 release (backend composer fix #2361).

Closes #565