### PR TITLE
feat(audit): SIEM export (CSV + versioned JSON) for the audit log

### DIFF
--- a/src/app/(app)/(admin)/audit/__tests__/page.test.tsx
+++ b/src/app/(app)/(admin)/audit/__tests__/page.test.tsx
@@ -1,7 +1,13 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import "@testing-library/jest-dom/vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -18,6 +24,8 @@ vi.mock("lucide-react", () => {
   return {
     RefreshCw: stub("RefreshCw"),
     ScrollText: stub("ScrollText"),
+    Download: stub("Download"),
+    Loader2: stub("Loader2"),
   };
 });
 
@@ -26,13 +34,24 @@ const {
   mockUseQuery,
   mockInvalidateQueries,
   mockAuditList,
+  mockAuditExport,
   mockAdminListUsers,
+  mockTriggerDownload,
+  mockToast,
 } = vi.hoisted(() => ({
   mockUseAuth: vi.fn(),
   mockUseQuery: vi.fn(),
   mockInvalidateQueries: vi.fn(),
   mockAuditList: vi.fn(),
+  mockAuditExport: vi.fn(),
   mockAdminListUsers: vi.fn(),
+  mockTriggerDownload: vi.fn(),
+  mockToast: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+  },
 }));
 
 vi.mock("@/providers/auth-provider", () => ({
@@ -50,7 +69,10 @@ vi.mock("@/lib/api/audit", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/api/audit")>();
   return {
     ...actual,
-    auditApi: { list: (...args: any[]) => mockAuditList(...args) },
+    auditApi: {
+      list: (...args: any[]) => mockAuditList(...args),
+      export: (...args: any[]) => mockAuditExport(...args),
+    },
   };
 });
 
@@ -58,6 +80,25 @@ vi.mock("@/lib/api/admin", () => ({
   adminApi: {
     listUsers: (...args: any[]) => mockAdminListUsers(...args),
   },
+}));
+
+vi.mock("@/lib/download", () => ({
+  triggerBrowserDownload: (...args: any[]) => mockTriggerDownload(...args),
+}));
+
+vi.mock("sonner", () => ({ toast: mockToast }));
+
+// Minimal dropdown-menu that renders its items inline so the export actions are
+// clickable without portals/pointer events.
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuItem: ({ children, onSelect, disabled }: any) => (
+    <button disabled={disabled} onClick={() => onSelect?.()}>
+      {children}
+    </button>
+  ),
 }));
 
 // UI components
