### PR TITLE
feat(storage): per-folder deduplicated usage + migrate storage.ts to SDK

### DIFF
--- a/src/app/(app)/repositories/_components/repo-detail-content.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.tsx
@@ -59,6 +59,7 @@ import { QuarantineBadge } from "@/components/common/quarantine-badge";
 import { QuarantineBanner } from "@/components/common/quarantine-banner";
 import { RepoSettingsTab } from "./repo-settings-tab";
 import { RepoStoragePanel } from "./repo-storage-panel";
+import { RepoFolderStoragePanel } from "./repo-folder-storage-panel";
 import { formatBytes, REPO_TYPE_COLORS } from "@/lib/utils";
 import { useAuth } from "@/providers/auth-provider";
 import { useSystemConfig } from "@/providers/system-config-provider";
@@ -654,6 +655,17 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
           non-admins on instance-scope backends is enforced by the backend and
           handled gracefully by the panel. */}
       <RepoStoragePanel
+        repository={repository}
+        isAdmin={!!user?.is_admin}
+      />
+
+      {/* Per-folder deduplicated storage (epic artifact-keeper#2056, sub-task
+          4). Lists each top-level folder's real physical footprint and dedup
+          split. The folder-level figures are not yet part of the generated SDK,
+          so the panel reads them from the tree response via a validated
+          trust-boundary adapter and renders nothing until a backend reports
+          them — no empty panel on backends that predate the folder API. */}
+      <RepoFolderStoragePanel
         repository={repository}
         isAdmin={!!user?.is_admin}
       />

