### PR TITLE
chore(deps): bump @artifact-keeper/sdk to 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "artifact-keeper-web",
       "version": "1.6.0",
       "dependencies": {
-        "@artifact-keeper/sdk": "^1.5.0",
+        "@artifact-keeper/sdk": "^1.6.0",
         "@hookform/resolvers": "^5.2.2",
         "@tanstack/react-query": "^5.100.9",
         "class-variance-authority": "^0.7.1",
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@artifact-keeper/sdk": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@artifact-keeper/sdk/-/sdk-1.5.0.tgz",
-      "integrity": "sha512-Xa5JtKV9/6bpp1QzDBo39wWW+XO+Wd95ZvSfxt7sqdxp4jxZXCfgl2yyAz5e/Zvgw1ey0yuPrUh5RNSvJu6lLw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@artifact-keeper/sdk/-/sdk-1.6.0.tgz",
+      "integrity": "sha512-nCqG6/c1Dt/3CsPri/GF+Wa2/5LCrwT34c6RzSUy6vts3FB1lhiNOslmzmSnrMac8g/zByqVbYHZ8nJcb2jIvw==",
       "license": "MIT",
       "dependencies": {
         "@hey-api/client-fetch": "^0.13.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "tutorial:generate-videos": "npx tsx e2e/tutorials/scripts/generate-videos.ts"
   },
   "dependencies": {
-    "@artifact-keeper/sdk": "^1.5.0",
+    "@artifact-keeper/sdk": "^1.6.0",
     "@hookform/resolvers": "^5.2.2",
     "@tanstack/react-query": "^5.100.9",
     "class-variance-authority": "^0.7.1",

--- a/src/lib/api/__tests__/promotion.test.ts
+++ b/src/lib/api/__tests__/promotion.test.ts
@@ -43,6 +43,7 @@ const SDK_REPO: SdkRepositoryResponse = {
   allow_anonymous_access: false,
   promotion_only: false,
   versioning_enabled: false,
+  has_trusted_gpg_key: false,
   created_at: "2026-04-01T00:00:00Z",
   updated_at: "2026-05-01T00:00:00Z",
 };

--- a/src/lib/api/__tests__/sso.test.ts
+++ b/src/lib/api/__tests__/sso.test.ts
@@ -117,6 +117,7 @@ const SDK_SAML: SdkSamlConfigResponse = {
   sign_requests: true,
   require_signed_assertions: true,
   use_absolute_acs_url: false,
+  map_groups_to_groups: false,
   admin_group: "Admins",
   is_enabled: true,
   created_at: "2026-04-01T00:00:00Z",


### PR DESCRIPTION
## Summary

Bumps `@artifact-keeper/sdk` from `^1.5.0` to `^1.6.0` and refreshes `package-lock.json` so it resolves 1.6.0. This is the prerequisite dependency bump that unblocks all 1.6.0 web feature work.

This PR is strictly the dependency bump plus making the existing code compile / lint / build clean against 1.6.0. No new feature UI is added here.

## What the bump changed

The 1.6.0 SDK adds two new **required** fields to existing response types. The only code affected in this repo was SDK-typed test fixtures:

- `RepositoryResponse.has_trusted_gpg_key: boolean` — RPM curation signature verification (backend #2568)
- `SamlConfigResponse.map_groups_to_groups: boolean` — SAML group-mapping opt-in flag

Both fields were added to the affected fixtures (`src/lib/api/__tests__/promotion.test.ts`, `src/lib/api/__tests__/sso.test.ts`). **No production source changes were required** — all of `src/lib/api/*` and `src/lib/sdk-client.ts` compile and build clean against 1.6.0.

The `apiFetch`-workaround files (`storage`, `blast-radius`, `audit`, `rate-limits`, `quality-checks`) are intentionally left untouched; migrating them onto any newly available SDK operations is follow-up feature work, not part of this bump.

## Verification (run exactly as CI)

- `npm run lint` — 0 errors (warnings only, pre-existing)
- `npm run test:coverage` — 145 files / 2685 tests passed; lines 87.62%, statements 86.96% (above the 80% gate)
- `npm run build` — success
- `package-lock.json` resolves `@artifact-keeper/sdk` 1.6.0

Closes #600
Refs #599