@@ -425,6 +466,114 @@ describe("AuditLogPage", () => {
     // The long payload preview is truncated to 80 chars with an ellipsis.
     const expectedPreview = `${JSON.stringify(longDetails).slice(0, 80)}…`;
     expect(screen.getByText(expectedPreview)).toBeInTheDocument();
+  });
+});
+
+describe("AuditLogPage export", () => {
+  function renderWithEvents(total = 3) {
+    queryState({
+      audit: {
+        data: { items: [EVENT], total, page: 1, per_page: 50 },
+        isLoading: false,
+        isError: false,
+        isFetching: false,
+      },
+      users: [{ id: ACTOR_ID, username: "alice-admin" }],
+    });
+    render(<AuditLogPage />);
+  }
+
+  it("exports CSV honoring the applied filters", async () => {
+    renderWithEvents();
+    mockAuditExport.mockResolvedValue({
+      items: [EVENT],
+      total: 1,
+      truncated: false,
+    });
+
+    fireEvent.change(screen.getByLabelText(/^action$/i), {
+      target: { value: "LOGIN" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /apply filters/i }));
+    fireEvent.click(screen.getByRole("button", { name: /export as csv/i }));
+
+    await waitFor(() => expect(mockTriggerDownload).toHaveBeenCalledTimes(1));
+
+    expect(mockAuditExport).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "LOGIN" })
+    );
+    const [filename, content, mime] = mockTriggerDownload.mock.calls[0];
+    expect(filename).toMatch(/^audit-log-.*\.csv$/);
+    expect(mime).toMatch(/text\/csv/);
+    expect(content).toContain("id,created_at,action"); // header row
+    expect(content).toContain("USER_CREATED");
+    expect(mockToast.success).toHaveBeenCalled();
+  });
+
+  it("exports JSON as a versioned structured envelope", async () => {
+    renderWithEvents();
+    mockAuditExport.mockResolvedValue({
+      items: [EVENT],
+      total: 1,
+      truncated: false,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /export as json/i }));
+
+    await waitFor(() => expect(mockTriggerDownload).toHaveBeenCalledTimes(1));
+    const [filename, content, mime] = mockTriggerDownload.mock.calls[0];
+    expect(filename).toMatch(/\.json$/);
+    expect(mime).toMatch(/application\/json/);
+    const parsed = JSON.parse(content);
+    expect(parsed.schema_version).toBe("1.0");
+    expect(parsed.count).toBe(1);
+    expect(parsed.items).toHaveLength(1);
+  });
+
+  it("shows an info toast and skips download when nothing matches", async () => {
+    renderWithEvents();
+    mockAuditExport.mockResolvedValue({
+      items: [],
+      total: 0,
+      truncated: false,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /export as csv/i }));
+
+    await waitFor(() => expect(mockToast.info).toHaveBeenCalled());
+    expect(mockTriggerDownload).not.toHaveBeenCalled();
+  });
+
+  it("warns when a large export is truncated", async () => {
+    renderWithEvents();
+    mockAuditExport.mockResolvedValue({
+      items: [EVENT, { ...EVENT, id: "e2" }],
+      total: 1000,
+      truncated: true,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /export as csv/i }));
+
+    await waitFor(() => expect(mockTriggerDownload).toHaveBeenCalledTimes(1));
+    expect(mockToast.warning).toHaveBeenCalled();
+    expect(mockToast.success).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an error toast when the export fails", async () => {
+    renderWithEvents();
+    mockAuditExport.mockRejectedValue(new Error("network"));
+
+    fireEvent.click(screen.getByRole("button", { name: /export as json/i }));
+
+    await waitFor(() => expect(mockToast.error).toHaveBeenCalled());
+    expect(mockTriggerDownload).not.toHaveBeenCalled();
+  });
+
+  it("disables the export control when there are no events", () => {
+    renderWithEvents(0);
+    expect(
+      screen.getByRole("button", { name: /export audit log/i })
+    ).toBeDisabled();
   });
 });
 

--- a/src/app/(app)/(admin)/audit/page.tsx
+++ b/src/app/(app)/(admin)/audit/page.tsx
@@ -3,15 +3,24 @@
 import { useMemo, useState } from "react";
 import { useAuth } from "@/providers/auth-provider";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { RefreshCw, ScrollText } from "lucide-react";
+import { Download, Loader2, RefreshCw, ScrollText } from "lucide-react";
+import { toast } from "sonner";
 
 import {
   auditApi,
   isValidUuid,
   AUDIT_DEFAULT_PER_PAGE,
+  AUDIT_EXPORT_CSV_MIME,
+  AUDIT_EXPORT_JSON_MIME,
+  auditItemsToCsv,
+  auditItemsToJson,
+  buildAuditExportFilename,
+  type AuditExportFormat,
   type AuditLogItem,
+  type AuditLogQuery,
 } from "@/lib/api/audit";
 import { adminApi } from "@/lib/api/admin";
+import { triggerBrowserDownload } from "@/lib/download";
 
 import { PageHeader } from "@/components/common/page-header";
 import { DataTable, type DataTableColumn } from "@/components/common/data-table";
@@ -20,6 +29,12 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 export const AUDIT_LOG_QUERY_KEY = ["admin-audit-log"] as const;
 
