### PR TITLE
test(e2e): harden flaky interaction specs (selectors/timing)

### DIFF
--- a/e2e/fixtures/page-objects/ArtifactVersionsPage.ts
+++ b/e2e/fixtures/page-objects/ArtifactVersionsPage.ts
@@ -16,6 +16,7 @@ export class ArtifactVersionsPage {
   readonly versioningToggle: Locator;
   readonly saveButton: Locator;
   readonly artifactsTable: Locator;
+  readonly artifactRows: Locator;
   readonly versionsTab: Locator;
   readonly versionsSection: Locator;
   readonly versionRows: Locator;
@@ -28,6 +29,12 @@ export class ArtifactVersionsPage {
     this.versioningToggle = page.getByLabel('Enable versioning');
     this.saveButton = page.getByRole('button', { name: /save changes/i });
     this.artifactsTable = page.getByRole('table').first();
+    // The artifact browser renders via the shared <DataTable>, which spreads
+    // `role="button"` onto each clickable data <tr> (so a row click opens the
+    // detail dialog). That override strips the implicit `row` role, so
+    // `getByRole('row')` only ever matches the header. Locate data rows by the
+    // DOM structure (`tbody tr`) instead, which is unambiguous and role-neutral.
+    this.artifactRows = this.artifactsTable.locator('tbody tr');
     this.versionsTab = page.getByRole('tab', { name: /versions/i });
     this.versionsSection = page.getByTestId('artifact-versions-section');
     this.versionRows = page.getByTestId('artifact-version-row');
@@ -38,10 +45,27 @@ export class ArtifactVersionsPage {
     await this.page.waitForLoadState('domcontentloaded');
   }
 
+  /** A data row in the artifact browser matching `name` (see artifactRows). */
+  artifactRow(name: string): Locator {
+    return this.artifactRows.filter({ hasText: name });
+  }
+
+  /**
+   * Select the repository Settings tab and wait for it to become the active
+   * tab before callers assert on its contents. Radix flips `aria-selected` /
+   * `data-state=active` once the panel is mounted, so gating on that removes
+   * the load-timing race where an assertion runs before the tab has switched.
+   */
+  async openSettingsTab() {
+    await this.settingsTab.click();
+    await this.settingsTab
+      .and(this.page.locator('[data-state="active"]'))
+      .waitFor({ state: 'visible', timeout: 8000 });
+  }
+
   /** Open the artifact detail dialog by clicking the row for `name`. */
   async openArtifactDetail(name: string) {
-    const row = this.artifactsTable.getByRole('row').filter({ hasText: name });
-    await row.first().click();
+    await this.artifactRow(name).first().click();
   }
 
   /** Per-revision download button by revision number. */

--- a/e2e/suites/interactions/admin/migration.spec.ts
+++ b/e2e/suites/interactions/admin/migration.spec.ts
@@ -40,8 +40,12 @@ test.describe('Migration Page', () => {
     await page.getByRole('button', { name: /add connection/i }).first().click();
     await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10000 });
 
-    await expect(page.getByLabel(/name/i)).toBeVisible({ timeout: 10000 });
-    await expect(page.getByLabel(/endpoint url/i).or(page.getByLabel(/url/i))).toBeVisible({ timeout: 10000 });
+    // Scope to the dialog and match the exact "Name" label so we resolve the
+    // connection-name input, not the "Sort by Name" sort button on the
+    // Source Connections table rendered behind the dialog.
+    const dialog = page.getByRole('dialog');
+    await expect(dialog.getByLabel('Name', { exact: true })).toBeVisible({ timeout: 10000 });
+    await expect(dialog.getByLabel(/endpoint url/i)).toBeVisible({ timeout: 10000 });
     await expect(page.getByText(/authentication type|auth type/i).first()).toBeVisible({ timeout: 10000 });
 
     // Close dialog

--- a/e2e/suites/interactions/dashboard/live-updates.spec.ts
+++ b/e2e/suites/interactions/dashboard/live-updates.spec.ts
@@ -1,57 +1,57 @@
 import { test, expect } from '@playwright/test';
+import { TEST_ROLES } from '../../../setup/auth-states';
 
 /**
  * Live data update tests: verifies that SSE events cause one browser tab
  * to see changes made by another tab without a manual page refresh.
  *
+ * Both tabs are authenticated by *reusing the admin storageState* that
+ * global-setup already produced, rather than driving the login form twice.
+ * The old approach re-typed a hardcoded admin password into the UI in each
+ * fresh context; global-setup rotates the initial admin password to the
+ * role password (`Admin1234!`) on first login, so that stale password no
+ * longer authenticates and the second context hung on `/login`. Loading the
+ * saved cookies makes both tabs deterministically signed in.
+ *
  * Run locally:
  *   npx playwright test --config playwright-local.config.ts --headed
  */
 
-const ADMIN_USER = 'admin';
-const ADMIN_PASS = process.env.ADMIN_PASSWORD || 'TestRunner!2026secure';
-
-async function loginPage(page: import('@playwright/test').Page) {
-  await page.goto('/login');
-  await page.getByLabel('Username').fill(ADMIN_USER);
-  await page.getByLabel('Password').fill(ADMIN_PASS);
-  await page.getByRole('button', { name: 'Sign In' }).click();
-  await expect(page).toHaveURL(/\/$|\/dashboard|\/change-password/, { timeout: 15000 });
-
-  if (page.url().includes('change-password')) {
-    await page.getByLabel(/new password/i).first().fill(ADMIN_PASS);
-    await page.getByLabel(/confirm/i).fill(ADMIN_PASS);
-    await page.getByRole('button', { name: /change|update|save/i }).click();
-    await expect(page).toHaveURL(/\/$/);
-  }
-}
+const ADMIN_STATE = TEST_ROLES.admin.storageStatePath;
 
 test.describe('Live Data Updates (SSE)', () => {
-  test.use({ storageState: undefined });
-
   test('creating a user in one tab updates the users list in another tab', async ({
     browser,
     baseURL,
   }) => {
     const base = baseURL || 'http://localhost:3000';
-    const ctxA = await browser.newContext({ ignoreHTTPSErrors: true, baseURL: base });
-    const ctxB = await browser.newContext({ ignoreHTTPSErrors: true, baseURL: base });
+    const ctxA = await browser.newContext({
+      ignoreHTTPSErrors: true,
+      baseURL: base,
+      storageState: ADMIN_STATE,
+    });
+    const ctxB = await browser.newContext({
+      ignoreHTTPSErrors: true,
+      baseURL: base,
+      storageState: ADMIN_STATE,
+    });
     const pageA = await ctxA.newPage();
     const pageB = await ctxB.newPage();
 
-    await loginPage(pageA);
-    await loginPage(pageB);
-
-    // Window B: navigate to users page and wait for table
+    // Window B: navigate to users page and wait for table. Wait for the SSE
+    // stream response (headers = EventSource opened) rather than a blind sleep,
+    // so we don't trigger the change before tab B is actually listening.
+    const sseConnected = pageB
+      .waitForResponse(
+        (r) => r.url().includes('/api/v1/events/stream') && r.status() === 200,
+        { timeout: 20000 }
+      )
+      .catch(() => null);
     await pageB.goto('/users');
     const table = pageB.getByRole('table');
     await expect(table).toBeVisible({ timeout: 15000 });
     await expect(table.locator('tbody tr').first()).toBeVisible({ timeout: 10000 });
-
-    // Give the SSE connection time to establish
-    await pageB.waitForTimeout(3000);
-
-    const initialRows = await table.locator('tbody tr').count();
+    await sseConnected;
 
     // Window A: create a new user via the API
     const username = `sse-test-${Date.now()}`;
@@ -66,16 +66,14 @@ test.describe('Live Data Updates (SSE)', () => {
     });
     expect(createResponse.ok()).toBeTruthy();
 
-    // Window B: wait for the new user to appear without a page refresh.
-    // SSE fires entity.changed -> hook invalidates "users" queries -> TanStack refetches.
-    await expect(async () => {
-      const rows = await table.locator('tbody tr').count();
-      expect(rows).toBeGreaterThan(initialRows);
-    }).toPass({ timeout: 30000, intervals: [500, 1000, 2000] });
-
+    // Window B: the new user must appear without a manual refresh — SSE fires
+    // `user.created` -> the hook invalidates the "users" query -> TanStack
+    // refetches. Assert on the specific username cell rather than an absolute
+    // row-count delta, so a user created/removed by a concurrent test can't
+    // offset the count and mask (or fake) the result.
     await expect(
       table.getByRole('cell', { name: username, exact: true })
-    ).toBeVisible({ timeout: 5000 });
+    ).toBeVisible({ timeout: 30000 });
 
     // Cleanup
     const body = await createResponse.json();
@@ -91,13 +89,18 @@ test.describe('Live Data Updates (SSE)', () => {
     baseURL,
   }) => {
     const base = baseURL || 'http://localhost:3000';
-    const ctxA = await browser.newContext({ ignoreHTTPSErrors: true, baseURL: base });
-    const ctxB = await browser.newContext({ ignoreHTTPSErrors: true, baseURL: base });
+    const ctxA = await browser.newContext({
+      ignoreHTTPSErrors: true,
+      baseURL: base,
+      storageState: ADMIN_STATE,
+    });
+    const ctxB = await browser.newContext({
+      ignoreHTTPSErrors: true,
+      baseURL: base,
+      storageState: ADMIN_STATE,
+    });
     const pageA = await ctxA.newPage();
     const pageB = await ctxB.newPage();
-
-    await loginPage(pageA);
-    await loginPage(pageB);
 
     // Create a user first
     const username = `sse-del-${Date.now()}`;
@@ -113,18 +116,21 @@ test.describe('Live Data Updates (SSE)', () => {
     expect(createResponse.ok()).toBeTruthy();
     const createBody = await createResponse.json();
 
-    // Window B: navigate to users page and wait for the new user
+    // Window B: navigate to users page and wait for the new user. Wait for the
+    // SSE stream to open (headers received) so the deletion below isn't missed.
+    const sseConnected = pageB
+      .waitForResponse(
+        (r) => r.url().includes('/api/v1/events/stream') && r.status() === 200,
+        { timeout: 20000 }
+      )
+      .catch(() => null);
     await pageB.goto('/users');
     const table = pageB.getByRole('table');
     await expect(table).toBeVisible({ timeout: 15000 });
     await expect(
       table.getByRole('cell', { name: username, exact: true })
     ).toBeVisible({ timeout: 15000 });
-
-    // Give SSE time to connect
-    await pageB.waitForTimeout(3000);
-
-    const rowsBeforeDelete = await table.locator('tbody tr').count();
+    await sseConnected;
 
     // Window A: delete the user
     const uid = createBody?.user?.id;
@@ -132,15 +138,12 @@ test.describe('Live Data Updates (SSE)', () => {
     const deleteResponse = await pageA.request.delete(`/api/v1/users/${uid}`);
     expect(deleteResponse.ok()).toBeTruthy();
 
-    // Window B: user should disappear without refresh
-    await expect(async () => {
-      const rows = await table.locator('tbody tr').count();
-      expect(rows).toBeLessThan(rowsBeforeDelete);
-    }).toPass({ timeout: 30000, intervals: [500, 1000, 2000] });
-
+    // Window B: the user should disappear without a refresh. Assert on the
+    // specific username cell rather than an absolute row-count delta, so a
+    // concurrent test mutating the list can't offset the count.
     await expect(
       table.getByRole('cell', { name: username, exact: true })
-    ).not.toBeVisible({ timeout: 5000 });
+    ).toBeHidden({ timeout: 30000 });
 
     await ctxA.close();
     await ctxB.close();

--- a/e2e/suites/interactions/repositories/artifact-version-history.spec.ts
+++ b/e2e/suites/interactions/repositories/artifact-version-history.spec.ts
@@ -153,7 +153,7 @@ test.describe.serial('Generic artifact version history (#571)', () => {
       await page.waitForTimeout(1500);
     }
 
-    const row = vp.artifactsTable.getByRole('row').filter({ hasText: 'app-config.yaml' });
+    const row = vp.artifactRow('app-config.yaml');
     if (!(await row.first().isVisible({ timeout: 5000 }).catch(() => false))) {
       test.skip(true, 'Artifact row not visible in table');
       return;
@@ -180,11 +180,24 @@ test.describe.serial('Generic artifact version history (#571)', () => {
     const vp = new ArtifactVersionsPage(page);
     await vp.goto(REPO_KEY);
 
-    if (!(await vp.settingsTab.isVisible({ timeout: 8000 }).catch(() => false))) {
+    // Wait for the repo-detail tabs to hydrate before probing for the
+    // admin-only Settings tab. `locator.isVisible()` is a non-retrying instant
+    // check that ignores the `timeout` option, so calling it straight after
+    // `domcontentloaded` raced the client render and made this test always
+    // auto-skip. `waitFor` actually polls, so as admin we proceed and assert,
+    // while a non-admin session (no Settings tab) still skips as intended.
+    const settingsVisible = await vp.settingsTab
+      .waitFor({ state: 'visible', timeout: 8000 })
+      .then(() => true)
+      .catch(() => false);
+    if (!settingsVisible) {
       test.skip(true, 'Settings tab not visible (requires admin); API tests cover the contract');
       return;
     }
-    await vp.settingsTab.click();
+    // Wait for the tab to actually become active before asserting on its
+    // contents — the settings panel mounts asynchronously and the versioning
+    // section only renders once the repository data has hydrated.
+    await vp.openSettingsTab();
 
     await expect(vp.versioningHeading).toBeVisible({ timeout: 8000 });
     await expect(vp.versioningToggle).toBeVisible({ timeout: 5000 });

--- a/e2e/suites/interactions/security/security-scans.spec.ts
+++ b/e2e/suites/interactions/security/security-scans.spec.ts
@@ -13,12 +13,14 @@ test.describe('Security Scans Page', () => {
   });
 
   test('scans table or empty state is visible', async ({ page }) => {
-    // Use .or() with expect().toBeVisible() so Playwright auto-retries until data loads
-    await expect(
-      page.getByRole('table').first()
-        .or(page.getByText(/no scan results found/i).first())
-        .or(page.getByText(/no data found/i).first())
-    ).toBeVisible({ timeout: 15000 });
+    // The scans list renders through the shared <DataTable>, which always
+    // mounts a <table> (its column header row) regardless of whether there are
+    // results — the "No scan results found." copy is an extra element rendered
+    // *alongside* that header table, not instead of it. The old `.or()` chain
+    // therefore matched two elements (table + empty-state text) in the empty
+    // case and tripped strict mode. Asserting on the always-present header
+    // table is unambiguous and still auto-retries until the page hydrates.
+    await expect(page.getByRole('table').first()).toBeVisible({ timeout: 15000 });
   });
 
   test('trigger scan button is visible', async ({ page }) => {


### PR DESCRIPTION
Closes #576

## Summary
Hardens four flaky/failing Playwright interaction specs found by the v1.5.0 integration pass against a full all-features backend. In every case the UI works correctly (confirmed by hand during the pass) — these are **test-side** selector-ambiguity, non-retrying-assertion, and cross-test-interference bugs. No product code is changed. Root causes and fixes:

1. **`repositories/artifact-version-history.spec.ts` (2 UI tests skipped)**
   - The artifact browser renders via the shared `<DataTable>`, which spreads `role="button"` onto each clickable data `<tr>` (unit-tested, intentional). That override strips the implicit `row` role, so `getByRole('row').filter(...)` only matched the header → row never found → skip. Now located by `tbody tr` (role-neutral, DOM-accurate) via a new `artifactRow()` helper.
   - The settings-tab guard used `locator.isVisible({ timeout: 8000 })`; `isVisible()` is a **non-retrying instant check that ignores `timeout`**, so it ran before the client tabs hydrated and always returned false → skip. Replaced with `waitFor`, plus an `openSettingsTab()` helper that waits for the tab to become active before asserting.

2. **`admin/migration.spec.ts:38` (strict-mode)** — `getByLabel(/name/i)` matched both the "Sort by Name" column sort-button and the dialog Name input. Scoped to the dialog with an exact label.

3. **`security/security-scans.spec.ts:15` (strict-mode)** — an empty `<DataTable>` renders both a `<table>` (header) and the "No scan results found." text, so `.or()` matched two elements. Now asserts the always-present header table (covers populated and empty states).

4. **`dashboard/live-updates.spec.ts:32 & :89` (stuck on `/login` + count interference)** — the helper re-typed a hardcoded admin password that global-setup had already rotated, hanging the second tab on `/login`. Both tabs now reuse the admin `storageState` (deterministic auth). Once auth was fixed, the two SSE tests interfered under parallel execution via absolute row-count assertions; they now wait for the SSE stream to open before mutating and assert on the specific username cell instead of a count delta.

## Test Checklist
- [ ] Unit tests added/updated
- [x] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

Validation (against `:dev` backend via `docker-compose.e2e.yml`):
- All 4 fixed suites pass green — 23/23 (setup + version-history 6/6 incl. the previously-skipped settings-tab test, migration, security-scans, live-updates 2/2), **0 skipped, 0 flaky**.
- `live-updates` run 3× in parallel: 3/3 green (previously 1 failed + 1 flaky).
- `npm run lint` clean (0 errors); `npm test` (vitest) 143 files / 2665 tests pass — unaffected.

## UI Changes
- [x] N/A - no UI changes (test/page-object only)

<!-- linked issue #576 -->