### PR TITLE
fix(migration): guard job-detail report render against absent category summaries (#2455)

### DIFF
--- a/src/app/(app)/(admin)/migration/__tests__/page.test.tsx
+++ b/src/app/(app)/(admin)/migration/__tests__/page.test.tsx
@@ -1444,7 +1444,100 @@ describe("MigrationPage — feature parity (#520)", () => {
     expect(screen.getByText("Reconciliation Report")).toBeInTheDocument();
     // Artifacts migrated/total from the report summary.
     expect(screen.getByText("9/10")).toBeInTheDocument();
+    expect(screen.getByText("2/2")).toBeInTheDocument();
     expect(screen.getByText("Re-run failed artifacts")).toBeInTheDocument();
+  });
+
+  // Regression for artifact-keeper#2455: the backend materializes `summary`
+  // dynamically and OMITS a per-category key (artifacts/repositories/...) when
+  // the completed job migrated no items of that type (assessment jobs, or full
+  // jobs that touched no artifacts). The detail modal used to read
+  // `report.summary.artifacts.migrated` unguarded, so an absent category threw
+  // "Cannot read properties of undefined (reading 'migrated')" and the admin
+  // error boundary replaced the whole page.
+  it("renders a completed job whose report omits the artifacts/repositories summary without crashing", async () => {
+    const job = makeJob({
+      id: "job-part-0001",
+      status: "completed",
+      job_type: "full",
+    });
+    // Partial report: only users were migrated, so artifacts/repositories keys
+    // are absent from `summary` — exactly what generate_report emits.
+    const partialReport = makeReport({
+      job_id: job.id,
+      summary: {
+        duration_seconds: 30,
+        users: { total: 2, migrated: 2, failed: 0, skipped: 0 },
+        total_bytes_transferred: 0,
+      } as MigrationReport["summary"],
+    });
+    configureQueries({
+      connections: { data: [makeConnection()] },
+      migrations: { data: { items: [job], pagination: {} } },
+      report: { data: partialReport },
+    });
+    await renderPage();
+    await switchToJobsTab();
+    await act(async () => fireEvent.click(screen.getByText("job-part...")));
+    // The report block renders; missing categories fall back to an em dash
+    // instead of crashing the page.
+    expect(screen.getByText("Reconciliation Report")).toBeInTheDocument();
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders a completed assessment job with a summary-only report (no category counts) without crashing", async () => {
+    const job = makeJob({
+      id: "job-asmt-9999",
+      status: "completed",
+      job_type: "assessment",
+    });
+    // Assessment jobs create no migration items → summary has only the scalar
+    // fields, and warnings/errors/recommendations may be empty.
+    const summaryOnly = makeReport({
+      job_id: job.id,
+      summary: {
+        duration_seconds: 5,
+        total_bytes_transferred: 0,
+      } as MigrationReport["summary"],
+      warnings: [],
+      errors: [],
+      recommendations: [],
+    });
+    configureQueries({
+      connections: { data: [makeConnection()] },
+      migrations: { data: { items: [job], pagination: {} } },
+      report: { data: summaryOnly },
+    });
+    await renderPage();
+    await switchToJobsTab();
+    await act(async () => fireEvent.click(screen.getByText("job-asmt...")));
+    expect(screen.getByText("Reconciliation Report")).toBeInTheDocument();
+    // Both category tiles show the em-dash fallback; warnings/errors show 0.
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("0").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("shows the progress view (and no reconciliation report) for a running job", async () => {
+    const job = makeJob({
+      id: "job-run-0001",
+      status: "running",
+      job_type: "full",
+      completed_items: 7,
+      total_items: 20,
+    });
+    // Running jobs are non-terminal, so the report query stays disabled/empty.
+    configureQueries({
+      connections: { data: [makeConnection()] },
+      migrations: { data: { items: [job], pagination: {} } },
+      report: { data: undefined },
+    });
+    await renderPage();
+    await switchToJobsTab();
+    await act(async () => fireEvent.click(screen.getByText("job-run-...")));
+    // Progress counts render (list row + dialog); the reconciliation report
+    // block does not.
+    expect(screen.getAllByText("7/20").length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText("Reconciliation Report")).not.toBeInTheDocument();
   });
 
   it("downloads the HTML report on demand", async () => {

--- a/src/app/(app)/(admin)/migration/page.tsx
+++ b/src/app/(app)/(admin)/migration/page.tsx
@@ -41,6 +41,7 @@ import type {
   MigrationJobType,
   MigrationProgressEvent,
   MigrationReport,
+  ItemSummary,
   AssessmentResult,
 } from "@/types";
 
@@ -130,6 +131,17 @@ const TERMINAL_STATUSES: ReadonlySet<MigrationJobStatus> = new Set([
   "failed",
   "cancelled",
 ]);
+
+// The reconciliation report's per-category summary (artifacts/repositories/...)
+// is only present when the job migrated at least one item of that type, so a
+// category can be absent on completed jobs (assessment runs, or a full job that
+// touched no artifacts). Render "migrated/total" defensively: an absent summary
+// shows "—" and a partial one falls back to 0 instead of crashing the whole
+// admin page with a TypeError (artifact-keeper#2455).
+function formatItemCount(summary: ItemSummary | undefined): string {
+  if (!summary) return "—";
+  return `${summary.migrated ?? 0}/${summary.total ?? 0}`;
+}
 
 // The create-migration config defaults mirror the backend `MigrationConfig`
 // serde defaults (models/migration.rs): users/groups/permissions and checksum
@@ -1576,27 +1588,27 @@ export default function MigrationPage() {
                     <div>
                       <p className="text-xs text-muted-foreground">Artifacts</p>
                       <p className="font-semibold">
-                        {report.summary.artifacts.migrated}/
-                        {report.summary.artifacts.total}
+                        {formatItemCount(report.summary?.artifacts)}
                       </p>
                     </div>
                     <div>
                       <p className="text-xs text-muted-foreground">Repos</p>
                       <p className="font-semibold">
-                        {report.summary.repositories.migrated}/
-                        {report.summary.repositories.total}
+                        {formatItemCount(report.summary?.repositories)}
                       </p>
                     </div>
                     <div>
                       <p className="text-xs text-muted-foreground">Warnings</p>
-                      <p className="font-semibold">{report.warnings.length}</p>
+                      <p className="font-semibold">
+                        {report.warnings?.length ?? 0}
+                      </p>
                     </div>
                     <div>
                       <p className="text-xs text-muted-foreground">Errors</p>
-                      <p className="font-semibold">{report.errors.length}</p>
+                      <p className="font-semibold">{report.errors?.length ?? 0}</p>
                     </div>
                   </div>
-                  {report.recommendations.length > 0 && (
+                  {(report.recommendations?.length ?? 0) > 0 && (
                     <ul className="list-disc pl-5 text-xs text-muted-foreground">
                       {report.recommendations.map((rec, i) => (
                         <li key={i}>{rec}</li>

--- a/src/types/migration.ts
+++ b/src/types/migration.ts
@@ -142,13 +142,19 @@ export interface ItemSummary {
   skipped: number;
 }
 
+// The backend materializes `summary` dynamically: it only emits a per-category
+// key (repositories/artifacts/users/groups/permissions) when the job has at
+// least one migration item of that type (migration_service.rs `generate_report`
+// GROUP BYs item_type). Assessment jobs and full jobs that migrated no items of
+// a given category therefore omit that key entirely, so every category summary
+// is optional and consumers must guard for its absence (artifact-keeper#2455).
 export interface ReportSummary {
   duration_seconds: number;
-  repositories: ItemSummary;
-  artifacts: ItemSummary;
-  users: ItemSummary;
-  groups: ItemSummary;
-  permissions: ItemSummary;
+  repositories?: ItemSummary;
+  artifacts?: ItemSummary;
+  users?: ItemSummary;
+  groups?: ItemSummary;
+  permissions?: ItemSummary;
   total_bytes_transferred: number;
 }
 


### PR DESCRIPTION
## Summary

Fixes the crash where opening a **completed** migration job in **Migration → Migration Jobs** replaces the whole admin page with "Administration Error" (`TypeError: Cannot read properties of undefined (reading 'migrated')`). Non-completed jobs (pending/assessing/running) were unaffected because the report only exists once a job reaches a terminal state.

**Root cause.** The job-detail modal renders the reconciliation report by reading `report.summary.artifacts.migrated` and `report.summary.repositories.migrated` unconditionally (`src/app/(app)/(admin)/migration/page.tsx`). The backend materializes the report `summary` **dynamically** — it only emits a per-category key (`artifacts` / `repositories` / `users` / `groups` / `permissions`) when the completed job migrated at least one item of that type (`generate_report` groups `migration_items` by `item_type`). So the key is **absent** for assessment jobs (which create no items) and for full jobs that touched no artifacts. Reading `.migrated` off the resulting `undefined` category threw, and the admin error boundary escalated it to a full-page error.

The web type `ReportSummary` incorrectly declared every category as a **required** `ItemSummary`, masking the mismatch at compile time.

This is a web-only fix that matches the backend's real (conditionally-present) response shape. The backend DTO is intentionally sparse — no backend change is warranted.

## Changes
- `src/types/migration.ts` — make the per-category `ItemSummary` fields on `ReportSummary` optional to reflect the real backend shape.
- `src/app/(app)/(admin)/migration/page.tsx` — render the counts through a `formatItemCount` helper using optional chaining + fallbacks: an absent category shows an em dash (`—`), a partial one falls back to `0`, and `warnings` / `errors` / `recommendations` tolerate absent arrays. Running/pending progress view is unchanged.

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

Added regression tests to `migration/__tests__/page.test.tsx`:
- completed full job whose report omits `artifacts`/`repositories` renders without crashing (em-dash fallback);
- completed assessment job with a summary-only report renders without crashing (counts + `0` for warnings/errors);
- running job still shows the progress view and no reconciliation report.

Full suite: **143 files / 2670 tests pass**. `eslint` clean (0 errors). No new type errors introduced in the migration files.

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [x] N/A - display-only fallback; no layout/visual change beyond an em-dash placeholder for absent counts

Closes #2455

The tracking issue lives in the backend repo: artifact-keeper/artifact-keeper#2455.

Closes #590 (web); fixes artifact-keeper/artifact-keeper#2455.