@@ -80,21 +95,27 @@ export default function AuditLogPage() {
   const [draft, setDraft] = useState<AuditFilters>(EMPTY_FILTERS);
   const [applied, setApplied] = useState<AuditFilters>(EMPTY_FILTERS);
   const [filterError, setFilterError] = useState<string | null>(null);
+  const [isExporting, setIsExporting] = useState(false);
 
   const hasAppliedFilters = Object.values(applied).some((v) => v !== "");
+
+  // The active filters as an `AuditLogQuery`, shared by the list query and the
+  // export action so both honor exactly the same criteria.
+  const appliedQuery: AuditLogQuery = useMemo(
+    () => ({
+      user_id: applied.user_id || undefined,
+      action: applied.action || undefined,
+      resource_type: applied.resource_type || undefined,
+      ...dateBoundsToIso(applied),
+    }),
+    [applied]
+  );
 
   // -- queries --
   const { data, isLoading, isError, isFetching } = useQuery({
     queryKey: [...AUDIT_LOG_QUERY_KEY, page, pageSize, applied],
     queryFn: () =>
-      auditApi.list({
-        page,
-        per_page: pageSize,
-        user_id: applied.user_id || undefined,
-        action: applied.action || undefined,
-        resource_type: applied.resource_type || undefined,
-        ...dateBoundsToIso(applied),
-      }),
+      auditApi.list({ ...appliedQuery, page, per_page: pageSize }),
     enabled: !!user?.is_admin,
     retry: false,
     placeholderData: (prev) => prev,
@@ -133,6 +154,49 @@ export default function AuditLogPage() {
     setApplied(EMPTY_FILTERS);
     setFilterError(null);
     setPage(1);
+  }
+
+  // Nothing to export when the current filters match no events. Disabling the
+  // control is a friendlier signal than letting the user trigger an empty file.
+  const noEvents = !isLoading && data != null && data.total === 0;
+
+  async function handleExport(format: AuditExportFormat) {
+    setIsExporting(true);
+    try {
+      const result = await auditApi.export(appliedQuery);
+      if (result.items.length === 0) {
+        toast.info("No audit events match the current filters.");
+        return;
+      }
+      const content =
+        format === "csv"
+          ? auditItemsToCsv(result.items)
+          : auditItemsToJson(result.items, {
+              filters: appliedQuery,
+              total: result.total,
+              truncated: result.truncated,
+            });
+      triggerBrowserDownload(
+        buildAuditExportFilename(format),
+        content,
+        format === "csv" ? AUDIT_EXPORT_CSV_MIME : AUDIT_EXPORT_JSON_MIME
+      );
+
+      const n = result.items.length.toLocaleString();
+      if (result.truncated) {
+        toast.warning(
+          `Exported the first ${n} of ${result.total.toLocaleString()} matching events. Narrow the filters to export the rest.`
+        );
+      } else {
+        toast.success(
+          `Exported ${n} audit event${result.items.length === 1 ? "" : "s"}.`
+        );
+      }
+    } catch {
+      toast.error("Failed to export the audit log. Please try again.");
+    } finally {
+      setIsExporting(false);
+    }
   }
 
   const columns: DataTableColumn<AuditLogItem>[] = [
@@ -235,6 +299,37 @@ export default function AuditLogPage() {
         actions={
           <div className="flex items-center gap-2">
             <ScrollText className="size-5 text-muted-foreground" />
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={isExporting || noEvents}
+                  aria-label="Export audit log"
+                >
+                  {isExporting ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <Download className="size-4" />
+                  )}
+                  Export
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  onSelect={() => handleExport("csv")}
+                  disabled={isExporting}
+                >
+                  Export as CSV
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onSelect={() => handleExport("json")}
+                  disabled={isExporting}
+                >
+                  Export as JSON
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
             <Button
               variant="outline"
               size="icon-sm"

--- a/src/lib/__tests__/download.test.ts
+++ b/src/lib/__tests__/download.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { triggerBrowserDownload } from "../download";
+
+describe("triggerBrowserDownload", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // jsdom implements neither of these; stub them.
+    (URL as unknown as { createObjectURL: unknown }).createObjectURL = vi
+      .fn()
+      .mockReturnValue("blob:mock-url");
+    (URL as unknown as { revokeObjectURL: unknown }).revokeObjectURL = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("creates an anchor, clicks it, and cleans up", () => {
+    const clicked: string[] = [];
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        clicked.push(this.download);
+      });
+
+    triggerBrowserDownload("audit.csv", "a,b\r\n", "text/csv;charset=utf-8");
+
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    const blob = (URL.createObjectURL as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as Blob;
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe("text/csv;charset=utf-8");
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(clicked[0]).toBe("audit.csv");
+
+    // Anchor is removed synchronously; URL is revoked on the next tick.
+    expect(document.querySelector("a[download]")).toBeNull();
+    expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+    vi.runAllTimers();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+  });
+
+  it("revokes the object URL even if the click throws", () => {
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {
+      throw new Error("boom");
+    });
+
+    expect(() =>
+      triggerBrowserDownload("x.json", "{}", "application/json")
+    ).toThrow("boom");
+
+    vi.runAllTimers();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+  });
+});

--- a/src/lib/api/__tests__/audit.test.ts
+++ b/src/lib/api/__tests__/audit.test.ts
@@ -125,3 +125,212 @@ describe("auditApi", () => {
     expect(mod.isValidUuid("")).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Export builders (#603)
+// ---------------------------------------------------------------------------
+
+/** A parsed AuditLogItem as callers see it (nulls normalized). */
+const ITEM = {
+  id: ROW.id,
+  user_id: ROW.user_id,
+  actor_username: "alice",
+  action: "USER_CREATED",
+  resource_type: "user",
+  resource_id: ROW.resource_id,
+  details: { username: "alice" },
+  ip_address: "10.0.0.1",
+  correlation_id: ROW.correlation_id,
+  created_at: ROW.created_at,
+};
+
+describe("auditCsvCell", () => {
+  it("returns empty string for null/undefined", async () => {
+    const { auditCsvCell } = await import("../audit");
+    expect(auditCsvCell(null)).toBe("");
+    expect(auditCsvCell(undefined)).toBe("");
+  });
+
+  it("quotes and escapes values with commas, quotes, or newlines", async () => {
+    const { auditCsvCell } = await import("../audit");
+    expect(auditCsvCell("a,b")).toBe('"a,b"');
+    expect(auditCsvCell('say "hi"')).toBe('"say ""hi"""');
+    expect(auditCsvCell("line1\nline2")).toBe('"line1\nline2"');
+  });
+
+  it("neutralizes spreadsheet formula injection (CWE-1236)", async () => {
+    const { auditCsvCell } = await import("../audit");
+    expect(auditCsvCell("=SUM(A1:A2)")).toBe("'=SUM(A1:A2)");
+    expect(auditCsvCell("+1")).toBe("'+1");
+    expect(auditCsvCell("-1")).toBe("'-1");
+    expect(auditCsvCell("@cmd")).toBe("'@cmd");
+    // A dangerous prefix combined with a comma is both de-fanged and quoted.
+    expect(auditCsvCell("=1,2")).toBe(`"'=1,2"`);
+  });
+});
+
+describe("auditItemsToCsv", () => {
+  it("emits a header-only document for an empty export", async () => {
+    const { auditItemsToCsv, AUDIT_EXPORT_COLUMNS } = await import("../audit");
+    const csv = auditItemsToCsv([]);
+    expect(csv).toBe(`${AUDIT_EXPORT_COLUMNS.join(",")}\r\n`);
+  });
+
+  it("writes one CRLF-terminated row per event with details serialized", async () => {
+    const { auditItemsToCsv, AUDIT_EXPORT_COLUMNS } = await import("../audit");
+    const csv = auditItemsToCsv([ITEM as never]);
+    const lines = csv.trimEnd().split("\r\n");
+    expect(lines[0]).toBe(AUDIT_EXPORT_COLUMNS.join(","));
+    const cols = lines[1].split(",");
+    expect(cols[0]).toBe(ITEM.id); // id
+    expect(cols[2]).toBe("USER_CREATED"); // action
+    // details (last column) is a JSON string, quoted because it contains a comma-free
+    // object here but quotes from JSON — assert it round-trips the username.
+    expect(lines[1]).toContain("alice");
+  });
+
+  it("serializes null and string details safely", async () => {
+    const { auditItemsToCsv } = await import("../audit");
+    const csv = auditItemsToCsv([
+      { ...ITEM, id: "a", details: null } as never,
+      { ...ITEM, id: "b", details: "plain" } as never,
+    ]);
+    const rows = csv.trimEnd().split("\r\n").slice(1);
+    expect(rows[0].endsWith(",")).toBe(true); // null -> empty trailing cell
+    expect(rows[1].endsWith(",plain")).toBe(true);
+  });
+});
+
+describe("buildAuditExportEnvelope / auditItemsToJson", () => {
+  it("wraps items in a versioned envelope with normalized filters", async () => {
+    const { buildAuditExportEnvelope, AUDIT_EXPORT_SCHEMA_VERSION } =
+      await import("../audit");
+    const env = buildAuditExportEnvelope([ITEM as never], {
+      filters: {
+        action: "  LOGIN  ",
+        resource_type: "",
+        user_id: "   ",
+        from: "2026-07-01T00:00:00.000Z",
+        page: 3,
+        per_page: 25,
+      },
+      total: 42,
+      truncated: true,
+      exportedAt: "2026-07-19T00:00:00.000Z",
+    });
+    expect(env.schema_version).toBe(AUDIT_EXPORT_SCHEMA_VERSION);
+    expect(env.exported_at).toBe("2026-07-19T00:00:00.000Z");
+    expect(env.count).toBe(1);
+    expect(env.total).toBe(42);
+    expect(env.truncated).toBe(true);
+    // Empty + paging filters are dropped; free-text is trimmed.
+    expect(env.filters).toEqual({
+      action: "LOGIN",
+      from: "2026-07-01T00:00:00.000Z",
+    });
+    expect(env.items).toHaveLength(1);
+  });
+
+  it("defaults total/truncated/exported_at when omitted", async () => {
+    const { buildAuditExportEnvelope } = await import("../audit");
+    const env = buildAuditExportEnvelope([ITEM as never]);
+    expect(env.total).toBe(1);
+    expect(env.truncated).toBe(false);
+    expect(typeof env.exported_at).toBe("string");
+    expect(env.filters).toEqual({});
+  });
+
+  it("auditItemsToJson produces parseable JSON matching the envelope", async () => {
+    const { auditItemsToJson, buildAuditExportEnvelope } = await import(
+      "../audit"
+    );
+    const meta = { exportedAt: "2026-07-19T00:00:00.000Z" };
+    const json = auditItemsToJson([ITEM as never], meta);
+    expect(JSON.parse(json)).toEqual(
+      buildAuditExportEnvelope([ITEM as never], meta)
+    );
+  });
+});
+
+describe("buildAuditExportFilename", () => {
+  it("builds a filesystem-safe timestamped name per format", async () => {
+    const { buildAuditExportFilename } = await import("../audit");
+    const at = new Date("2026-07-19T12:34:56.789Z");
+    expect(buildAuditExportFilename("csv", at)).toBe(
+      "audit-log-2026-07-19T12-34-56-789Z.csv"
+    );
+    expect(buildAuditExportFilename("json", at)).toBe(
+      "audit-log-2026-07-19T12-34-56-789Z.json"
+    );
+  });
+});
+
+describe("auditApi.export", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  /** Serve `total` rows across pages of `AUDIT_MAX_PER_PAGE` from apiFetch. */
+  function servePages(total: number, perPage: number) {
+    mockApiFetch.mockImplementation((url: string) => {
+      const qs = new URLSearchParams(url.split("?")[1] ?? "");
+      const page = Number(qs.get("page") ?? "1");
+      const start = (page - 1) * perPage;
+      const items = Array.from(
+        { length: Math.max(0, Math.min(perPage, total - start)) },
+        (_, i) => ({ ...ROW, id: `row-${start + i}` })
+      );
+      return Promise.resolve({ items, total, page, per_page: perPage });
+    });
+  }
+
+  it("collects every matching row across pages, honoring filters", async () => {
+    const mod = await import("../audit");
+    servePages(450, mod.AUDIT_MAX_PER_PAGE); // 200 + 200 + 50 => 3 pages
+
+    const res = await mod.auditApi.export({ action: "LOGIN", page: 9, per_page: 5 });
+
+    expect(res.total).toBe(450);
+    expect(res.items).toHaveLength(450);
+    expect(res.truncated).toBe(false);
+
+    // Three page requests, each at the backend max page size, all carrying the
+    // filter and NOT the caller's page/per_page.
+    expect(mockApiFetch).toHaveBeenCalledTimes(3);
+    const urls = mockApiFetch.mock.calls.map((c) => c[0] as string);
+    urls.forEach((url, idx) => {
+      const qs = new URLSearchParams(url.split("?")[1]);
+      expect(qs.get("action")).toBe("LOGIN");
+      expect(qs.get("per_page")).toBe(String(mod.AUDIT_MAX_PER_PAGE));
+      expect(qs.get("page")).toBe(String(idx + 1));
+    });
+  });
+
+  it("stops after a single page when results fit", async () => {
+    const mod = await import("../audit");
+    servePages(10, mod.AUDIT_MAX_PER_PAGE);
+    const res = await mod.auditApi.export();
+    expect(res.items).toHaveLength(10);
+    expect(res.truncated).toBe(false);
+    expect(mockApiFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("caps at maxRows and reports truncation without over-fetching", async () => {
+    const mod = await import("../audit");
+    servePages(1000, mod.AUDIT_MAX_PER_PAGE);
+    const res = await mod.auditApi.export({}, { maxRows: 250 });
+    expect(res.items).toHaveLength(250);
+    expect(res.total).toBe(1000);
+    expect(res.truncated).toBe(true);
+    // Only two pages needed to reach 250 rows (200 + 50 kept).
+    expect(mockApiFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("handles an empty result set", async () => {
+    const mod = await import("../audit");
+    servePages(0, mod.AUDIT_MAX_PER_PAGE);
+    const res = await mod.auditApi.export();
+    expect(res.items).toHaveLength(0);
+    expect(res.total).toBe(0);
+    expect(res.truncated).toBe(false);
+    expect(mockApiFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/api/audit.ts
+++ b/src/lib/api/audit.ts
@@ -133,6 +133,166 @@ export function buildAuditQueryString(query: AuditLogQuery): string {
   return qs ? `?${qs}` : "";
 }
 
+// ---------------------------------------------------------------------------
+// Export for SIEM (#603 / backend #2413)
+// ---------------------------------------------------------------------------
+//
+// SDK-operation note: the generated `@artifact-keeper/sdk@1.6.0` client was
+// inspected for a dedicated audit-export operation. It exposes only
+// `listAuditLogs` (GET /api/v1/admin/audit -> AuditLogListResponse); there is
+// NO export operation and no schema-version field on the audit types (the only
+// `event_schema_version` fields in the SDK belong to webhooks). Because the
+// export operation is genuinely absent, we build the export client-side by
+// paginating the existing list endpoint through the shared `apiFetch` wrapper
+// (same trust-boundary validation as `list`), then format CSV / JSON here.
+//
+// The JSON export is wrapped in a *versioned structured envelope* so downstream
+// SIEM pipelines can key off `schema_version` — mirroring the intent of backend
+// #2413's versioned structured schema. Bump this when the envelope shape
+// changes in a non-additive way.
+export const AUDIT_EXPORT_SCHEMA_VERSION = "1.0";
+
+/** Safety cap on the number of rows a single client-side export will pull. */
+export const AUDIT_EXPORT_MAX_ROWS = 50_000;
+
+export const AUDIT_EXPORT_CSV_MIME = "text/csv;charset=utf-8";
+export const AUDIT_EXPORT_JSON_MIME = "application/json;charset=utf-8";
+
+export type AuditExportFormat = "csv" | "json";
+
+/**
+ * Column order for the flat CSV / structured JSON export. Kept explicit (rather
+ * than derived from an item) so the schema is stable and reviewable, and so a
+ * new optional field on `AuditLogItem` doesn't silently change the output.
+ */
+export const AUDIT_EXPORT_COLUMNS = [
+  "id",
+  "created_at",
+  "action",
+  "resource_type",
+  "resource_id",
+  "user_id",
+  "actor_username",
+  "ip_address",
+  "correlation_id",
+  "details",
+] as const;
+
+export interface AuditExportResult {
+  /** Rows collected (bounded by `maxRows`). */
+  items: AuditLogItem[];
+  /** Total rows matching the filters server-side (may exceed `items.length`). */
+  total: number;
+  /** True when the export was capped before pulling every matching row. */
+  truncated: boolean;
+}
+
+export interface AuditExportOptions {
+  /** Override the row cap (defaults to `AUDIT_EXPORT_MAX_ROWS`). */
+  maxRows?: number;
+}
+
+export interface AuditExportMeta {
+  /** Active filters, echoed into the JSON envelope for provenance. */
+  filters?: AuditLogQuery;
+  /** Server-side total matching the filters. */
+  total?: number;
+  /** Whether the export was capped. */
+  truncated?: boolean;
+  /** Override the export timestamp (primarily for tests). */
+  exportedAt?: string;
+}
+
+export interface AuditExportEnvelope {
+  schema_version: string;
+  exported_at: string;
+  filters: Record<string, unknown>;
+  count: number;
+  total: number;
+  truncated: boolean;
+  items: AuditLogItem[];
+}
+
+function serializeDetails(details: unknown): string {
+  if (details == null) return "";
+  return typeof details === "string" ? details : JSON.stringify(details);
+}
+
+/**
+ * Render a single CSV cell (RFC 4180). Two defensive steps, in order:
+ *  1. Neutralize spreadsheet formula injection (CWE-1236): a cell that a tool
+ *     like Excel would evaluate as a formula (leading `= + - @`, tab or CR) is
+ *     prefixed with a single quote. Audit `action`/`details` can carry
+ *     attacker-influenced strings, and this export is meant for analyst tools.
+ *  2. Quote-and-escape if the value contains a comma, quote, CR or LF.
+ */
+export function auditCsvCell(value: unknown): string {
+  let s = value == null ? "" : String(value);
+  if (/^[=+\-@\t\r]/.test(s)) s = `'${s}`;
+  if (/[",\r\n]/.test(s)) s = `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+/** Build the flat CSV document (header + one row per event, CRLF-terminated). */
+export function auditItemsToCsv(items: AuditLogItem[]): string {
+  const header = AUDIT_EXPORT_COLUMNS.join(",");
+  const rows = items.map((item) =>
+    AUDIT_EXPORT_COLUMNS.map((col) =>
+      col === "details"
+        ? auditCsvCell(serializeDetails(item.details))
+        : auditCsvCell((item as Record<string, unknown>)[col])
+    ).join(",")
+  );
+  // Trailing CRLF so the file ends on a record boundary; empty result still
+  // yields a valid header-only document.
+  return [header, ...rows].join("\r\n") + "\r\n";
+}
+
+/** Strip empty/paging fields so the envelope records only the active filters. */
+function normalizeExportFilters(query: AuditLogQuery): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (query.user_id?.trim()) out.user_id = query.user_id.trim();
+  if (query.action?.trim()) out.action = query.action.trim();
+  if (query.resource_type?.trim()) out.resource_type = query.resource_type.trim();
+  if (query.resource_id?.trim()) out.resource_id = query.resource_id.trim();
+  if (query.from) out.from = query.from;
+  if (query.to) out.to = query.to;
+  return out;
+}
+
+/** Build the versioned structured JSON envelope (#2413-style schema_version). */
+export function buildAuditExportEnvelope(
+  items: AuditLogItem[],
+  meta: AuditExportMeta = {}
+): AuditExportEnvelope {
+  return {
+    schema_version: AUDIT_EXPORT_SCHEMA_VERSION,
+    exported_at: meta.exportedAt ?? new Date().toISOString(),
+    filters: normalizeExportFilters(meta.filters ?? {}),
+    count: items.length,
+    total: meta.total ?? items.length,
+    truncated: meta.truncated ?? false,
+    items,
+  };
+}
+
+/** Serialize the versioned JSON export document. */
+export function auditItemsToJson(
+  items: AuditLogItem[],
+  meta: AuditExportMeta = {}
+): string {
+  return JSON.stringify(buildAuditExportEnvelope(items, meta), null, 2);
+}
+
+/** Timestamped, filesystem-safe download filename, e.g. `audit-log-...-.csv`. */
+export function buildAuditExportFilename(
+  format: AuditExportFormat,
+  now: Date = new Date()
+): string {
+  const ts = now.toISOString().replace(/[:.]/g, "-");
+  return `audit-log-${ts}.${format}`;
+}
+
 export const auditApi = {
   list: async (query: AuditLogQuery = {}): Promise<AuditLogListResponse> => {
     const data = await apiFetch<unknown>(
@@ -140,6 +300,55 @@ export const auditApi = {
       { method: "GET" }
     );
     return parseAuditLogList(data);
+  },
+
+  /**
+   * Collect every audit event matching `query` for export, honoring the same
+   * filters as `list` but ignoring caller-supplied paging — it walks pages at
+   * the backend max page size until it has every matching row or hits the
+   * `maxRows` safety cap (large-export guard). Returns the rows plus the
+   * server-side total and whether the result was truncated.
+   */
+  export: async (
+    query: AuditLogQuery = {},
+    options: AuditExportOptions = {}
+  ): Promise<AuditExportResult> => {
+    const maxRows = Math.max(1, options.maxRows ?? AUDIT_EXPORT_MAX_ROWS);
+    // Drop caller paging; we drive pagination ourselves.
+    const filters: AuditLogQuery = { ...query };
+    delete filters.page;
+    delete filters.per_page;
+
+    const items: AuditLogItem[] = [];
+    let total = 0;
+    let page = 1;
+
+    for (;;) {
+      const res = await auditApi.list({
+        ...filters,
+        page,
+        per_page: AUDIT_MAX_PER_PAGE,
+      });
+      total = res.total;
+
+      for (const item of res.items) {
+        if (items.length >= maxRows) break;
+        items.push(item);
+      }
+
+      const drainedPage = res.items.length < AUDIT_MAX_PER_PAGE;
+      if (
+        drainedPage ||
+        res.items.length === 0 ||
+        items.length >= maxRows ||
+        items.length >= total
+      ) {
+        break;
+      }
+      page += 1;
+    }
+
+    return { items, total, truncated: items.length < total };
   },
 };
 

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -1,0 +1,30 @@
+/**
+ * Trigger a client-side file download of in-memory text content.
+ *
+ * Wraps the content in a Blob, creates a temporary object URL, and clicks a
+ * transient `<a download>` element. The object URL is revoked on the next tick
+ * so the browser has a chance to start the download before the URL is released.
+ *
+ * Browser-only (touches `document` / `URL`); call from event handlers, not
+ * during render.
+ */
+export function triggerBrowserDownload(
+  filename: string,
+  content: string,
+  mimeType: string
+): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  try {
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = filename;
+    anchor.rel = "noopener";
+    anchor.style.display = "none";
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+  } finally {
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+  }
+}


### PR DESCRIPTION
## Summary

Adds an **Export** action to the admin audit-log page (`/audit`) so operators can pull the audit trail into SIEM pipelines. The export honors the currently-active filters (action / resource type / user / date range) and is offered in two formats, triggered as a client-side file download:

- **CSV** — flat, RFC 4180, one row per event, stable column order.
- **JSON** — a *versioned structured envelope* (`schema_version`, `exported_at`, echoed `filters`, `count`, `total`, `truncated`, `items`) mirroring the intent of backend #2413's versioned schema.

## SDK operation used

The generated `@artifact-keeper/sdk@1.6.0` client was inspected for a dedicated audit-export operation: it exposes only `listAuditLogs` (`GET /api/v1/admin/audit` → `AuditLogListResponse`), and the only `event_schema_version` fields belong to webhooks, not audit. Since an export operation is **genuinely absent** from the SDK, `auditApi.export()` builds the export client-side by paginating the existing list endpoint through the shared `apiFetch` wrapper (same trust-boundary zod validation as `auditApi.list()`), then formats CSV / JSON locally. This is documented inline so it can be swapped for a real SDK export operation once one ships.

## What changed

- `src/lib/api/audit.ts`
  - `auditApi.export(query, { maxRows })` — paginates at the backend max page size, collecting every matching row up to a safety cap (`AUDIT_EXPORT_MAX_ROWS = 50000`), returning `{ items, total, truncated }`. Ignores caller paging; honors all filters.
  - Pure builders: `auditItemsToCsv` (with a spreadsheet formula-injection guard, CWE-1236, since audit `action`/`details` can be attacker-influenced and the file targets analyst tools), `auditItemsToJson` / `buildAuditExportEnvelope`, `buildAuditExportFilename`, plus format/MIME/schema-version constants.
- `src/lib/download.ts` — `triggerBrowserDownload()` helper (Blob + transient `<a download>`, object URL revoked on next tick).
- `src/app/(app)/(admin)/audit/page.tsx` — Export dropdown (CSV / JSON) in the page header, sharing one `appliedQuery` with the list query so both honor identical filters. Disabled on empty result sets; toast feedback for success / empty / truncated-large-export / error.

## Empty & large exports

- **Empty:** the control is disabled when the current filters match zero events, and the handler also short-circuits with an info toast if a fetch returns nothing.
- **Large:** pagination is capped at 50k rows; when the match set exceeds the cap the file still downloads and a warning toast tells the operator to narrow filters to export the rest (`truncated` is also recorded in the JSON envelope).

## Verification (as CI runs it)

- `npm install` — clean
- `npm run lint` — 0 errors
- `npm run test:coverage` — all tests pass; overall statements **87.06%**, branches **81.54%**, functions **82.36%**, lines **87.77%** (all >80%). Added tests cover the export builders, filter passthrough + pagination/cap, the download helper, and the page export UI.
- `npm run build` — succeeds

Closes #603
Refs #599