### PR TITLE
chore(release): v1.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artifact-keeper-web",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artifact-keeper-web",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dependencies": {
         "@artifact-keeper/sdk": "^1.5.0",
         "@hookform/resolvers": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-keeper-web",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Align web version with the backend **v1.5.1** patch release and publish the `web:1.5.1` image the backend release verify-images gate requires. No web feature changes; SDK pin stays at 1.5.0 (the 1.5.1 npm-scope-policy endpoint is deferred to web#580/1.6.0).