--- a/src/app/(app)/repositories/_components/repo-folder-storage-panel.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-folder-storage-panel.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+import type { TreeNode } from "@/types/tree";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// useQuery response for the folder tree lookup
+// (queryKey[0] === "repository-folder-storage").
+let treeResponse: { data: TreeNode[] | undefined } = { data: undefined };
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (opts: { queryKey: unknown[]; queryFn?: () => unknown }) => {
+    // Execute the queryFn so its arrow is covered; treeApi is mocked below.
+    try {
+      opts.queryFn?.();
+    } catch {
+      /* ignore */
+    }
+    return treeResponse;
+  },
+}));
+
+const mockGetChildren = vi.fn();
+vi.mock("@/lib/api/tree", () => ({
+  treeApi: {
+    getChildren: (...a: unknown[]) => mockGetChildren(...a),
+  },
+}));
+
+import { RepoFolderStoragePanel } from "./repo-folder-storage-panel";
+
+const REPO = { key: "oci-local" };
+
+function folderWithDedup(
+  name: string,
+  dedup: NonNullable<
+    NonNullable<TreeNode["metadata"]>["folder"]
+  >["dedup"],
+): TreeNode {
+  return {
+    id: `id-${name}`,
+    name,
+    type: "folder",
+    path: name,
+    has_children: true,
+    metadata: { folder: { file_count: 1, folder_count: 0, dedup } },
+  };
+}
+
+const plainFolder: TreeNode = {
+  id: "plain",
+  name: "src",
+  type: "folder",
+  path: "src",
+  has_children: true,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  treeResponse = { data: undefined };
+});
+afterEach(() => cleanup());
+
+describe("RepoFolderStoragePanel", () => {
+  it("renders a per-folder dedup breakdown when folders report it", () => {
+    treeResponse = {
+      data: [
+        folderWithDedup("images", {
+          logical_bytes: 1000,
+          physical_bytes: 400,
+          unique_bytes: 300,
+          shared_bytes: 100,
+          dedup_ratio: 2.5,
+        }),
+        plainFolder,
+      ],
+    };
+
+    render(<RepoFolderStoragePanel repository={REPO} isAdmin={false} />);
+
+    expect(screen.getByTestId("folder-storage-panel")).toBeInTheDocument();
+    // Only the folder carrying dedup data produces a row.
+    expect(screen.getAllByTestId("folder-storage-row")).toHaveLength(1);
+    expect(screen.getByText("images")).toBeInTheDocument();
+    expect(screen.getByText("2.50× deduplication")).toBeInTheDocument();
+    // Unique/shared split bar is rendered.
+    expect(screen.getByTestId("folder-bar-unique")).toBeInTheDocument();
+    expect(screen.getByTestId("folder-bar-shared")).toBeInTheDocument();
+  });
+
+  it("renders nothing when no folder reports dedup (current backends)", () => {
+    treeResponse = { data: [plainFolder] };
+    const { container } = render(
+      <RepoFolderStoragePanel repository={REPO} isAdmin={false} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByTestId("folder-storage-panel")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing while the tree is still loading (no data yet)", () => {
+    treeResponse = { data: undefined };
+    const { container } = render(
+      <RepoFolderStoragePanel repository={REPO} isAdmin={true} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the cross-repository sharing caveat only to admins", () => {
+    treeResponse = {
+      data: [
+        folderWithDedup("images", {
+          logical_bytes: 1000,
+          physical_bytes: 400,
+          unique_bytes: 300,
+          shared_bytes: 100,
+          dedup_ratio: 2.5,
+        }),
+      ],
+    };
+
+    const { rerender } = render(
+      <RepoFolderStoragePanel repository={REPO} isAdmin={false} />,
+    );
+    expect(screen.queryByText(/Shared.*bytes are blobs/i)).not.toBeInTheDocument();
+
+    rerender(<RepoFolderStoragePanel repository={REPO} isAdmin={true} />);
+    expect(screen.getByText(/bytes are blobs a folder has in common/i)).toBeInTheDocument();
+  });
+
+  it("omits absent figures without rendering zeros", () => {
+    treeResponse = {
+      data: [
+        folderWithDedup("partial", {
+          logical_bytes: 500,
+          physical_bytes: 250,
+          // unique/shared/ratio omitted by the backend
+        }),
+      ],
+    };
+
+    render(<RepoFolderStoragePanel repository={REPO} isAdmin={false} />);
+
+    expect(screen.getByText("Logical")).toBeInTheDocument();
+    expect(screen.getByText("Physical")).toBeInTheDocument();
+    // No unique/shared figures, so no split bar and no ratio line.
+    expect(screen.queryByTestId("folder-bar-unique")).not.toBeInTheDocument();
+    expect(screen.queryByText(/deduplication$/)).not.toBeInTheDocument();
+  });
+});

--- a/src/app/(app)/repositories/_components/repo-folder-storage-panel.tsx
+++ b/src/app/(app)/repositories/_components/repo-folder-storage-panel.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Folder, Info, Layers } from "lucide-react";
+
+import { treeApi } from "@/lib/api/tree";
+import { formatBytes } from "@/lib/utils";
+import type { TreeNode, FolderDedupUsage } from "@/types/tree";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+
+interface RepoFolderStoragePanelProps {
+  /** Repository whose top-level folders are being described. Only `key` is read. */
+  repository: { key: string };
+  /**
+   * Whether the current viewer is an administrator. Gates the descriptive copy
+   * about cross-repository sharing, mirroring the per-repository panel. Field
+   * visibility itself is enforced by the backend.
+   */
+  isAdmin: boolean;
+}
+
+/** A per-folder row with its dedup breakdown. */
+interface FolderRow {
+  id: string;
+  name: string;
+  path: string;
+  dedup: FolderDedupUsage;
+}
+
+/** A single labelled figure. */
+function Figure({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="space-y-0.5">
+      <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      <div className="text-sm font-semibold tabular-nums">{value}</div>
+    </div>
+  );
+}
+
+/** Unique-vs-shared mini bar for one folder. */
+function UniqueSharedBar({
+  unique,
+  shared,
+}: {
+  unique: number;
+  shared: number;
+}) {
+  const total = unique + shared;
+  if (total <= 0) return null;
+  const uniquePct = (unique / total) * 100;
+  const sharedPct = (shared / total) * 100;
+  return (
+    <div className="flex h-2 overflow-hidden rounded-full bg-muted">
+      <div
+        className="bg-primary"
+        style={{ width: `${uniquePct}%` }}
+        data-testid="folder-bar-unique"
+        aria-hidden
+      />
+      <div
+        className="bg-amber-400 dark:bg-amber-500"
+        style={{ width: `${sharedPct}%` }}
+        data-testid="folder-bar-shared"
+        aria-hidden
+      />
+    </div>
+  );
+}
+
+/**
+ * Per-folder deduplicated storage detail view (epic artifact-keeper#2056,
+ * sub-task 4).
+ *
+ * Lists each top-level folder in the repository with its deduplicated storage
+ * breakdown — logical vs physical bytes, dedup ratio, and a unique-vs-shared
+ * split — so operators can see which folders actually consume physical storage
+ * after content-addressable deduplication, not just their logical footprint.
+ *
+ * The folder-level figures are NOT part of the generated `@artifact-keeper/sdk`
+ * (v1.6.0 exposes only the repo-level `/storage` operation), so they are read
+ * from the tree response through the zod trust-boundary adapter in
+ * `lib/api/tree.ts` and are treated as optional. When the backend reports no
+ * per-folder dedup — the case for every backend that predates the folder-level
+ * `/storage/tree` API — this component renders nothing rather than a panel of
+ * zeros, and it lights up automatically once the data starts arriving.
+ */
+export function RepoFolderStoragePanel({
+  repository,
+  isAdmin,
+}: RepoFolderStoragePanelProps) {
+  const repoKey = repository.key;
+
+  const { data: nodes } = useQuery({
+    queryKey: ["repository-folder-storage", repoKey],
+    queryFn: () =>
+      treeApi.getChildren({
+        repository_key: repoKey,
+        include_metadata: true,
+      }),
+    enabled: !!repoKey,
+  });
+
+  const folders = useMemo<FolderRow[]>(() => {
+    return (nodes ?? [])
+      .map((node: TreeNode): FolderRow | null => {
+        const dedup = node.metadata?.folder?.dedup;
+        if (!dedup) return null;
+        return { id: node.id, name: node.name, path: node.path, dedup };
+      })
+      .filter((row): row is FolderRow => row !== null);
+  }, [nodes]);
+
+  // Nothing to show until the backend reports per-folder dedup. Rendering an
+  // empty "unavailable" panel here would be noise on every current backend, so
+  // the component simply stays out of the layout until real data arrives.
+  if (folders.length === 0) return null;
+
+  return (
+    <Card data-testid="folder-storage-panel">
+      <CardHeader className="flex flex-row items-center justify-between gap-2">
+        <CardTitle className="text-base">Per-folder storage</CardTitle>
+        <Badge variant="outline" className="text-xs font-normal">
+          Deduplicated
+        </Badge>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <ul className="space-y-4">
+          {folders.map((folder) => {
+            const { dedup } = folder;
+            const unique = dedup.unique_bytes ?? 0;
+            const shared = dedup.shared_bytes ?? 0;
+            return (
+              <li
+                key={folder.id}
+                className="space-y-2 border-b pb-4 last:border-b-0 last:pb-0"
+                data-testid="folder-storage-row"
+              >
+                <div className="flex items-center gap-2">
+                  <Folder className="size-4 shrink-0 text-muted-foreground" />
+                  <span className="truncate text-sm font-medium">
+                    {folder.name}
+                  </span>
+                </div>
+                <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+                  {dedup.logical_bytes != null && (
+                    <Figure
+                      label="Logical"
+                      value={formatBytes(dedup.logical_bytes)}
+                    />
+                  )}
+                  {dedup.physical_bytes != null && (
+                    <Figure
+                      label="Physical"
+                      value={formatBytes(dedup.physical_bytes)}
+                    />
+                  )}
+                  {dedup.unique_bytes != null && (
+                    <Figure label="Unique" value={formatBytes(unique)} />
+                  )}
+                  {dedup.shared_bytes != null && (
+                    <Figure label="Shared" value={formatBytes(shared)} />
+                  )}
+                </div>
+                {(dedup.unique_bytes != null || dedup.shared_bytes != null) && (
+                  <UniqueSharedBar unique={unique} shared={shared} />
+                )}
+                {dedup.dedup_ratio != null && (
+                  <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <Layers className="size-3.5" />
+                    {dedup.dedup_ratio.toFixed(2)}× deduplication
+                  </p>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+        {isAdmin && (
+          <p className="flex items-start gap-1.5 text-xs text-muted-foreground">
+            <Info className="mt-0.5 size-3.5 shrink-0" />
+            &ldquo;Shared&rdquo; bytes are blobs a folder has in common with
+            other folders or repositories; reclaiming them requires the last
+            referencing path to release them.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default RepoFolderStoragePanel;

--- a/src/app/(app)/repositories/_components/repo-storage-panel.tsx
+++ b/src/app/(app)/repositories/_components/repo-storage-panel.tsx
@@ -344,18 +344,20 @@ export function RepoStoragePanel({ repository, isAdmin }: RepoStoragePanelProps)
           </div>
         )}
 
-        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span data-testid="storage-computed-at">
-                Computed {formatRelativeTimestamp(usage.computed_at)}
-              </span>
-            </TooltipTrigger>
-            <TooltipContent>
-              {new Date(usage.computed_at).toLocaleString()}
-            </TooltipContent>
-          </Tooltip>
-        </div>
+        {usage.computed_at && (
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span data-testid="storage-computed-at">
+                  Computed {formatRelativeTimestamp(usage.computed_at)}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                {new Date(usage.computed_at).toLocaleString()}
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/lib/api/__tests__/storage.test.ts
+++ b/src/lib/api/__tests__/storage.test.ts
@@ -1,8 +1,25 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+// getUsage now goes through the generated SDK; runGc stays on apiFetch (the
+// per-repo /storage-gc operation is still absent from the SDK).
+vi.mock("@/lib/sdk-client", () => ({}));
+
 const mockApiFetch = vi.fn();
+const mockAssertData = vi.fn(<T,>(d: T) => d);
 vi.mock("@/lib/api/fetch", () => ({
   apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+  assertData: <T,>(d: T) => mockAssertData(d),
+  narrowEnum: <T extends string>(
+    value: string,
+    allowed: ReadonlySet<T>,
+    fallback: T,
+  ): T => (allowed.has(value as T) ? (value as T) : fallback),
+}));
+
+const mockGetRepositoryStorage = vi.fn();
+vi.mock("@artifact-keeper/sdk", () => ({
+  getRepositoryStorage: (...args: unknown[]) =>
+    mockGetRepositoryStorage(...args),
 }));
 
 import { storageApi } from "../storage";
@@ -10,39 +27,91 @@ import { storageApi } from "../storage";
 describe("storageApi.getUsage", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("GETs the per-repository storage endpoint", async () => {
-    mockApiFetch.mockResolvedValue({
-      logical_bytes: 100,
-      physical_bytes: 40,
-      dedup_scope: "per_repo",
-      blob_count: 3,
-      computed_at: "2026-07-15T00:00:00Z",
+  it("calls the generated getRepositoryStorage operation with the key", async () => {
+    mockGetRepositoryStorage.mockResolvedValue({
+      data: {
+        repository_key: "npm-local",
+        logical_bytes: 100,
+        physical_bytes: 40,
+        unique_bytes: 30,
+        shared_bytes: 10,
+        dedup_ratio: 2.5,
+        dedup_scope: "per_repo",
+        blob_count: 3,
+        instance_unique_bytes: 500,
+        computed_at: "2026-07-15T00:00:00Z",
+      },
+      error: undefined,
     });
+
     const result = await storageApi.getUsage("npm-local");
-    expect(mockApiFetch).toHaveBeenCalledWith(
-      "/api/v1/repositories/npm-local/storage",
-    );
-    expect(result.logical_bytes).toBe(100);
-    expect(result.dedup_scope).toBe("per_repo");
-  });
 
-  it("encodes the repository key", async () => {
-    mockApiFetch.mockResolvedValue({
-      logical_bytes: 0,
-      dedup_scope: "instance",
-      blob_count: 0,
-      computed_at: "2026-07-15T00:00:00Z",
+    expect(mockGetRepositoryStorage).toHaveBeenCalledWith({
+      path: { key: "npm-local" },
     });
-    await storageApi.getUsage("a/b");
-    expect(mockApiFetch).toHaveBeenCalledWith(
-      "/api/v1/repositories/a%2Fb/storage",
-    );
+    expect(result.logical_bytes).toBe(100);
+    expect(result.physical_bytes).toBe(40);
+    expect(result.dedup_scope).toBe("per_repo");
+    expect(result.instance_unique_bytes).toBe(500);
   });
 
-  it("propagates errors from apiFetch", async () => {
-    mockApiFetch.mockRejectedValue(new Error("storage boom"));
+  it("passes the raw key through (the SDK client does path encoding)", async () => {
+    mockGetRepositoryStorage.mockResolvedValue({
+      data: {
+        repository_key: "a/b",
+        logical_bytes: 0,
+        dedup_scope: "instance",
+        blob_count: 0,
+        computed_at: null,
+      },
+      error: undefined,
+    });
+
+    const result = await storageApi.getUsage("a/b");
+
+    expect(mockGetRepositoryStorage).toHaveBeenCalledWith({
+      path: { key: "a/b" },
+    });
+    // computed_at can be null before the first refresh has run.
+    expect(result.computed_at).toBeNull();
+  });
+
+  it("narrows an unknown dedup_scope to 'instance'", async () => {
+    mockGetRepositoryStorage.mockResolvedValue({
+      data: {
+        repository_key: "npm-local",
+        logical_bytes: 1,
+        dedup_scope: "galaxy-wide",
+        blob_count: 1,
+        computed_at: "2026-07-15T00:00:00Z",
+      },
+      error: undefined,
+    });
+
+    const result = await storageApi.getUsage("npm-local");
+    expect(result.dedup_scope).toBe("instance");
+  });
+
+  it("throws when the SDK returns an error", async () => {
+    mockGetRepositoryStorage.mockResolvedValue({
+      data: undefined,
+      error: { message: "storage boom" },
+    });
+    await expect(storageApi.getUsage("npm-local")).rejects.toEqual({
+      message: "storage boom",
+    });
+  });
+
+  it("throws on an empty success body (assertData guard)", async () => {
+    mockAssertData.mockImplementationOnce(() => {
+      throw new Error("Empty response body for storageApi.getUsage");
+    });
+    mockGetRepositoryStorage.mockResolvedValue({
+      data: undefined,
+      error: undefined,
+    });
     await expect(storageApi.getUsage("npm-local")).rejects.toThrow(
-      "storage boom",
+      "Empty response body",
     );
   });
 });
@@ -50,7 +119,7 @@ describe("storageApi.getUsage", () => {
 describe("storageApi.runGc", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("POSTs a dry-run by default", async () => {
+  it("POSTs a per-repo dry-run via apiFetch by default", async () => {
     mockApiFetch.mockResolvedValue({
       artifacts_removed: 0,
       bytes_freed: 2048,
@@ -63,6 +132,8 @@ describe("storageApi.runGc", () => {
       "/api/v1/repositories/npm-local/storage-gc",
       { method: "POST", body: JSON.stringify({ dry_run: true }) },
     );
+    // getUsage's SDK path must not be involved in the GC call.
+    expect(mockGetRepositoryStorage).not.toHaveBeenCalled();
     expect(result.bytes_freed).toBe(2048);
     expect(result.dry_run).toBe(true);
   });
@@ -79,6 +150,21 @@ describe("storageApi.runGc", () => {
     expect(mockApiFetch).toHaveBeenCalledWith(
       "/api/v1/repositories/npm-local/storage-gc",
       { method: "POST", body: JSON.stringify({ dry_run: false }) },
+    );
+  });
+
+  it("encodes the repository key", async () => {
+    mockApiFetch.mockResolvedValue({
+      artifacts_removed: 0,
+      bytes_freed: 0,
+      dry_run: true,
+      errors: [],
+      storage_keys_deleted: 0,
+    });
+    await storageApi.runGc("a/b");
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      "/api/v1/repositories/a%2Fb/storage-gc",
+      { method: "POST", body: JSON.stringify({ dry_run: true }) },
     );
   });
 

--- a/src/lib/api/__tests__/tree-getchildren.test.ts
+++ b/src/lib/api/__tests__/tree-getchildren.test.ts
@@ -90,3 +90,127 @@ describe("treeApi.getChildren", () => {
     expect(result[0].name).toBe("package.json");
   });
 });
+
+describe("treeApi.getChildren — per-folder dedup passthrough (artifact-keeper#2056)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("validates and attaches a top-level `dedup` object to folder metadata", async () => {
+    const nodes = [
+      {
+        id: "f1",
+        name: "images",
+        type: "folder",
+        path: "images",
+        has_children: true,
+        dedup: {
+          logical_bytes: 1000,
+          physical_bytes: 400,
+          unique_bytes: 300,
+          shared_bytes: 100,
+          dedup_ratio: 2.5,
+        },
+      },
+    ];
+    mockGetTree.mockResolvedValue({ data: { nodes }, error: undefined });
+
+    const result = await treeApi.getChildren({ repository_key: "oci-local" });
+
+    expect(result[0].metadata?.folder?.dedup).toEqual({
+      logical_bytes: 1000,
+      physical_bytes: 400,
+      unique_bytes: 300,
+      shared_bytes: 100,
+      dedup_ratio: 2.5,
+    });
+  });
+
+  it("reads dedup from nested metadata.folder.dedup", async () => {
+    const nodes = [
+      {
+        id: "f2",
+        name: "layers",
+        type: "folder",
+        path: "layers",
+        has_children: true,
+        metadata: {
+          folder: {
+            file_count: 4,
+            folder_count: 1,
+            dedup: { logical_bytes: 50, physical_bytes: 25 },
+          },
+        },
+      },
+    ];
+    mockGetTree.mockResolvedValue({ data: { nodes }, error: undefined });
+
+    const result = await treeApi.getChildren({ repository_key: "oci-local" });
+
+    expect(result[0].metadata?.folder?.dedup).toEqual({
+      logical_bytes: 50,
+      physical_bytes: 25,
+    });
+    // Existing folder metadata fields are preserved alongside the dedup merge.
+    expect(result[0].metadata?.folder?.file_count).toBe(4);
+  });
+
+  it("leaves folder metadata untouched when no dedup is reported", async () => {
+    const nodes = [
+      {
+        id: "f3",
+        name: "src",
+        type: "folder",
+        path: "src",
+        has_children: true,
+      },
+    ];
+    mockGetTree.mockResolvedValue({ data: { nodes }, error: undefined });
+
+    const result = await treeApi.getChildren({ repository_key: "npm-local" });
+
+    expect(result[0].metadata).toBeUndefined();
+  });
+
+  it("collapses an all-null dedup object to undefined (absent, not zero)", async () => {
+    const nodes = [
+      {
+        id: "f4",
+        name: "empty",
+        type: "folder",
+        path: "empty",
+        has_children: false,
+        dedup: {
+          logical_bytes: null,
+          physical_bytes: null,
+          unique_bytes: null,
+          shared_bytes: null,
+          dedup_ratio: null,
+        },
+      },
+    ];
+    mockGetTree.mockResolvedValue({ data: { nodes }, error: undefined });
+
+    const result = await treeApi.getChildren({ repository_key: "npm-local" });
+
+    expect(result[0].metadata?.folder?.dedup).toBeUndefined();
+  });
+
+  it("drops a malformed dedup payload rather than surfacing garbage", async () => {
+    const nodes = [
+      {
+        id: "f5",
+        name: "weird",
+        type: "folder",
+        path: "weird",
+        has_children: false,
+        dedup: { physical_bytes: "not-a-number" },
+      },
+    ];
+    mockGetTree.mockResolvedValue({ data: { nodes }, error: undefined });
+
+    const result = await treeApi.getChildren({ repository_key: "npm-local" });
+
+    expect(result[0].metadata?.folder?.dedup).toBeUndefined();
+  });
+});

--- a/src/lib/api/storage.ts
+++ b/src/lib/api/storage.ts
@@ -1,18 +1,61 @@
-import { apiFetch } from '@/lib/api/fetch';
-import type { RepositoryStorageUsage, StorageGcResult } from '@/types/storage';
+import '@/lib/sdk-client';
+import { getRepositoryStorage } from '@artifact-keeper/sdk';
+import type { RepositoryStorageStatsResponse } from '@artifact-keeper/sdk';
+import { apiFetch, assertData, narrowEnum } from '@/lib/api/fetch';
+import type {
+  DedupScope,
+  RepositoryStorageUsage,
+  StorageGcResult,
+} from '@/types/storage';
 
 /**
- * Per-repository deduplicated storage endpoints (backend epic
- * artifact-keeper#2056).
+ * Deduplicated storage endpoints (backend epic artifact-keeper#2056).
  *
- * These routes are new to the backend and are NOT yet exposed by the published
- * `@artifact-keeper/sdk` (v1.5.0 only ships the instance-wide
- * `/admin/analytics/storage/breakdown` + `/admin/storage-gc` operations, which
- * report a single `storage_bytes` figure and no dedup breakdown). Until the SDK
- * is regenerated from the backend spec, they go through the shared `apiFetch`
- * wrapper — the same pattern used for routing-rules, upstream-auth, and the age
- * policy in `repositories.ts`.
+ * `getUsage` now goes through the generated `@artifact-keeper/sdk` — the
+ * repo-level `getRepositoryStorage` operation (`GET /repositories/{key}/storage`)
+ * shipped with sdk@1.6.0, so the previous `apiFetch` workaround has been
+ * collapsed back to the generated client, adapting the SDK response at the
+ * trust boundary (`assertData` + `narrowEnum` for the free-form `dedup_scope`).
+ *
+ * `runGc` deliberately STAYS on `apiFetch`: the per-repository GC endpoint
+ * (`POST /repositories/{key}/storage-gc`) is still absent from the SDK. The
+ * only garbage-collection operation the generated client exposes is the
+ * instance-wide `runStorageGc` (`POST /admin/storage-gc`), which is a different,
+ * admin-only, whole-instance surface — it is NOT the per-repo dry-run the panel
+ * needs for its "reclaimable now" estimate. Once the backend spec grows a
+ * per-repo GC operation this can collapse to the generated call too.
  */
+
+const DEDUP_SCOPES = new Set<DedupScope>(['per_repo', 'instance']);
+
+/**
+ * Adapt the generated `RepositoryStorageStatsResponse` to the local
+ * `RepositoryStorageUsage`. The SDK types `dedup_scope` as a free-form string,
+ * so it is narrowed to the `DedupScope` union (defaulting to `instance`, the
+ * conservative choice — it triggers the cross-tenant caveat copy rather than
+ * implying a repository-scoped guarantee we can't verify).
+ */
+function adaptUsage(sdk: RepositoryStorageStatsResponse): RepositoryStorageUsage {
+  return {
+    repository_key: sdk.repository_key,
+    logical_bytes: sdk.logical_bytes,
+    physical_bytes: sdk.physical_bytes,
+    unique_bytes: sdk.unique_bytes,
+    shared_bytes: sdk.shared_bytes,
+    dedup_ratio: sdk.dedup_ratio,
+    dedup_scope: narrowEnum(
+      sdk.dedup_scope,
+      DEDUP_SCOPES,
+      'instance',
+      `storageApi.getUsage: unknown dedup_scope "${sdk.dedup_scope}" — ` +
+        `defaulting to 'instance'.`,
+    ),
+    blob_count: sdk.blob_count,
+    computed_at: sdk.computed_at ?? null,
+    instance_unique_bytes: sdk.instance_unique_bytes,
+  };
+}
+
 export const storageApi = {
   /**
    * Read the dedup-aware storage usage for a repository.
@@ -23,9 +66,11 @@ export const storageApi = {
    * callers must treat those fields as optional.
    */
   getUsage: async (repoKey: string): Promise<RepositoryStorageUsage> => {
-    return apiFetch<RepositoryStorageUsage>(
-      `/api/v1/repositories/${encodeURIComponent(repoKey)}/storage`,
-    );
+    const { data, error } = await getRepositoryStorage({
+      path: { key: repoKey },
+    });
+    if (error) throw error;
+    return adaptUsage(assertData(data, 'storageApi.getUsage'));
   },
 
   /**
@@ -35,6 +80,11 @@ export const storageApi = {
    * reclaimed without deleting anything; the panel uses the returned
    * `bytes_freed` as the admin-only "reclaimable now" estimate. This endpoint
    * is admin-gated on the backend, so callers should only offer it to admins.
+   *
+   * Still on `apiFetch`: the per-repo `/storage-gc` operation is not in the
+   * SDK (see the module note above), so the zod-free `apiFetch` trust boundary
+   * is retained here — this is the one operation that remains genuinely absent
+   * from the generated client.
    */
   runGc: async (repoKey: string, dryRun = true): Promise<StorageGcResult> => {
     return apiFetch<StorageGcResult>(

--- a/src/lib/api/tree.ts
+++ b/src/lib/api/tree.ts
@@ -1,11 +1,71 @@
 import '@/lib/sdk-client';
+import { z } from 'zod';
 import { getTree } from '@artifact-keeper/sdk';
 import type { TreeNodeResponse } from '@artifact-keeper/sdk';
 import { assertData, narrowEnum } from '@/lib/api/fetch';
 
 // Re-export types from the canonical types/ module
 export type { TreeNodeType, TreeNode } from '@/types/tree';
-import type { TreeNode, TreeNodeType, TreeNodeMetadata } from '@/types/tree';
+import type {
+  TreeNode,
+  TreeNodeType,
+  TreeNodeMetadata,
+  FolderDedupUsage,
+} from '@/types/tree';
+
+/**
+ * Trust-boundary schema for the per-folder deduplicated storage breakdown
+ * (backend epic artifact-keeper#2056 sub-task 4). The generated SDK does NOT
+ * model this — v1.6.0 ships only the repo-level `/storage` operation and its
+ * `TreeNodeResponse` carries just `size_bytes` — so the folder dedup figures,
+ * when a future backend attaches them to the tree response, arrive as untyped
+ * passthrough. This zod schema is the validation gate the migration keeps
+ * exactly where a generated operation is still genuinely absent: it coerces the
+ * numeric fields, drops anything malformed, and yields `undefined` (rather than
+ * a partial/garbage object) when the backend omits the breakdown entirely.
+ */
+const folderDedupSchema = z
+  .object({
+    logical_bytes: z.number().finite().nullish(),
+    physical_bytes: z.number().finite().nullish(),
+    unique_bytes: z.number().finite().nullish(),
+    shared_bytes: z.number().finite().nullish(),
+    dedup_ratio: z.number().finite().nullish(),
+  })
+  .partial();
+
+/**
+ * Extract and validate the per-folder dedup breakdown from an untyped tree
+ * node. Returns `undefined` when the node carries no dedup object or every
+ * field is absent, so callers can treat "absent" as "not reported" instead of
+ * "zero". The breakdown may live either at `node.dedup` or nested under
+ * `node.metadata.folder.dedup`, mirroring the two shapes the folder metadata
+ * has taken across backend revisions.
+ */
+function extractFolderDedup(
+  passthrough: Record<string, unknown>,
+): FolderDedupUsage | undefined {
+  const metadata =
+    passthrough.metadata && typeof passthrough.metadata === 'object'
+      ? (passthrough.metadata as Record<string, unknown>)
+      : undefined;
+  const folder =
+    metadata?.folder && typeof metadata.folder === 'object'
+      ? (metadata.folder as Record<string, unknown>)
+      : undefined;
+  const raw = passthrough.dedup ?? folder?.dedup;
+  if (!raw || typeof raw !== 'object') return undefined;
+
+  const parsed = folderDedupSchema.safeParse(raw);
+  if (!parsed.success) return undefined;
+
+  // Collapse an all-empty result (backend returned `{}` or only nulls) to
+  // `undefined` so the UI shows "not reported" rather than a row of zeros.
+  const hasAnyValue = Object.values(parsed.data).some(
+    (v) => v !== undefined && v !== null,
+  );
+  return hasAnyValue ? parsed.data : undefined;
+}
 
 export interface GetChildrenParams {
   repository_key?: string;
@@ -34,6 +94,20 @@ function adaptTreeNode(sdk: TreeNodeResponse): TreeNode {
     passthrough.metadata && typeof passthrough.metadata === 'object'
       ? (passthrough.metadata as TreeNodeMetadata)
       : undefined;
+
+  // Per-folder deduplicated storage (artifact-keeper#2056 sub-task 4) is not
+  // modelled by the SDK, so it comes through as validated passthrough. Merge it
+  // into the folder metadata when present; leave the node untouched otherwise so
+  // existing folder rendering is byte-for-byte unchanged against current
+  // backends that don't report it.
+  const dedup = extractFolderDedup(passthrough);
+  const mergedMetadata: TreeNodeMetadata | undefined = dedup
+    ? {
+        ...metadata,
+        folder: { file_count: 0, folder_count: 0, ...metadata?.folder, dedup },
+      }
+    : metadata;
+
   return {
     id: sdk.id,
     name: sdk.name,
@@ -41,7 +115,7 @@ function adaptTreeNode(sdk: TreeNodeResponse): TreeNode {
     path: sdk.path,
     has_children: sdk.has_children,
     children_count: sdk.children_count ?? undefined,
-    metadata,
+    metadata: mergedMetadata,
   };
 }
 

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -57,8 +57,13 @@ export interface RepositoryStorageUsage {
   dedup_scope: DedupScope;
   /** Number of distinct stored blobs backing this repository. Always returned. */
   blob_count: number;
-  /** ISO-8601 timestamp of when these figures were computed. */
-  computed_at: string;
+  /**
+   * ISO-8601 timestamp of when these figures were computed. `null` before the
+   * first background refresh has run for the repository (the stats cache is
+   * materialized on a schedule + post-GC), so consumers must guard the
+   * freshness display on presence.
+   */
+  computed_at: string | null;
   /**
    * Instance-wide unique physical bytes across ALL repositories. Admin-only —
    * the backend only includes it for admin viewers, so it is optional here and

--- a/src/types/tree.ts
+++ b/src/types/tree.ts
@@ -96,6 +96,42 @@ export interface TreeFolderMetadata {
   folder_count: number;
   /** Total size of files in this folder (not recursive) */
   total_size_bytes?: number;
+  /**
+   * Deduplicated per-folder storage (backend epic artifact-keeper#2056,
+   * sub-task 4: `GET /api/v1/repositories/{key}/storage/tree`). Mirrors the
+   * repo-level dedup accounting scoped to a single folder/path prefix so
+   * operators can see which folders actually consume physical storage after
+   * content-addressable deduplication — not just their logical footprint.
+   *
+   * IMPORTANT: these fields are OPTIONAL and are NOT part of the generated
+   * `@artifact-keeper/sdk` (v1.6.0 ships only the repo-level `/storage`
+   * operation; the folder-level API and the `repository_path_storage_stats`
+   * rows it reads have not been released to the SDK/backend spec yet). The tree
+   * API adapter therefore reads them from the response via a zod trust-boundary
+   * schema and leaves them `undefined` when the backend omits them. Consumers
+   * MUST treat "absent" as "not reported by this backend" rather than "zero",
+   * exactly as the per-repository panel treats the #2560 field omission.
+   */
+  dedup?: FolderDedupUsage;
+}
+
+/**
+ * Per-folder deduplicated storage breakdown. Field semantics mirror
+ * `RepositoryStorageUsage` in `types/storage.ts` but scoped to one folder path.
+ * Every figure is optional/nullable because the folder-level backend API is not
+ * yet released; the fields travel together (present or all absent).
+ */
+export interface FolderDedupUsage {
+  /** Sum of referenced artifact sizes in this folder, before deduplication. */
+  logical_bytes?: number | null;
+  /** Bytes physically stored for this folder after deduplication. */
+  physical_bytes?: number | null;
+  /** Physical bytes referenced only by artifacts under this folder. */
+  unique_bytes?: number | null;
+  /** Physical bytes this folder shares with artifacts elsewhere. */
+  shared_bytes?: number | null;
+  /** `logical_bytes / physical_bytes` for this folder. */
+  dedup_ratio?: number | null;
 }
 
 export interface TreeLoadRequest {


### PR DESCRIPTION
## Summary

Implements #605: migrates the per-repository storage lookup off its `apiFetch` workaround to the generated `@artifact-keeper/sdk@1.6.0` client, and adds a per-folder deduplicated storage detail view. The existing per-repo panel (logical/physical/dedup-ratio/unique-vs-shared/GC-reclaimable, admin-gated with the #2560 non-admin omission) is preserved exactly.

### SDK migration (`lib/api/storage.ts`)
- **`getUsage` → generated `getRepositoryStorage`** (`GET /repositories/{key}/storage`). The response (`RepositoryStorageStatsResponse`) is adapted at the trust boundary with `assertData` + `narrowEnum` for the free-form `dedup_scope`, matching the pattern in `tree.ts` / `repositories.ts`. The "collapse back to a generated SDK call once the SDK is regenerated" comment is resolved.
- **`runGc` intentionally stays on `apiFetch`.** The per-repo `POST /repositories/{key}/storage-gc` operation is still **absent** from sdk@1.6.0 — the only GC operation the SDK exposes is the instance-wide `runStorageGc` (`POST /admin/storage-gc`), which is a different admin-only surface, not the per-repo dry-run the panel's "reclaimable now" estimate needs. The comment now documents *why* it remains.
- `types/storage.ts`: `computed_at` is now `string | null` to match the SDK (null before the first stats refresh); the panel guards its freshness line accordingly.

### Per-folder deduplicated usage
The folder-level API from #2056 (sub-task 4, `GET /repositories/{key}/storage/tree`, the `repository_path_storage_stats` table) is **not present in backend v1.6.0 or the generated SDK** — the tree endpoint returns only `size_bytes` for file nodes and nothing for folders. This PR therefore lands the surface *forward-compatibly*:
- `TreeFolderMetadata` gains an optional `dedup` breakdown (`logical/physical/unique/shared/dedup_ratio`).
- `lib/api/tree.ts` reads it from the tree response through a **zod trust-boundary schema** — kept precisely where a generated operation is still genuinely absent — coercing/validating the fields and collapsing an all-absent payload to `undefined`.
- A new `RepoFolderStoragePanel` (per-folder detail view, wired into `repo-detail-content.tsx` next to the repo panel) renders each folder's dedup breakdown when reported and **renders nothing** on backends that don't expose it (no empty panel today), lighting up automatically once the backend ships the folder API.

### SDK fields/operations used
- Operation: `getRepositoryStorage` (`GET /api/v1/repositories/{key}/storage`) → `RepositoryStorageStatsResponse` (`logical_bytes`, `physical_bytes`, `unique_bytes`, `shared_bytes`, `dedup_ratio`, `dedup_scope`, `blob_count`, `instance_unique_bytes`, `computed_at`).
- Existing `getTree` operation reused for the per-folder view; per-folder dedup fields are read via validated passthrough (not modelled by the SDK).

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [ ] Playwright E2E spec covers the change
- [x] Responsive layout verified (mobile + desktop)
- [x] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes

CI verified locally: `npm install`, `npm run lint` (0 errors), `npm run test:coverage` (87.0% stmts / 81.6% branch / 82.3% funcs / 87.7% lines; changed source files 100% line-covered), `npm run build`, jscpd on changed files 0%.

Closes #605
Refs #599