### PR TITLE
feat(security): accessible-not-downloaded latent exposure on blast radius

### DIFF
--- a/src/app/(app)/(admin)/security/blast-radius/__tests__/page.test.tsx
+++ b/src/app/(app)/(admin)/security/blast-radius/__tests__/page.test.tsx
@@ -26,6 +26,7 @@ vi.mock("lucide-react", () => {
     Lock: stub("Lock"),
     Network: stub("Network"),
     RefreshCw: stub("RefreshCw"),
+    ShieldAlert: stub("ShieldAlert"),
     Users: stub("Users"),
   };
 });
@@ -36,6 +37,8 @@ const {
   mockInvalidateQueries,
   mockForCve,
   mockForArtifact,
+  mockAccForCve,
+  mockAccForArtifact,
   searchParamsState,
   tabsState,
 } = vi.hoisted(() => ({
@@ -44,6 +47,8 @@ const {
   mockInvalidateQueries: vi.fn(),
   mockForCve: vi.fn(),
   mockForArtifact: vi.fn(),
+  mockAccForCve: vi.fn(),
+  mockAccForArtifact: vi.fn(),
   searchParamsState: { value: "" },
   tabsState: { onValueChange: undefined as ((v: string) => void) | undefined },
 }));
@@ -71,6 +76,10 @@ vi.mock("@/lib/api/blast-radius", async (importOriginal) => {
     blastRadiusApi: {
       forCve: (...args: any[]) => mockForCve(...args),
       forArtifact: (...args: any[]) => mockForArtifact(...args),
+    },
+    accessibleUsersApi: {
+      forCve: (...args: any[]) => mockAccForCve(...args),
+      forArtifact: (...args: any[]) => mockAccForArtifact(...args),
     },
   };
 });
@@ -121,6 +130,23 @@ vi.mock("@/components/ui/tabs", () => ({
   TabsList: ({ children }: any) => <div>{children}</div>,
   TabsTrigger: ({ children, value }: any) => (
     <button onClick={() => tabsState.onValueChange?.(value)}>{children}</button>
+  ),
+}));
+
+// Minimal Select stand-in: exposes the current value and a button that fires
+// onValueChange with a fixed repo id so tests can switch the scoped repository.
+vi.mock("@/components/ui/select", () => ({
+  Select: ({ children, value, onValueChange }: any) => (
+    <div data-testid="repo-select" data-value={value ?? ""}>
+      <button onClick={() => onValueChange?.("r2")}>select-r2</button>
+      {children}
+    </div>
+  ),
+  SelectTrigger: ({ children }: any) => <div>{children}</div>,
+  SelectValue: ({ placeholder }: any) => <span>{placeholder}</span>,
+  SelectContent: ({ children }: any) => <div>{children}</div>,
+  SelectItem: ({ children, value }: any) => (
+    <div data-value={value}>{children}</div>
   ),
 }));
 
@@ -179,7 +205,12 @@ vi.mock("@/components/common/data-table", () => ({
   },
 }));
 
-import BlastRadiusPage, { AccessScopeBadge, ipPreview } from "../page";
+import BlastRadiusPage, {
+  AccessScopeBadge,
+  ExposureBadge,
+  ViaBadge,
+  ipPreview,
+} from "../page";
 
 // ---------------------------------------------------------------------------
 // Fixtures / helpers
@@ -253,6 +284,23 @@ const REPORT = {
   per_page: 20,
 };
 
