### PR TITLE
chore(release): v1.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artifact-keeper-web",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artifact-keeper-web",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "dependencies": {
         "@artifact-keeper/sdk": "^1.5.0",
         "@hookform/resolvers": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-keeper-web",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Align web version + publish web:1.5.2 for the **v1.5.2 backend security hotfix** (#2430). No web feature changes; SDK pin unchanged.