### PR TITLE
fix(quality-checks): point admin list at /admin/quality-checks list-all (#2419)

### DIFF
--- a/src/lib/api/__tests__/quality-checks.test.ts
+++ b/src/lib/api/__tests__/quality-checks.test.ts
@@ -39,24 +39,24 @@ const ISSUE = {
 beforeEach(() => vi.clearAllMocks());
 
 describe("qualityChecksApi", () => {
-  it("list builds the query string and maps CheckResponse[]", async () => {
-    mockApiFetch.mockResolvedValue([CHECK]);
+  it("list hits the admin list-all endpoint and unwraps the envelope", async () => {
+    mockApiFetch.mockResolvedValue({ items: [CHECK], total: 1, page: 1, per_page: 50 });
     const out = await qualityChecksApi.list({ repository_id: "r1" });
-    expect(mockApiFetch).toHaveBeenCalledWith("/api/v1/quality/checks?repository_id=r1");
+    expect(mockApiFetch).toHaveBeenCalledWith("/api/v1/admin/quality-checks?repository_id=r1");
     expect(out[0]).toMatchObject({ id: "c1", check_type: "metadata", passed: false, critical_count: 1 });
   });
 
-  it("list with no params queries the unfiltered endpoint", async () => {
-    mockApiFetch.mockResolvedValue([]);
+  it("list with no params queries the unfiltered admin endpoint", async () => {
+    mockApiFetch.mockResolvedValue({ items: [], total: 0, page: 1, per_page: 50 });
     await qualityChecksApi.list();
-    expect(mockApiFetch).toHaveBeenCalledWith("/api/v1/quality/checks");
+    expect(mockApiFetch).toHaveBeenCalledWith("/api/v1/admin/quality-checks");
   });
 
   it("list encodes both artifact_id and repository_id filters", async () => {
-    mockApiFetch.mockResolvedValue([]);
+    mockApiFetch.mockResolvedValue({ items: [], total: 0, page: 1, per_page: 50 });
     await qualityChecksApi.list({ repository_id: "r1", artifact_id: "a1" });
     expect(mockApiFetch).toHaveBeenCalledWith(
-      "/api/v1/quality/checks?repository_id=r1&artifact_id=a1",
+      "/api/v1/admin/quality-checks?repository_id=r1&artifact_id=a1",
     );
   });
 

--- a/src/lib/api/quality-checks.ts
+++ b/src/lib/api/quality-checks.ts
@@ -47,6 +47,14 @@ export interface ListChecksParams {
   artifact_id?: string;
 }
 
+/** Paginated envelope returned by GET /api/v1/admin/quality-checks (#2419). */
+interface QualityCheckListResponse {
+  items: CheckResponse[];
+  total: number;
+  page: number;
+  per_page: number;
+}
+
 // The web models a subset of CheckResponse/IssueResponse — add fields here
 // (e.g. started_at, checker_version, details, suppressed_by) when the UI
 // surfaces them. Nothing currently rendered is dropped.
@@ -87,22 +95,23 @@ function adaptIssue(sdk: IssueResponse): QualityIssue {
 
 const qualityChecksApi = {
   list: async (params: ListChecksParams = {}): Promise<QualityCheck[]> => {
-    // SDK 1.5.0's generated `listChecks` types its query as
-    // `{ artifact_id: string }` — required, and with no `repository_id`. That
-    // contradicts the real GET /api/v1/quality/checks, which accepts an
-    // OPTIONAL `artifact_id` plus a `repository_id` filter and is what this
-    // admin view (list-all, or filter by repo) depends on. Rather than
-    // force-cast our honest `ListChecksParams` through the wrong SDK query
-    // type, this call goes through the shared `apiFetch` trust boundary (the
-    // same pattern repositories.ts uses for fields the SDK doesn't model yet).
-    // Collapse back to the SDK `listChecks` once the backend OpenAPI query
-    // schema is corrected and the SDK regenerated.
+    // The admin quality-checks view needs a list-all (or filter-by-repo) view.
+    // The artifact-scoped GET /api/v1/quality/checks 400s without `artifact_id`
+    // (its #2334 contract), so this goes through the dedicated admin list-all
+    // endpoint GET /api/v1/admin/quality-checks (#2419), which accepts optional
+    // `repository_id`/`artifact_id`/`status` and returns a paginated
+    // `{ items, total, page, per_page }` envelope. The SDK doesn't model this
+    // endpoint yet, so the call uses the shared `apiFetch` trust boundary (the
+    // same pattern repositories.ts uses for endpoints the SDK doesn't model);
+    // collapse back to a generated SDK call once the SDK is regenerated.
     const qs = new URLSearchParams();
     if (params.repository_id) qs.set('repository_id', params.repository_id);
     if (params.artifact_id) qs.set('artifact_id', params.artifact_id);
     const suffix = qs.toString() ? `?${qs.toString()}` : '';
-    const data = await apiFetch<CheckResponse[]>(`/api/v1/quality/checks${suffix}`);
-    return assertData(data, 'qualityChecksApi.list').map(adaptCheck);
+    const data = await apiFetch<QualityCheckListResponse>(
+      `/api/v1/admin/quality-checks${suffix}`,
+    );
+    return assertData(data, 'qualityChecksApi.list').items.map(adaptCheck);
   },
 
   get: async (id: string): Promise<QualityCheck> => {


### PR DESCRIPTION
## Summary

Point the admin quality-checks page's data source at the new backend admin
list-all endpoint (artifact-keeper#2419).

`qualityChecksApi.list()` previously called the artifact-scoped
`GET /api/v1/quality/checks`, which requires `artifact_id` and 400s without it
(its #2334 contract) — so the admin list-all view had no valid request to make.
It now calls `GET /api/v1/admin/quality-checks`, which accepts optional
`repository_id` / `artifact_id` / `status` and returns a paginated
`{ items, total, page, per_page }` envelope; the adapter unwraps `.items` and
maps through the existing `adaptCheck`.

The page component is unchanged — the adapter shields it (it still receives
`QualityCheck[]`).

Companion to the backend PR for artifact-keeper#2419 (paired change, no linked
issue in this repo).

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

`src/lib/api/__tests__/quality-checks.test.ts` updated: `list()` now asserts the
`/api/v1/admin/quality-checks` URL (with and without filters) and that the
`{items,...}` envelope is unwrapped to `QualityCheck[]`.

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [x] N/A - no UI changes (data-source URL + envelope unwrap only; page unchanged)
