### PR TITLE
chore(release): bump web version to 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artifact-keeper-web",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artifact-keeper-web",
-      "version": "1.5.3",
+      "version": "1.6.0",
       "dependencies": {
         "@artifact-keeper/sdk": "^1.5.0",
         "@hookform/resolvers": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-keeper-web",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
Release-prep version bump for the 1.6.0 cut. Bumps the web app version `1.5.3 -> 1.6.0`.

- `package.json` `"version"` — the single source of the baked Web version. `next.config.ts` inlines it as `NEXT_PUBLIC_APP_VERSION: pkg.version`, so this one line drives the version shown in the UI.
- `package-lock.json` root version (2 occurrences) bumped to match, per the established release-commit convention.

No functional/UI changes. No other hardcoded `1.5.3` strings exist in the source tree.

Closes #597

## Test Checklist
- [ ] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [ ] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [x] N/A - no UI changes
