### PR TITLE
feat(setup): offer both single-line and DEB822 APT source formats

### DIFF
--- a/src/app/(app)/setup/page.tsx
+++ b/src/app/(app)/setup/page.tsx
@@ -647,9 +647,23 @@ export GONOSUMCHECK=*`,
     case "debian":
       return [
         {
-          title: "Add APT repository",
+          title: "Add repository signing key",
+          code: `sudo mkdir -m 0755 -p /etc/apt/keyrings
+sudo curl -Lo /etc/apt/keyrings/artifact-keeper.gpg.asc ${REGISTRY_URL}/debian/${repoKey}/gpg-key.asc`,
+        },
+        {
+          title: "Add APT repository (single-line, old)",
           description: "Add to /etc/apt/sources.list.d/artifact-keeper.list:",
-          code: `deb ${REGISTRY_URL}/debian/${repoKey}/ stable main`,
+          code: `deb [signed-by=/etc/apt/keyrings/artifact-keeper.gpg.asc] ${REGISTRY_URL}/debian/${repoKey}/ stable main`,
+        },
+        {
+          title: "Add APT repository (DEB822, modern)",
+          description: "Add to /etc/apt/sources.list.d/artifact-keeper.sources:",
+          code: `Types: deb
+URIs: ${REGISTRY_URL}/debian/${repoKey}
+Suites: stable
+Components: main
+Signed-By: /etc/apt/keyrings/artifact-keeper.gpg.asc`,
         },
         {
           title: "Update and install",


### PR DESCRIPTION
Resolves #596

## Summary

Add a signing-key download step and present Debian/APT setup instructions in both the legacy single-line format (with explicit `signed-by`) and the modern DEB822 .sources format. The key is installed into /etc/apt/keyrings/ before configuring either source entry.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [ ] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [x] N/A - no UI changes