+const ACCESSIBLE_REPORT = {
+  target: { kind: "cve", value: "CVE-2021-44228" },
+  repository: {
+    repository_id: "r1",
+    repository_key: "public-npm",
+    access_scope: "restricted_acl",
+  },
+  exposure: "enumerable",
+  accessible_not_downloaded: [
+    { reason: "has-access", user_id: "u1", username: "carol", via: "permission" },
+    { reason: "has-access", user_id: "u2", username: "dave", via: "role" },
+  ],
+  total: 2,
+  page: 1,
+  per_page: 20,
+};
+
 const IDLE = {
   data: undefined,
   isLoading: false,
@@ -260,10 +308,16 @@ const IDLE = {
   isFetching: false,
 };
 
-function queryState(state: Partial<typeof IDLE> & { data?: unknown } = {}) {
+function queryState(
+  state: Partial<typeof IDLE> & { data?: unknown } = {},
+  accessibleState: Partial<typeof IDLE> & { data?: unknown } = {}
+) {
   mockUseQuery.mockImplementation((opts: any) => {
     if (opts.queryKey?.[0] === "admin-blast-radius") {
       return { ...IDLE, ...state };
+    }
+    if (opts.queryKey?.[0] === "admin-accessible-users") {
+      return { ...IDLE, ...accessibleState };
     }
     throw new Error(`Unexpected query key: ${JSON.stringify(opts.queryKey)}`);
   });
@@ -273,6 +327,13 @@ function lastQueryOpts() {
   return mockUseQuery.mock.calls
     .map(([o]) => o)
     .filter((o) => o.queryKey?.[0] === "admin-blast-radius")
+    .at(-1);
+}
+
+function lastAccessibleOpts() {
+  return mockUseQuery.mock.calls
+    .map(([o]) => o)
+    .filter((o) => o.queryKey?.[0] === "admin-accessible-users")
     .at(-1);
 }
 
@@ -472,8 +533,9 @@ describe("BlastRadiusPage", () => {
     ).toBeInTheDocument();
 
     // Affected repos: the public repo is loudly flagged, the private scopes
-    // get their own labels.
-    expect(screen.getByText("public-npm")).toBeInTheDocument();
+    // get their own labels. (The repo key also appears in the latent-exposure
+    // repository selector, so there may be more than one match.)
+    expect(screen.getAllByText("public-npm").length).toBeGreaterThan(0);
     expect(
       screen.getByText(/public — everyone exposed/i)
     ).toBeInTheDocument();
@@ -545,12 +607,167 @@ describe("BlastRadiusPage", () => {
       screen.queryByText(/anonymous downloads present/i)
     ).not.toBeInTheDocument();
   });
+
+  it("renders the latent-exposure section, separated from confirmed downloaders", () => {
+    searchParamsState.value = "cve=CVE-2021-44228";
+    queryState({ data: REPORT }, { data: ACCESSIBLE_REPORT });
+
+    render(<BlastRadiusPage />);
+
+    // The section and its copy make the latent-vs-confirmed distinction clear.
+    expect(
+      screen.getByRole("heading", { name: /accessible, not downloaded/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/latent exposure/i)).toBeInTheDocument();
+    expect(screen.getByText(/potential/i)).toBeInTheDocument();
+    // The confirmed downloaders view is still intact alongside it.
+    expect(screen.getByText("jane")).toBeInTheDocument();
+
+    // Accessible-but-not-downloaded users render with their access path.
+    expect(screen.getByText("carol")).toBeInTheDocument();
+    expect(screen.getByText("dave")).toBeInTheDocument();
+    expect(screen.getByText(/permission grant/i)).toBeInTheDocument();
+    expect(screen.getByText(/role assignment/i)).toBeInTheDocument();
+    expect(screen.getByText(/enumerable set/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 with latent access/i)).toBeInTheDocument();
+  });
+
+  it("scopes the CVE accessible-users query to the first affected repo, switchable", async () => {
+    searchParamsState.value = "cve=CVE-2021-44228";
+    queryState({ data: REPORT }, { data: ACCESSIBLE_REPORT });
+    mockAccForCve.mockResolvedValue(ACCESSIBLE_REPORT);
+
+    render(<BlastRadiusPage />);
+
+    let opts = lastAccessibleOpts();
+    expect(opts.enabled).toBe(true);
+    await opts.queryFn();
+    // Defaults to the first affected repository (r1).
+    expect(mockAccForCve).toHaveBeenCalledWith("CVE-2021-44228", {
+      repository_id: "r1",
+      page: 1,
+      per_page: 20,
+    });
+
+    // Switching the repository selector re-scopes the enumeration to r2.
+    mockAccForCve.mockClear();
+    fireEvent.click(screen.getByRole("button", { name: "select-r2" }));
+    opts = lastAccessibleOpts();
+    await opts.queryFn();
+    expect(mockAccForCve).toHaveBeenCalledWith("CVE-2021-44228", {
+      repository_id: "r2",
+      page: 1,
+      per_page: 20,
+    });
+  });
+
+  it("runs the artifact accessible-users query without a repository_id", async () => {
+    searchParamsState.value = `artifact=${ARTIFACT_ID}`;
+    queryState(
+      { data: { ...REPORT, target: { kind: "artifact", value: ARTIFACT_ID } } },
+      {
+        data: {
+          ...ACCESSIBLE_REPORT,
+          target: { kind: "artifact", value: ARTIFACT_ID },
+        },
+      }
+    );
+    mockAccForArtifact.mockResolvedValue(ACCESSIBLE_REPORT);
+
+    render(<BlastRadiusPage />);
+
+    const opts = lastAccessibleOpts();
+    expect(opts.enabled).toBe(true);
+    await opts.queryFn();
+    expect(mockAccForArtifact).toHaveBeenCalledWith(ARTIFACT_ID, {
+      page: 1,
+      per_page: 20,
+    });
+    // No repository selector in artifact mode (the artifact implies the repo).
+    expect(
+      screen.queryByRole("button", { name: "select-r2" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the everyone banner for a public repo instead of a user list", () => {
+    searchParamsState.value = "cve=CVE-2021-44228";
+    queryState(
+      { data: REPORT },
+      {
+        data: {
+          ...ACCESSIBLE_REPORT,
+          repository: {
+            ...ACCESSIBLE_REPORT.repository,
+            access_scope: "public",
+          },
+          exposure: "everyone",
+          accessible_not_downloaded: [],
+          total: null,
+        },
+      }
+    );
+
+    render(<BlastRadiusPage />);
+
+    expect(
+      screen.getByText(/public repository — everyone can access/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText("carol")).not.toBeInTheDocument();
+  });
+
+  it("shows a latent-exposure error without hiding the downloaders view", () => {
+    searchParamsState.value = "cve=CVE-2021-44228";
+    queryState({ data: REPORT }, { isError: true });
+
+    render(<BlastRadiusPage />);
+
+    expect(screen.getByText(/latent exposure unavailable/i)).toBeInTheDocument();
+    // The confirmed-downloaders view still renders.
+    expect(screen.getByText("jane")).toBeInTheDocument();
+  });
 });
 
 describe("AccessScopeBadge", () => {
   it("degrades unknown scopes to a neutral badge with the raw value", () => {
     render(<AccessScopeBadge scope="quarantined" />);
     expect(screen.getByText("quarantined")).toBeInTheDocument();
+  });
+});
+
+describe("ExposureBadge", () => {
+  it("loudly flags a public 'everyone' exposure", () => {
+    render(<ExposureBadge exposure="everyone" />);
+    expect(
+      screen.getByText(/everyone — public repository/i)
+    ).toBeInTheDocument();
+  });
+
+  it("labels the enumerable and effectively-everyone cases", () => {
+    const { rerender } = render(<ExposureBadge exposure="enumerable" />);
+    expect(screen.getByText(/enumerable set/i)).toBeInTheDocument();
+    rerender(<ExposureBadge exposure="effectively-everyone" />);
+    expect(screen.getByText(/effectively everyone/i)).toBeInTheDocument();
+  });
+
+  it("degrades an unknown exposure to a neutral badge with the raw value", () => {
+    render(<ExposureBadge exposure="quantum" />);
+    expect(screen.getByText("quantum")).toBeInTheDocument();
+  });
+});
+
+describe("ViaBadge", () => {
+  it("maps known access paths to friendly labels", () => {
+    const { rerender } = render(<ViaBadge via="admin" />);
+    expect(screen.getByText("Administrator")).toBeInTheDocument();
+    rerender(<ViaBadge via="permission" />);
+    expect(screen.getByText("Permission grant")).toBeInTheDocument();
+    rerender(<ViaBadge via="role" />);
+    expect(screen.getByText("Role assignment")).toBeInTheDocument();
+  });
+
+  it("falls back to the raw value for an unknown access path", () => {
+    render(<ViaBadge via="mystery" />);
+    expect(screen.getByText("mystery")).toBeInTheDocument();
   });
 });
 

--- a/src/app/(app)/(admin)/security/blast-radius/page.tsx
+++ b/src/app/(app)/(admin)/security/blast-radius/page.tsx
@@ -15,16 +15,19 @@ import {
   Lock,
   Network,
   RefreshCw,
+  ShieldAlert,
   Users,
 } from "lucide-react";
 
 import {
   blastRadiusApi,
+  accessibleUsersApi,
   isValidVulnId,
   normalizeVulnId,
   BLAST_RADIUS_DEFAULT_PER_PAGE,
   type AffectedRepo,
   type BlastRadiusDownloader,
+  type AccessibleUser,
 } from "@/lib/api/blast-radius";
 import { isValidUuid } from "@/lib/api/audit";
 
@@ -36,9 +39,17 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 export const BLAST_RADIUS_QUERY_KEY = ["admin-blast-radius"] as const;
+export const ACCESSIBLE_USERS_QUERY_KEY = ["admin-accessible-users"] as const;
 
 type TargetKind = "cve" | "artifact";
 
@@ -89,6 +100,62 @@ export function AccessScopeBadge({ scope }: { scope: string }) {
   }
   // A scope this UI doesn't know yet degrades to a neutral badge.
   return <Badge variant="secondary">{scope}</Badge>;
+}
+
+/**
+ * Badge for the coarse breadth of latent access (1.6.0, #2386). `everyone` is
+ * the loud one — a public repo where every principal (and anonymous clients)
+ * can reach the artifact, so per-user enumeration is not applicable.
+ */
+export function ExposureBadge({ exposure }: { exposure: string }) {
+  if (exposure === "everyone") {
+    return (
+      <Badge
+        variant="outline"
+        className="border-red-200 bg-red-100 font-semibold text-red-700 dark:border-red-800 dark:bg-red-900/30 dark:text-red-400"
+      >
+        <Globe className="mr-1 size-3" />
+        Everyone — public repository
+      </Badge>
+    );
+  }
+  if (exposure === "effectively-everyone") {
+    return (
+      <Badge
+        variant="outline"
+        className="border-amber-200 bg-amber-100 text-amber-700 dark:border-amber-800 dark:bg-amber-900/30 dark:text-amber-400"
+      >
+        <AlertTriangle className="mr-1 size-3" />
+        Effectively everyone
+      </Badge>
+    );
+  }
+  if (exposure === "enumerable") {
+    return (
+      <Badge variant="secondary">
+        <Users className="mr-1 size-3" />
+        Enumerable set
+      </Badge>
+    );
+  }
+  // A future exposure classification degrades to a neutral badge.
+  return <Badge variant="secondary">{exposure}</Badge>;
+}
+
+/**
+ * Badge describing how a principal is granted access: `admin` (global),
+ * `permission` (direct or group grant), or `role` (role assignment).
+ */
+export function ViaBadge({ via }: { via: string }) {
+  const label =
+    via === "admin"
+      ? "Administrator"
+      : via === "permission"
+        ? "Permission grant"
+        : via === "role"
+          ? "Role assignment"
+          : via;
+  return <Badge variant="secondary">{label}</Badge>;
 }
 
 /** Compact preview of a downloader's IP sample: first few, then "+n more". */
@@ -142,6 +209,13 @@ function BlastRadiusContent() {
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(BLAST_RADIUS_DEFAULT_PER_PAGE);
 
+  // Latent-exposure (accessible-but-not-downloaded) pagination + repository
+  // scope. A CVE spans many repos, so the accessible-users enumeration is
+  // scoped to one repository chosen from the report's affected list.
+  const [selectedRepoId, setSelectedRepoId] = useState<string | null>(null);
+  const [accPage, setAccPage] = useState(1);
+  const [accPageSize, setAccPageSize] = useState(BLAST_RADIUS_DEFAULT_PER_PAGE);
+
   const { data, isLoading, isError, isFetching } = useQuery({
     queryKey: [...BLAST_RADIUS_QUERY_KEY, applied, page, pageSize],
     queryFn: () =>
@@ -152,6 +226,47 @@ function BlastRadiusContent() {
             per_page: pageSize,
           }),
     enabled: !!user?.is_admin && applied != null,
+    retry: false,
+    placeholderData: (prev) => prev,
+  });
+
+  // The affected repositories drive the CVE-mode repository scope selector.
+  const affectedRepos = data?.affected_repos ?? [];
+  // Artifact mode implies its repository (repository_id ignored server-side);
+  // CVE mode defaults to the first affected repo until the admin picks another.
+  const effectiveRepoId =
+    applied?.kind === "artifact"
+      ? null
+      : (selectedRepoId ?? affectedRepos[0]?.repository_id ?? null);
+
+  const {
+    data: accessibleData,
+    isLoading: accessibleLoading,
+    isError: accessibleError,
+    isFetching: accessibleFetching,
+  } = useQuery({
+    queryKey: [
+      ...ACCESSIBLE_USERS_QUERY_KEY,
+      applied,
+      effectiveRepoId,
+      accPage,
+      accPageSize,
+    ],
+    queryFn: () =>
+      applied!.kind === "cve"
+        ? accessibleUsersApi.forCve(applied!.value, {
+            repository_id: effectiveRepoId!,
+            page: accPage,
+            per_page: accPageSize,
+          })
+        : accessibleUsersApi.forArtifact(applied!.value, {
+            page: accPage,
+            per_page: accPageSize,
+          }),
+    enabled:
+      !!user?.is_admin &&
+      applied != null &&
+      (applied?.kind === "artifact" || !!effectiveRepoId),
     retry: false,
     placeholderData: (prev) => prev,
   });
@@ -176,6 +291,9 @@ function BlastRadiusContent() {
       setApplied({ kind: "artifact", value });
     }
     setPage(1);
+    // New target: reset the latent-exposure scope + pagination.
+    setSelectedRepoId(null);
+    setAccPage(1);
   }
 
   function switchMode(next: TargetKind) {
@@ -287,6 +405,29 @@ function BlastRadiusContent() {
     },
   ];
 
+  const accessibleColumns: DataTableColumn<AccessibleUser>[] = [
+    {
+      id: "user",
+      header: "User",
+      accessor: (u) => u.username,
+      cell: (u) => (
+        <span title={u.user_id}>
+          {u.username || (
+            <span className="font-mono text-xs">{truncateId(u.user_id)}</span>
+          )}
+        </span>
+      ),
+      sortable: true,
+    },
+    {
+      id: "via",
+      header: "Access via",
+      accessor: (u) => u.via,
+      cell: (u) => <ViaBadge via={u.via} />,
+      sortable: true,
+    },
+  ];
+
   if (!user?.is_admin) {
     return (
       <div className="space-y-6">
@@ -313,14 +454,19 @@ function BlastRadiusContent() {
               variant="outline"
               size="icon-sm"
               aria-label="Refresh blast radius"
-              onClick={() =>
+              onClick={() => {
                 queryClient.invalidateQueries({
                   queryKey: BLAST_RADIUS_QUERY_KEY,
-                })
-              }
+                });
+                queryClient.invalidateQueries({
+                  queryKey: ACCESSIBLE_USERS_QUERY_KEY,
+                });
+              }}
             >
               <RefreshCw
-                className={`size-4 ${isFetching ? "animate-spin" : ""}`}
+                className={`size-4 ${
+                  isFetching || accessibleFetching ? "animate-spin" : ""
+                }`}
               />
             </Button>
           </div>
@@ -491,6 +637,129 @@ function BlastRadiusContent() {
               emptyMessage="No downloads of affected artifacts recorded."
               rowKey={(d) => d.user_id ?? "anonymous"}
             />
+          </section>
+
+          {/* Latent exposure: accessible but not downloaded (1.6.0, #2386).
+              Visually separated and tinted so it reads as *potential* reach,
+              distinct from the confirmed downloaders above. */}
+          <section
+            className="space-y-3 rounded-lg border border-amber-200 bg-amber-50/50 p-4 dark:border-amber-900/40 dark:bg-amber-950/20"
+            aria-label="Accessible but not downloaded"
+          >
+            <div className="space-y-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <ShieldAlert className="size-5 text-amber-600 dark:text-amber-400" />
+                <h2 className="text-lg font-semibold tracking-tight">
+                  Accessible, not downloaded
+                </h2>
+                <Badge
+                  variant="outline"
+                  className="border-amber-300 bg-amber-100 text-amber-800 dark:border-amber-800 dark:bg-amber-900/30 dark:text-amber-300"
+                >
+                  Latent exposure
+                </Badge>
+              </div>
+              <p className="max-w-3xl text-sm text-muted-foreground">
+                Users who <strong>could</strong> read an affected artifact but
+                have <strong>not</strong> downloaded it. This is{" "}
+                <strong>potential</strong> reach, not confirmed exposure — the
+                downloaders above are who actually pulled the artifact.
+              </p>
+            </div>
+
+            {/* A CVE spans many repositories; scope the enumeration to one. */}
+            {applied.kind === "cve" && affectedRepos.length > 0 && (
+              <div className="flex flex-wrap items-center gap-2">
+                <Label htmlFor="accessible-repo" className="text-sm">
+                  Repository
+                </Label>
+                <Select
+                  value={effectiveRepoId ?? undefined}
+                  onValueChange={(v) => {
+                    setSelectedRepoId(v);
+                    setAccPage(1);
+                  }}
+                >
+                  <SelectTrigger id="accessible-repo" className="w-[280px]">
+                    <SelectValue placeholder="Select a repository" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {affectedRepos.map((r) => (
+                      <SelectItem key={r.repository_id} value={r.repository_id}>
+                        {r.repository_key}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            {accessibleError ? (
+              <Alert variant="destructive">
+                <AlertTitle>Latent exposure unavailable</AlertTitle>
+                <AlertDescription>
+                  Unable to load the accessible-but-not-downloaded report. This
+                  server may not support the accessible-users endpoint yet, or
+                  the request failed.
+                </AlertDescription>
+              </Alert>
+            ) : accessibleLoading || !accessibleData ? (
+              <div className="flex h-24 items-center justify-center">
+                <Loader2 className="size-5 animate-spin text-muted-foreground" />
+              </div>
+            ) : (
+              <>
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-sm text-muted-foreground">
+                    Exposure
+                  </span>
+                  <ExposureBadge exposure={accessibleData.exposure} />
+                  <Badge variant="outline" className="font-mono">
+                    {accessibleData.repository.repository_key}
+                  </Badge>
+                  {accessibleData.total != null && (
+                    <span className="text-sm text-muted-foreground">
+                      {accessibleData.total} with latent access
+                    </span>
+                  )}
+                </div>
+
+                {accessibleData.exposure === "enumerable" ? (
+                  <DataTable
+                    columns={accessibleColumns}
+                    data={accessibleData.accessible_not_downloaded}
+                    total={
+                      accessibleData.total ??
+                      accessibleData.accessible_not_downloaded.length
+                    }
+                    page={accPage}
+                    pageSize={accPageSize}
+                    onPageChange={setAccPage}
+                    onPageSizeChange={(s) => {
+                      setAccPageSize(s);
+                      setAccPage(1);
+                    }}
+                    pageSizeOptions={[20, 50, 100]}
+                    loading={false}
+                    emptyMessage="No users have latent access without a recorded download."
+                    rowKey={(u) => u.user_id}
+                  />
+                ) : (
+                  <Alert>
+                    <AlertTitle>
+                      {accessibleData.exposure === "everyone"
+                        ? "Public repository — everyone can access"
+                        : "Access is too broad to enumerate"}
+                    </AlertTitle>
+                    <AlertDescription>
+                      {accessibleData.exposure === "everyone"
+                        ? "This artifact lives in an anonymous-readable repository, so every user (and unauthenticated clients) can reach it. A per-user list is not applicable."
+                        : "So many principals can reach this artifact that a per-user list is not meaningful. Tighten the repository's access scope to narrow the latent blast radius."}
+                    </AlertDescription>
+                  </Alert>
+                )}
+              </>
+            )}
           </section>
         </>
       )}

--- a/src/lib/api/__tests__/blast-radius.test.ts
+++ b/src/lib/api/__tests__/blast-radius.test.ts
@@ -165,3 +165,131 @@ describe("blastRadiusApi", () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Accessible-but-not-downloaded (latent exposure) — 1.6.0 dimension (#2386)
+// ---------------------------------------------------------------------------
+
+const ACCESSIBLE_USER = {
+  reason: "has-access",
+  user_id: "0e8b23a5-1111-4f2b-9f7d-1c2d3e4f5a6b",
+  username: "carol",
+  via: "permission",
+};
+
+const ACCESSIBLE_RESPONSE = {
+  target: { kind: "cve", value: "CVE-2021-44228" },
+  repository: {
+    repository_id: "1f7a12b4-2222-4f2b-9f7d-1c2d3e4f5a6b",
+    repository_key: "libs-release",
+    access_scope: "restricted_acl",
+  },
+  exposure: "enumerable",
+  accessible_not_downloaded: [ACCESSIBLE_USER],
+  total: 5,
+  page: 1,
+  per_page: 20,
+};
+
+describe("accessibleUsersApi", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("parses an accessible-users response and scopes the CVE route to a repo", async () => {
+    mockApiFetch.mockResolvedValue(ACCESSIBLE_RESPONSE);
+    const mod = await import("../blast-radius");
+    const res = await mod.accessibleUsersApi.forCve("CVE-2021-44228", {
+      repository_id: "1f7a12b4-2222-4f2b-9f7d-1c2d3e4f5a6b",
+      page: 1,
+      per_page: 20,
+    });
+    expect(res.exposure).toBe("enumerable");
+    expect(res.repository.repository_key).toBe("libs-release");
+    expect(res.accessible_not_downloaded[0].username).toBe("carol");
+    expect(res.accessible_not_downloaded[0].via).toBe("permission");
+    expect(res.accessible_not_downloaded[0].reason).toBe("has-access");
+    expect(res.total).toBe(5);
+
+    const url = mockApiFetch.mock.calls[0][0] as string;
+    expect(
+      url.startsWith(
+        "/api/v1/admin/security/cve/CVE-2021-44228/accessible-users?"
+      )
+    ).toBe(true);
+    const qs = new URLSearchParams(url.split("?")[1]);
+    expect(qs.get("repository_id")).toBe(
+      "1f7a12b4-2222-4f2b-9f7d-1c2d3e4f5a6b"
+    );
+    expect(qs.get("page")).toBe("1");
+    expect(qs.get("per_page")).toBe("20");
+  });
+
+  it("routes artifact targets through the artifact accessible-users endpoint", async () => {
+    mockApiFetch.mockResolvedValue({
+      ...ACCESSIBLE_RESPONSE,
+      target: { kind: "artifact", value: ACCESSIBLE_RESPONSE.repository.repository_id },
+    });
+    const mod = await import("../blast-radius");
+    await mod.accessibleUsersApi.forArtifact(
+      ` ${ACCESSIBLE_RESPONSE.repository.repository_id} `,
+      { page: 2, per_page: 50 }
+    );
+    const url = mockApiFetch.mock.calls[0][0] as string;
+    expect(
+      url.startsWith(
+        `/api/v1/admin/security/artifact/${ACCESSIBLE_RESPONSE.repository.repository_id}/accessible-users?`
+      )
+    ).toBe(true);
+    const qs = new URLSearchParams(url.split("?")[1]);
+    expect(qs.get("page")).toBe("2");
+    expect(qs.get("per_page")).toBe("50");
+  });
+
+  it("normalizes a public/everyone response with a null total and empty list", async () => {
+    mockApiFetch.mockResolvedValue({
+      ...ACCESSIBLE_RESPONSE,
+      repository: {
+        ...ACCESSIBLE_RESPONSE.repository,
+        access_scope: "public",
+      },
+      exposure: "everyone",
+      accessible_not_downloaded: [],
+      total: null,
+    });
+    const mod = await import("../blast-radius");
+    const res = await mod.accessibleUsersApi.forCve("CVE-2021-44228", {
+      repository_id: "r1",
+    });
+    expect(res.exposure).toBe("everyone");
+    expect(res.accessible_not_downloaded).toEqual([]);
+    expect(res.total).toBeNull();
+  });
+
+  it("treats an omitted total as null", async () => {
+    const noTotal: Record<string, unknown> = { ...ACCESSIBLE_RESPONSE };
+    delete noTotal.total;
+    mockApiFetch.mockResolvedValue(noTotal);
+    const mod = await import("../blast-radius");
+    const res = await mod.accessibleUsersApi.forArtifact("art");
+    expect(res.total).toBeNull();
+  });
+
+  it("throws on an accessible-users response that does not match the shape", async () => {
+    mockApiFetch.mockResolvedValue({ users: [] });
+    const mod = await import("../blast-radius");
+    await expect(
+      mod.accessibleUsersApi.forCve("CVE-2021-44228", { repository_id: "r1" })
+    ).rejects.toThrow(/did not match the expected shape/);
+  });
+
+  it("omits empty params and clamps per_page in the accessible-users query string", async () => {
+    const mod = await import("../blast-radius");
+    expect(mod.buildAccessibleUsersQueryString({})).toBe("");
+    const qs = new URLSearchParams(
+      mod
+        .buildAccessibleUsersQueryString({ page: 0, per_page: 999 })
+        .slice(1)
+    );
+    expect(qs.get("page")).toBe("1");
+    expect(qs.get("per_page")).toBe(String(mod.BLAST_RADIUS_MAX_PER_PAGE));
+  });
+});

--- a/src/lib/api/blast-radius.ts
+++ b/src/lib/api/blast-radius.ts
@@ -7,6 +7,9 @@ import type {
   BlastRadiusTargetInfo,
   AffectedRepo,
   BlastDownloader,
+  AccessibleUsersResponse,
+  AccessibleUser,
+  RepoExposure,
 } from "@artifact-keeper/sdk";
 
 // Re-export the generated SDK types (regenerated from the OpenAPI spec),
@@ -18,6 +21,10 @@ export type {
   BlastRadiusResponse,
   BlastRadiusSummary,
   AffectedRepo,
+  // 1.6.0 disclosure dimension (backend #2386): accessible-but-not-downloaded.
+  AccessibleUsersResponse,
+  AccessibleUser,
+  RepoExposure,
 };
 export type BlastRadiusTarget = BlastRadiusTargetInfo;
 export type BlastRadiusDownloader = BlastDownloader;
@@ -30,18 +37,34 @@ export type BlastRadiusDownloader = BlastDownloader;
  * attribution seam (`download_statistics.user_id` / `ip_address`) and
  * answers "who is exposed": the principals that downloaded an affected
  * artifact plus a per-repository classification of how widely each affected
- * repository is reachable. Neither endpoint is in the generated SDK yet, so
- * we use the shared `apiFetch` wrapper and validate responses with zod at
- * the trust boundary (same pattern as audit and downloads).
+ * repository is reachable.
+ *
+ * The operations and response schemas ARE now in the generated
+ * `@artifact-keeper/sdk@1.6.0` (`cveBlastRadius` / `artifactBlastRadius` /
+ * `cveAccessibleUsers` / `artifactAccessibleUsers`), so we import the generated
+ * response *types* as the source of truth. We deliberately keep fetching through
+ * the shared `apiFetch` wrapper and validate every response with zod at the
+ * trust boundary — the same pattern the rest of this module (and audit /
+ * downloads) uses — rather than mixing in the generated client. This keeps one
+ * fetch/validation path for the whole feature and guarantees a backend that
+ * drifts from the spec surfaces as a clear parse error instead of an untyped
+ * runtime shape.
  *
  * Endpoints (under the admin-guarded router):
- *   GET /api/v1/admin/security/cve/{cve_id}/blast-radius           -> BlastRadiusResponse
- *   GET /api/v1/admin/security/artifact/{artifact_id}/blast-radius -> BlastRadiusResponse
+ *   GET /api/v1/admin/security/cve/{cve_id}/blast-radius            -> BlastRadiusResponse
+ *   GET /api/v1/admin/security/artifact/{artifact_id}/blast-radius  -> BlastRadiusResponse
+ *   GET /api/v1/admin/security/cve/{cve_id}/accessible-users        -> AccessibleUsersResponse (#2386)
+ *   GET /api/v1/admin/security/artifact/{artifact_id}/accessible-users -> AccessibleUsersResponse (#2386)
  *
- * Query params (shared): page / per_page (default 20, max 100) over the
+ * Query params (blast-radius): page / per_page (default 20, max 100) over the
  * collapsed downloaders list, optional from / to (inclusive RFC 3339 bounds
  * on downloaded_at). `affected_repos` is bounded to 200 rows server-side and
  * per-downloader IP samples are capped at 50 (counts stay exact).
+ *
+ * Query params (accessible-users): page / per_page (same bounds) over the
+ * accessible-not-downloaded list, plus `repository_id` which is REQUIRED for
+ * the CVE route (a CVE spans many repos so enumeration must be scoped to one)
+ * and ignored for the artifact route (the repo is implied by the artifact).
  */
 
 /**
@@ -154,6 +177,154 @@ export function parseBlastRadius(data: unknown): BlastRadiusResponse {
     per_page: parsed.data.per_page,
   };
 }
+
+// ---------------------------------------------------------------------------
+// Accessible-but-not-downloaded (latent exposure) — 1.6.0 dimension (#2386)
+// ---------------------------------------------------------------------------
+
+export interface AccessibleUsersQuery {
+  /**
+   * Repository to scope enumeration to. REQUIRED for the CVE route (a CVE
+   * spans many repos); ignored server-side for the artifact route.
+   */
+  repository_id?: string;
+  /** 1-based page index over the accessible-users list (default 1). */
+  page?: number;
+  /** Accessible-users page size (backend default 20, max 100). */
+  per_page?: number;
+}
+
+/**
+ * Coarse breadth of who can reach the affected artifact in this repository:
+ * `enumerable` (a bounded, listable set of principals — the only case where
+ * `accessible_not_downloaded` is populated), `everyone` (public / anonymous
+ * readable — not enumerated, `total` is null), or `effectively-everyone`
+ * (so broadly granted that per-user enumeration is not meaningful). Kept as a
+ * plain string so a future value degrades to a neutral badge.
+ */
+export type Exposure = string;
+
+// The accessible-users response validates against the generated SDK
+// `AccessibleUsersResponse` shape. RepoExposure carries the single restricted
+// repository the enumeration was scoped to; `total` is null for public repos.
+const RepoExposureSchema = z
+  .object({
+    repository_id: z.string(),
+    repository_key: z.string(),
+    access_scope: z.string(),
+  })
+  .passthrough();
+
+const AccessibleUserSchema = z
+  .object({
+    // `reason` is always "has-access" for this endpoint (accessible minus
+    // downloaded) but is validated rather than assumed.
+    reason: z.string(),
+    user_id: z.string(),
+    username: z.string(),
+    // How access is granted: `admin` | `permission` | `role`.
+    via: z.string(),
+  })
+  .passthrough();
+
+const AccessibleUsersSchema = z
+  .object({
+    target: TargetSchema,
+    repository: RepoExposureSchema,
+    exposure: z.string(),
+    accessible_not_downloaded: z.array(AccessibleUserSchema),
+    // `null` for public repos (never enumerated); omitted is treated as null.
+    total: z.number().nullish(),
+    page: z.number(),
+    per_page: z.number(),
+  })
+  .passthrough();
+
+export function parseAccessibleUsers(data: unknown): AccessibleUsersResponse {
+  const parsed = AccessibleUsersSchema.safeParse(data);
+  if (!parsed.success) {
+    throw new Error(
+      "Accessible-users response did not match the expected shape"
+    );
+  }
+  return {
+    target: { kind: parsed.data.target.kind, value: parsed.data.target.value },
+    repository: {
+      repository_id: parsed.data.repository.repository_id,
+      repository_key: parsed.data.repository.repository_key,
+      access_scope: parsed.data.repository.access_scope,
+    },
+    exposure: parsed.data.exposure,
+    accessible_not_downloaded: parsed.data.accessible_not_downloaded.map(
+      (u) => ({
+        reason: u.reason,
+        user_id: u.user_id,
+        username: u.username,
+        via: u.via,
+      })
+    ),
+    total: parsed.data.total ?? null,
+    page: parsed.data.page,
+    per_page: parsed.data.per_page,
+  };
+}
+
+/**
+ * Build the query string for the accessible-users endpoints, omitting empty
+ * params and clamping page/per_page to the same bounds as blast-radius.
+ */
+export function buildAccessibleUsersQueryString(
+  query: AccessibleUsersQuery
+): string {
+  const params = new URLSearchParams();
+  if (query.repository_id) params.set("repository_id", query.repository_id);
+  if (query.page != null) params.set("page", String(Math.max(1, query.page)));
+  if (query.per_page != null) {
+    params.set(
+      "per_page",
+      String(Math.min(Math.max(1, query.per_page), BLAST_RADIUS_MAX_PER_PAGE))
+    );
+  }
+  const qs = params.toString();
+  return qs ? `?${qs}` : "";
+}
+
+export const accessibleUsersApi = {
+  /**
+   * Latent exposure of one CVE/GHSA id, scoped to a single repository: who
+   * COULD read an affected artifact but has not downloaded it. `repository_id`
+   * is required — a CVE spans many repos.
+   */
+  forCve: async (
+    cveId: string,
+    query: AccessibleUsersQuery = {}
+  ): Promise<AccessibleUsersResponse> => {
+    const data = await apiFetch<unknown>(
+      `/api/v1/admin/security/cve/${encodeURIComponent(
+        normalizeVulnId(cveId)
+      )}/accessible-users${buildAccessibleUsersQueryString(query)}`,
+      { method: "GET" }
+    );
+    return parseAccessibleUsers(data);
+  },
+
+  /**
+   * Latent exposure of one artifact: the repository is implied by the artifact
+   * so `repository_id` is ignored server-side.
+   */
+  forArtifact: async (
+    artifactId: string,
+    query: AccessibleUsersQuery = {}
+  ): Promise<AccessibleUsersResponse> => {
+    const data = await apiFetch<unknown>(
+      `/api/v1/admin/security/artifact/${encodeURIComponent(
+        artifactId.trim()
+      )}/accessible-users${buildAccessibleUsersQueryString(query)}`,
+      { method: "GET" }
+    );
+    return parseAccessibleUsers(data);
+  },
+};
 
 /**
  * Client-side validation of the blast-radius target id. The backend matches


### PR DESCRIPTION
## Summary
Extends the CVE blast-radius page (`/security/blast-radius`) with the new **1.6.0 disclosure dimension** from backend #2386: **accessible-but-not-downloaded** users — principals who *could* read an affected artifact but have not downloaded it. This is *latent / potential* exposure, kept clearly distinct from the confirmed downloaders.

## What changed
**`src/lib/api/blast-radius.ts`**
- New `accessibleUsersApi` (`forCve` / `forArtifact`) hitting the new admin endpoints:
  - `GET /api/v1/admin/security/cve/{cve_id}/accessible-users` (requires `repository_id` — a CVE spans many repos)
  - `GET /api/v1/admin/security/artifact/{artifact_id}/accessible-users` (repo implied)
- `parseAccessibleUsers` zod parser + `buildAccessibleUsersQueryString`.
- Re-exports the generated `AccessibleUsersResponse` / `AccessibleUser` / `RepoExposure` types. These operations/responses **are now typed** in `@artifact-keeper/sdk@1.6.0`, so the generated types are the source of truth; fetching stays on the module's established `apiFetch` + zod trust-boundary pattern for one consistent fetch/validation path (documented inline; the stale "not in the SDK yet" comment was corrected).

**`src/app/(app)/(admin)/security/blast-radius/page.tsx`**
- New **"Accessible, not downloaded"** section, tinted/bordered and labelled *Latent exposure* with copy stressing potential vs. confirmed exposure.
- Shows the coarse `exposure` classification (`ExposureBadge`: enumerable / everyone / effectively-everyone), a per-user table with the access path (`ViaBadge`: admin / permission / role), a "N with latent access" count, and a public-repo banner instead of a list when enumeration is not applicable.
- CVE mode adds a repository selector (from the report's affected repos, defaults to the first); artifact mode needs none.
- Second react-query keyed on `ACCESSIBLE_USERS_QUERY_KEY`; refresh invalidates both. **Existing downloaders view untouched.**

## Tests
Added parser/query-builder tests (`blast-radius.test.ts`) and section-rendering, repo-scoping, artifact-mode, public-repo-banner, error-isolation, and badge tests (`page.test.tsx`).

## Verification (as CI runs)
- `npm install` — ok
- `npm run lint` — 0 errors
- `npm run test:coverage` — pass; global 87.0% stmts / 81.5% branch / 82.3% funcs / 87.7% lines (all > 80%); `api/blast-radius.ts` 100% lines
- `npm run build` — ok (`/security/blast-radius` builds)

Closes #604
Refs #599