### PR TITLE
feat(repositories): add 1.6.0 format-specific config to create dialog & settings tab

### DIFF
--- a/src/app/(app)/repositories/_components/format-config-fields.test.tsx
+++ b/src/app/(app)/repositories/_components/format-config-fields.test.tsx
@@ -1,0 +1,300 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  parseList,
+  formatList,
+  buildRpmConfigFields,
+  buildDebianConfigFields,
+  buildNpmScopePolicyFields,
+  RpmTrustedKeyField,
+  DebianConfigFields,
+  NpmScopePolicyFields,
+  EMPTY_RPM_CONFIG,
+  EMPTY_DEBIAN_CONFIG,
+  EMPTY_NPM_SCOPE_POLICY,
+  type RpmConfigValue,
+  type DebianConfigValue,
+  type NpmScopePolicyValue,
+} from "./format-config-fields";
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+afterEach(() => cleanup());
+
+describe("parseList / formatList", () => {
+  it("splits on commas and newlines, trims, and drops blanks", () => {
+    expect(parseList("main, contrib\nnon-free ,, ")).toEqual([
+      "main",
+      "contrib",
+      "non-free",
+    ]);
+  });
+
+  it("returns an empty array for an empty/whitespace string", () => {
+    expect(parseList("")).toEqual([]);
+    expect(parseList("  ,  \n ")).toEqual([]);
+  });
+
+  it("formatList joins a list with ', '", () => {
+    expect(formatList(["amd64", "arm64"])).toBe("amd64, arm64");
+  });
+
+  it("formatList tolerates null/undefined", () => {
+    expect(formatList(undefined)).toBe("");
+    expect(formatList(null)).toBe("");
+  });
+
+  it("parseList and formatList round-trip", () => {
+    expect(parseList(formatList(["a", "b", "c"]))).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("buildRpmConfigFields", () => {
+  it("emits trusted_gpg_key when a key is present (trimmed)", () => {
+    expect(buildRpmConfigFields({ trusted_gpg_key: "  KEYDATA  " })).toEqual({
+      trusted_gpg_key: "KEYDATA",
+    });
+  });
+
+  it("omits the field entirely when the key is blank", () => {
+    expect(buildRpmConfigFields({ trusted_gpg_key: "   " })).toEqual({});
+    expect(buildRpmConfigFields(EMPTY_RPM_CONFIG)).toEqual({});
+  });
+});
+
+describe("buildDebianConfigFields", () => {
+  it("maps apt_* metadata and parses the filter lists", () => {
+    const value: DebianConfigValue = {
+      apt_origin: "acme",
+      apt_label: "Acme Mirror",
+      apt_release_version: "12",
+      apt_description: "internal",
+      distribution_paths: "bookworm, bullseye",
+      components: "main",
+      architectures: "amd64, arm64",
+    };
+    expect(buildDebianConfigFields(value)).toEqual({
+      apt_origin: "acme",
+      apt_label: "Acme Mirror",
+      apt_release_version: "12",
+      apt_description: "internal",
+      debian: {
+        distribution_paths: ["bookworm", "bullseye"],
+        components: ["main"],
+        architectures: ["amd64", "arm64"],
+      },
+    });
+  });
+
+  it("sends undefined for blank metadata and empty arrays for blank filters", () => {
+    expect(buildDebianConfigFields(EMPTY_DEBIAN_CONFIG)).toEqual({
+      apt_origin: undefined,
+      apt_label: undefined,
+      apt_release_version: undefined,
+      apt_description: undefined,
+      debian: {
+        distribution_paths: [],
+        components: [],
+        architectures: [],
+      },
+    });
+  });
+});
+
+describe("buildNpmScopePolicyFields", () => {
+  it("parses scope and pattern lists and carries the unscoped flag", () => {
+    const value: NpmScopePolicyValue = {
+      npm_allowed_scopes: "@acme, @internal",
+      npm_allowed_name_patterns: "@acme*, internal-*",
+      npm_allow_unscoped: true,
+    };
+    expect(buildNpmScopePolicyFields(value)).toEqual({
+      npm_allowed_scopes: ["@acme", "@internal"],
+      npm_allowed_name_patterns: ["@acme*", "internal-*"],
+      npm_allow_unscoped: true,
+    });
+  });
+
+  it("emits empty arrays and false for the empty policy", () => {
+    expect(buildNpmScopePolicyFields(EMPTY_NPM_SCOPE_POLICY)).toEqual({
+      npm_allowed_scopes: [],
+      npm_allowed_name_patterns: [],
+      npm_allow_unscoped: false,
+    });
+  });
+});
+
+describe("RpmTrustedKeyField", () => {
+  it("reports edits through onChange", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <RpmTrustedKeyField
+        idPrefix="t"
+        value={EMPTY_RPM_CONFIG}
+        onChange={onChange}
+      />
+    );
+    await user.type(screen.getByLabelText(/trusted gpg public key/i), "A");
+    expect(onChange).toHaveBeenCalledWith({ trusted_gpg_key: "A" });
+  });
+
+  it("shows the configured-key status only when a key exists", () => {
+    const { rerender } = render(
+      <RpmTrustedKeyField idPrefix="t" value={EMPTY_RPM_CONFIG} onChange={vi.fn()} />
+    );
+    expect(screen.queryByTestId("t-rpm-gpg-status")).toBeNull();
+
+    rerender(
+      <RpmTrustedKeyField
+        idPrefix="t"
+        value={EMPTY_RPM_CONFIG}
+        onChange={vi.fn()}
+        hasExistingKey
+      />
+    );
+    expect(screen.getByTestId("t-rpm-gpg-status")).toBeTruthy();
+  });
+
+  it("renders a Remove button and fires onRemove when a key exists", async () => {
+    const user = userEvent.setup();
+    const onRemove = vi.fn();
+    render(
+      <RpmTrustedKeyField
+        idPrefix="t"
+        value={EMPTY_RPM_CONFIG}
+        onChange={vi.fn()}
+        hasExistingKey
+        onRemove={onRemove}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /^remove$/i }));
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the removing state while a remove is pending", () => {
+    render(
+      <RpmTrustedKeyField
+        idPrefix="t"
+        value={EMPTY_RPM_CONFIG}
+        onChange={vi.fn()}
+        hasExistingKey
+        onRemove={vi.fn()}
+        removePending
+      />
+    );
+    const btn = screen.getByRole("button", { name: /removing/i });
+    expect(btn).toHaveProperty("disabled", true);
+  });
+});
+
+describe("DebianConfigFields", () => {
+  it("shows current values and reports edits without dropping other fields", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const value: DebianConfigValue = {
+      ...EMPTY_DEBIAN_CONFIG,
+      components: "main",
+    };
+    render(
+      <DebianConfigFields idPrefix="t" value={value} onChange={onChange} />
+    );
+
+    expect((screen.getByLabelText(/^components$/i) as HTMLInputElement).value).toBe(
+      "main"
+    );
+
+    await user.type(screen.getByLabelText(/architectures/i), "x");
+    // Preserves the existing `components` while patching architectures.
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ components: "main", architectures: "x" })
+    );
+  });
+
+  it("edits every Debian field via onChange", async () => {
+    const user = userEvent.setup();
+    const cases: Array<[RegExp, keyof DebianConfigValue]> = [
+      [/^origin$/i, "apt_origin"],
+      [/^label$/i, "apt_label"],
+      [/^version$/i, "apt_release_version"],
+      [/^description$/i, "apt_description"],
+      [/distributions/i, "distribution_paths"],
+      [/^components$/i, "components"],
+      [/architectures/i, "architectures"],
+    ];
+    for (const [label, key] of cases) {
+      const onChange = vi.fn();
+      const { unmount } = render(
+        <DebianConfigFields
+          idPrefix="t"
+          value={EMPTY_DEBIAN_CONFIG}
+          onChange={onChange}
+        />
+      );
+      await user.type(screen.getByLabelText(label), "z");
+      expect(onChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({ [key]: "z" })
+      );
+      unmount();
+    }
+  });
+});
+
+describe("NpmScopePolicyFields", () => {
+  it("edits the scopes list", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <NpmScopePolicyFields
+        idPrefix="t"
+        value={EMPTY_NPM_SCOPE_POLICY}
+        onChange={onChange}
+      />
+    );
+    await user.type(screen.getByLabelText(/allowed scopes/i), "@");
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ npm_allowed_scopes: "@" })
+    );
+  });
+
+  it("edits the name-patterns list", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <NpmScopePolicyFields
+        idPrefix="t"
+        value={EMPTY_NPM_SCOPE_POLICY}
+        onChange={onChange}
+      />
+    );
+    await user.type(screen.getByLabelText(/allowed name patterns/i), "x");
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ npm_allowed_name_patterns: "x" })
+    );
+  });
+
+  it("toggles the unscoped switch", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <NpmScopePolicyFields
+        idPrefix="t"
+        value={EMPTY_NPM_SCOPE_POLICY}
+        onChange={onChange}
+      />
+    );
+    await user.click(screen.getByRole("switch"));
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ npm_allow_unscoped: true })
+    );
+  });
+});

--- a/src/app/(app)/repositories/_components/format-config-fields.tsx
+++ b/src/app/(app)/repositories/_components/format-config-fields.tsx
@@ -1,0 +1,401 @@
+"use client";
+
+/**
+ * Format-specific repository configuration fields (issue #602, 1.6.0).
+ *
+ * These controlled, presentational field groups are shared verbatim between the
+ * create dialog (`repo-dialogs.tsx`) and the settings/edit tab
+ * (`repo-settings-tab.tsx`) so the two surfaces never drift. Each group owns no
+ * state of its own — the parent holds a string-based value object (lists are
+ * edited as comma/newline-separated text) and receives the next value on every
+ * change. The `build*` helpers turn those value objects into the exact SDK
+ * request fields at submit time.
+ *
+ * The three groups map to distinct 1.6.0 backend features:
+ *  - RPM curation trusted GPG key (#2568)
+ *  - Advanced Debian/APT config + Release metadata (#2407/#2460/#2489/#2459)
+ *  - npm scope policy (#2424)
+ */
+
+import type { DebianRepoConfig } from "@/types";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/ui/button";
+
+// ---------------------------------------------------------------------------
+// Value shapes (string-based so every field stays a controlled input)
+// ---------------------------------------------------------------------------
+
+export interface RpmConfigValue {
+  /** ASCII-armored OpenPGP *public* key block, or empty to leave unset. */
+  trusted_gpg_key: string;
+}
+
+export interface DebianConfigValue {
+  // Release metadata (top-level apt_* fields on the request)
+  apt_origin: string;
+  apt_label: string;
+  apt_release_version: string;
+  apt_description: string;
+  // Proxy/remote distro-filter allowlists (comma/newline-separated).
+  // Empty list = "all" (today's full-proxy behaviour).
+  distribution_paths: string;
+  components: string;
+  architectures: string;
+}
+
+export interface NpmScopePolicyValue {
+  /** Allowed `@scope` literals / globs, comma/newline-separated. */
+  npm_allowed_scopes: string;
+  /** Allowed full-name globs (`@acme*`, `internal-*`), comma/newline-separated. */
+  npm_allowed_name_patterns: string;
+  /** Whether unscoped package names may resolve through this repo. */
+  npm_allow_unscoped: boolean;
+}
+
+export const EMPTY_RPM_CONFIG: RpmConfigValue = { trusted_gpg_key: "" };
+
+export const EMPTY_DEBIAN_CONFIG: DebianConfigValue = {
+  apt_origin: "",
+  apt_label: "",
+  apt_release_version: "",
+  apt_description: "",
+  distribution_paths: "",
+  components: "",
+  architectures: "",
+};
+
+export const EMPTY_NPM_SCOPE_POLICY: NpmScopePolicyValue = {
+  npm_allowed_scopes: "",
+  npm_allowed_name_patterns: "",
+  npm_allow_unscoped: false,
+};
+
+// ---------------------------------------------------------------------------
+// List <-> text conversion
+// ---------------------------------------------------------------------------
+
+/** Split a comma/newline-separated field into a trimmed, de-blanked list. */
+export function parseList(input: string): string[] {
+  return input
+    .split(/[\n,]/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/** Render a stored list back into a comma-separated field value. */
+export function formatList(list?: string[] | null): string {
+  return (list ?? []).join(", ");
+}
+
+// ---------------------------------------------------------------------------
+// Request-field builders (pure; used by both create and edit submit paths)
+// ---------------------------------------------------------------------------
+
+export interface RpmConfigFields {
+  trusted_gpg_key?: string;
+}
+
+/** Only emit `trusted_gpg_key` when the operator actually typed a key. */
+export function buildRpmConfigFields(value: RpmConfigValue): RpmConfigFields {
+  const key = value.trusted_gpg_key.trim();
+  return key ? { trusted_gpg_key: key } : {};
+}
+
+export interface DebianConfigFieldsPayload {
+  apt_origin?: string;
+  apt_label?: string;
+  apt_release_version?: string;
+  apt_description?: string;
+  debian?: DebianRepoConfig;
+}
+
+export function buildDebianConfigFields(
+  value: DebianConfigValue,
+): DebianConfigFieldsPayload {
+  return {
+    apt_origin: value.apt_origin.trim() || undefined,
+    apt_label: value.apt_label.trim() || undefined,
+    apt_release_version: value.apt_release_version.trim() || undefined,
+    apt_description: value.apt_description.trim() || undefined,
+    debian: {
+      distribution_paths: parseList(value.distribution_paths),
+      components: parseList(value.components),
+      architectures: parseList(value.architectures),
+    },
+  };
+}
+
+export interface NpmScopePolicyFieldsPayload {
+  npm_allowed_scopes?: string[];
+  npm_allowed_name_patterns?: string[];
+  npm_allow_unscoped?: boolean;
+}
+
+export function buildNpmScopePolicyFields(
+  value: NpmScopePolicyValue,
+): NpmScopePolicyFieldsPayload {
+  return {
+    npm_allowed_scopes: parseList(value.npm_allowed_scopes),
+    npm_allowed_name_patterns: parseList(value.npm_allowed_name_patterns),
+    npm_allow_unscoped: value.npm_allow_unscoped,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Field groups
+// ---------------------------------------------------------------------------
+
+interface RpmTrustedKeyFieldProps {
+  value: RpmConfigValue;
+  onChange: (next: RpmConfigValue) => void;
+  idPrefix: string;
+  /** Whether a trusted key is already stored (never the key material itself). */
+  hasExistingKey?: boolean;
+  /** When provided and a key exists, renders a "Remove" control (edit only). */
+  onRemove?: () => void;
+  removePending?: boolean;
+}
+
+/**
+ * RPM curation *trusted* GPG key (#2568). This is the upstream public key used
+ * to verify a proxied RPM remote's `repomd.xml.asc` — NOT a server-side signing
+ * key. The key is write-only server-side: the response exposes only the
+ * `has_trusted_gpg_key` boolean, so the textarea always starts empty and a
+ * stored key is surfaced via `hasExistingKey`.
+ */
+export function RpmTrustedKeyField({
+  value,
+  onChange,
+  idPrefix,
+  hasExistingKey = false,
+  onRemove,
+  removePending = false,
+}: RpmTrustedKeyFieldProps) {
+  const id = `${idPrefix}-rpm-gpg-key`;
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={id}>Trusted GPG Public Key</Label>
+      <p className="text-xs text-muted-foreground">
+        ASCII-armored OpenPGP <strong>public</strong> key trusted to sign this
+        RPM remote&apos;s repository metadata (<code>repomd.xml</code>). When
+        set, curation sync verifies the upstream signature before ingesting.
+        This is the proxy-verification trusted key, not a server-side signing
+        key.
+      </p>
+      {hasExistingKey && (
+        <div
+          className="flex items-center justify-between rounded border border-muted bg-muted/30 p-2"
+          data-testid={`${idPrefix}-rpm-gpg-status`}
+        >
+          <p className="text-xs text-muted-foreground">
+            A trusted key is configured. Entering a new key below replaces it.
+          </p>
+          {onRemove && (
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              disabled={removePending}
+              onClick={onRemove}
+            >
+              {removePending ? "Removing..." : "Remove"}
+            </Button>
+          )}
+        </div>
+      )}
+      <Textarea
+        id={id}
+        placeholder="-----BEGIN PGP PUBLIC KEY BLOCK-----&#10;..."
+        value={value.trusted_gpg_key}
+        onChange={(e) => onChange({ trusted_gpg_key: e.target.value })}
+        rows={4}
+        className="font-mono text-xs"
+        autoComplete="off"
+        spellCheck={false}
+      />
+    </div>
+  );
+}
+
+interface DebianConfigFieldsProps {
+  value: DebianConfigValue;
+  onChange: (next: DebianConfigValue) => void;
+  idPrefix: string;
+}
+
+/**
+ * Advanced Debian/APT configuration (#2407/#2460/#2489/#2459): the proxy
+ * distro/component/architecture filter allowlists plus the `Release`-file
+ * metadata (Origin, Label, Version, Description).
+ */
+export function DebianConfigFields({
+  value,
+  onChange,
+  idPrefix,
+}: DebianConfigFieldsProps) {
+  const set = (patch: Partial<DebianConfigValue>) =>
+    onChange({ ...value, ...patch });
+  const fid = (name: string) => `${idPrefix}-debian-${name}`;
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-3">
+        <p className="text-xs font-medium text-muted-foreground">
+          Proxy filters
+        </p>
+        <p className="text-xs text-muted-foreground">
+          Comma-separated allowlists for a Debian proxy. Leave empty (or use{" "}
+          <code>*</code>) to proxy everything. Architecture-independent{" "}
+          (<code>all</code>) packages are always permitted.
+        </p>
+        <div className="space-y-2">
+          <Label htmlFor={fid("distributions")}>
+            Distributions (suites / codenames)
+          </Label>
+          <Input
+            id={fid("distributions")}
+            placeholder="bookworm, bullseye"
+            value={value.distribution_paths}
+            onChange={(e) => set({ distribution_paths: e.target.value })}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor={fid("components")}>Components</Label>
+          <Input
+            id={fid("components")}
+            placeholder="main, contrib, non-free"
+            value={value.components}
+            onChange={(e) => set({ components: e.target.value })}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor={fid("architectures")}>Architectures</Label>
+          <Input
+            id={fid("architectures")}
+            placeholder="amd64, arm64"
+            value={value.architectures}
+            onChange={(e) => set({ architectures: e.target.value })}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <p className="text-xs font-medium text-muted-foreground">
+          Release metadata
+        </p>
+        <p className="text-xs text-muted-foreground">
+          Optional fields written into generated <code>Release</code> files.
+        </p>
+        <div className="space-y-2">
+          <Label htmlFor={fid("origin")}>Origin</Label>
+          <Input
+            id={fid("origin")}
+            placeholder="artifact-keeper"
+            value={value.apt_origin}
+            onChange={(e) => set({ apt_origin: e.target.value })}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor={fid("label")}>Label</Label>
+          <Input
+            id={fid("label")}
+            placeholder="artifact-keeper"
+            value={value.apt_label}
+            onChange={(e) => set({ apt_label: e.target.value })}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor={fid("version")}>Version</Label>
+          <Input
+            id={fid("version")}
+            placeholder="1.0"
+            value={value.apt_release_version}
+            onChange={(e) => set({ apt_release_version: e.target.value })}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor={fid("description")}>Description</Label>
+          <Input
+            id={fid("description")}
+            placeholder="Internal Debian mirror"
+            value={value.apt_description}
+            onChange={(e) => set({ apt_description: e.target.value })}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface NpmScopePolicyFieldsProps {
+  value: NpmScopePolicyValue;
+  onChange: (next: NpmScopePolicyValue) => void;
+  idPrefix: string;
+}
+
+/**
+ * npm scope policy (#2424): the set of `@scope` literals / name globs that may
+ * resolve through this npm repository, plus whether bare (unscoped) names are
+ * allowed at all. Used for npm virtual/remote repos to constrain which packages
+ * the aggregate serves.
+ */
+export function NpmScopePolicyFields({
+  value,
+  onChange,
+  idPrefix,
+}: NpmScopePolicyFieldsProps) {
+  const set = (patch: Partial<NpmScopePolicyValue>) =>
+    onChange({ ...value, ...patch });
+  const scopesId = `${idPrefix}-npm-scopes`;
+  const patternsId = `${idPrefix}-npm-patterns`;
+  const unscopedId = `${idPrefix}-npm-unscoped`;
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor={scopesId}>Allowed scopes</Label>
+        <Textarea
+          id={scopesId}
+          placeholder="@acme, @internal"
+          value={value.npm_allowed_scopes}
+          onChange={(e) => set({ npm_allowed_scopes: e.target.value })}
+          rows={2}
+        />
+        <p className="text-xs text-muted-foreground">
+          Comma or newline-separated <code>@scope</code> literals. Empty leaves
+          the repository unrestricted by scope.
+        </p>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor={patternsId}>Allowed name patterns</Label>
+        <Textarea
+          id={patternsId}
+          placeholder="@acme*, internal-*"
+          value={value.npm_allowed_name_patterns}
+          onChange={(e) => set({ npm_allowed_name_patterns: e.target.value })}
+          rows={2}
+        />
+        <p className="text-xs text-muted-foreground">
+          Additive glob patterns (<code>*</code>/<code>?</code>). A name is
+          allowed if its scope is allowed OR any pattern matches.
+        </p>
+      </div>
+      <div className="flex items-center justify-between">
+        <div className="space-y-0.5">
+          <Label htmlFor={unscopedId}>Allow unscoped names</Label>
+          <p className="text-xs text-muted-foreground">
+            Permit bare (non-<code>@scope</code>) package names to resolve.
+          </p>
+        </div>
+        <Switch
+          id={unscopedId}
+          checked={value.npm_allow_unscoped}
+          onCheckedChange={(v) => set({ npm_allow_unscoped: v })}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/repositories/_components/repo-dialogs.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-dialogs.test.tsx
@@ -1777,3 +1777,132 @@ describe('RepoDialogs - Upstream Auth Edge Cases', () => {
     expect(within(dialog).getByRole('button', { name: /^change$/i })).toBeTruthy();
   });
 });
+
+describe('RepoDialogs - 1.6.0 format-specific config (#602)', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('does not show format-specific sections for a generic repo', () => {
+    render(<RepoDialogs {...defaultProps} />);
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).queryByLabelText(/trusted gpg public key/i)).toBeNull();
+    expect(within(dialog).queryByText('Debian / APT Configuration')).toBeNull();
+    expect(within(dialog).queryByText('npm Scope Policy')).toBeNull();
+  });
+
+  it('shows the RPM trusted GPG key field for rpm format and submits it', async () => {
+    const onCreateSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(<RepoDialogs {...defaultProps} onCreateSubmit={onCreateSubmit} />);
+
+    const dialog = screen.getByRole('dialog');
+    await user.type(within(dialog).getByPlaceholderText('my-repo'), 'rpm-repo');
+    await user.type(within(dialog).getByPlaceholderText('My Repository'), 'RPM Repo');
+
+    // Format select is index 0
+    fireEvent.change(within(dialog).getAllByTestId('mock-select')[0], {
+      target: { value: 'rpm' },
+    });
+
+    const keyField = within(dialog).getByLabelText(/trusted gpg public key/i);
+    await user.type(keyField, 'PUBKEYDATA');
+
+    await user.click(within(dialog).getByRole('button', { name: /^create$/i }));
+
+    expect(onCreateSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        format: 'rpm',
+        trusted_gpg_key: 'PUBKEYDATA',
+      })
+    );
+  });
+
+  it('does not include trusted_gpg_key when left blank', async () => {
+    const onCreateSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(<RepoDialogs {...defaultProps} onCreateSubmit={onCreateSubmit} />);
+
+    const dialog = screen.getByRole('dialog');
+    await user.type(within(dialog).getByPlaceholderText('my-repo'), 'rpm-blank');
+    await user.type(within(dialog).getByPlaceholderText('My Repository'), 'RPM Blank');
+    fireEvent.change(within(dialog).getAllByTestId('mock-select')[0], {
+      target: { value: 'rpm' },
+    });
+
+    await user.click(within(dialog).getByRole('button', { name: /^create$/i }));
+
+    const submitData = onCreateSubmit.mock.calls[0][0];
+    expect(submitData.trusted_gpg_key).toBeUndefined();
+  });
+
+  it('shows Debian config and submits apt metadata + filter arrays', async () => {
+    const onCreateSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(<RepoDialogs {...defaultProps} onCreateSubmit={onCreateSubmit} />);
+
+    const dialog = screen.getByRole('dialog');
+    await user.type(within(dialog).getByPlaceholderText('my-repo'), 'deb-repo');
+    await user.type(within(dialog).getByPlaceholderText('My Repository'), 'Deb Repo');
+    fireEvent.change(within(dialog).getAllByTestId('mock-select')[0], {
+      target: { value: 'debian' },
+    });
+
+    expect(within(dialog).getByText('Debian / APT Configuration')).toBeTruthy();
+
+    await user.type(within(dialog).getByLabelText(/^origin$/i), 'acme');
+    await user.type(
+      within(dialog).getByLabelText(/distributions/i),
+      'bookworm, bullseye'
+    );
+
+    await user.click(within(dialog).getByRole('button', { name: /^create$/i }));
+
+    expect(onCreateSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        format: 'debian',
+        apt_origin: 'acme',
+        debian: expect.objectContaining({
+          distribution_paths: ['bookworm', 'bullseye'],
+        }),
+      })
+    );
+  });
+
+  it('shows npm scope policy only for npm virtual/remote and submits it', async () => {
+    const onCreateSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(<RepoDialogs {...defaultProps} onCreateSubmit={onCreateSubmit} />);
+
+    const dialog = screen.getByRole('dialog');
+    await user.type(within(dialog).getByPlaceholderText('my-repo'), 'npm-virt');
+    await user.type(within(dialog).getByPlaceholderText('My Repository'), 'NPM Virtual');
+
+    // npm + local => hidden
+    fireEvent.change(within(dialog).getAllByTestId('mock-select')[0], {
+      target: { value: 'npm' },
+    });
+    expect(within(dialog).queryByText('npm Scope Policy')).toBeNull();
+
+    // switch to virtual => shown
+    fireEvent.change(within(dialog).getAllByTestId('mock-select')[1], {
+      target: { value: 'virtual' },
+    });
+    expect(within(dialog).getByText('npm Scope Policy')).toBeTruthy();
+
+    await user.type(within(dialog).getByLabelText(/allowed scopes/i), '@acme');
+    await user.click(within(dialog).getByRole('switch', { name: /allow unscoped names/i }));
+
+    await user.click(within(dialog).getByRole('button', { name: /^create$/i }));
+
+    expect(onCreateSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        format: 'npm',
+        repo_type: 'virtual',
+        npm_allowed_scopes: ['@acme'],
+        npm_allow_unscoped: true,
+      })
+    );
+  });
+});

--- a/src/app/(app)/repositories/_components/repo-dialogs.tsx
+++ b/src/app/(app)/repositories/_components/repo-dialogs.tsx
@@ -2,7 +2,13 @@
 
 import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import type { Repository, CreateRepositoryRequest, RepositoryFormat, RepositoryType, VirtualRepoMemberInput } from "@/types";
-import { FORMAT_OPTIONS, TYPE_OPTIONS } from "../_lib/constants";
+import {
+  FORMAT_OPTIONS,
+  TYPE_OPTIONS,
+  hasRpmTrustedKeyConfig,
+  hasDebianConfig,
+  hasNpmScopePolicy,
+} from "../_lib/constants";
 import { DEFAULT_UPSTREAM_URLS } from "../_lib/default-upstream-urls";
 
 // Alphabetised copy of FORMAT_OPTIONS for the create dialog's flat dropdown.
@@ -34,6 +40,20 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
+import {
+  RpmTrustedKeyField,
+  DebianConfigFields,
+  NpmScopePolicyFields,
+  buildRpmConfigFields,
+  buildDebianConfigFields,
+  buildNpmScopePolicyFields,
+  EMPTY_RPM_CONFIG,
+  EMPTY_DEBIAN_CONFIG,
+  EMPTY_NPM_SCOPE_POLICY,
+  type RpmConfigValue,
+  type DebianConfigValue,
+  type NpmScopePolicyValue,
+} from "./format-config-fields";
 
 type QuotaUnit = "MB" | "GB";
 
@@ -128,6 +148,14 @@ export function RepoDialogs({
   const [upstreamAuthType, setUpstreamAuthType] = useState<string>("none");
   const [upstreamUsername, setUpstreamUsername] = useState("");
   const [upstreamPassword, setUpstreamPassword] = useState("");
+
+  // 1.6.0 format-specific config state for the create dialog (#602).
+  const [rpmConfig, setRpmConfig] = useState<RpmConfigValue>(EMPTY_RPM_CONFIG);
+  const [debianConfig, setDebianConfig] =
+    useState<DebianConfigValue>(EMPTY_DEBIAN_CONFIG);
+  const [npmScopePolicy, setNpmScopePolicy] = useState<NpmScopePolicyValue>(
+    EMPTY_NPM_SCOPE_POLICY,
+  );
 
   /**
    * Suggest a default upstream URL when the repo type is "remote".
@@ -237,6 +265,9 @@ export function RepoDialogs({
     setUpstreamAuthType("none");
     setUpstreamUsername("");
     setUpstreamPassword("");
+    setRpmConfig(EMPTY_RPM_CONFIG);
+    setDebianConfig(EMPTY_DEBIAN_CONFIG);
+    setNpmScopePolicy(EMPTY_NPM_SCOPE_POLICY);
   };
 
   // Reset the create form whenever the dialog opens. The parent flips
@@ -294,6 +325,20 @@ export function RepoDialogs({
                   submitData.upstream_username = upstreamUsername;
                 }
                 submitData.upstream_password = upstreamPassword;
+              }
+              // 1.6.0 format-specific config (#602): attach only the group that
+              // matches the selected format so other formats send nothing.
+              if (hasRpmTrustedKeyConfig(createForm.format)) {
+                Object.assign(submitData, buildRpmConfigFields(rpmConfig));
+              } else if (hasDebianConfig(createForm.format)) {
+                Object.assign(submitData, buildDebianConfigFields(debianConfig));
+              } else if (
+                hasNpmScopePolicy(createForm.format, createForm.repo_type)
+              ) {
+                Object.assign(
+                  submitData,
+                  buildNpmScopePolicyFields(npmScopePolicy),
+                );
               }
               onCreateSubmit(submitData);
             }}
@@ -520,6 +565,41 @@ export function RepoDialogs({
                 <p className="text-xs text-muted-foreground">
                   Select repositories to aggregate. Order determines priority.
                 </p>
+              </div>
+            )}
+
+            {/* RPM curation trusted GPG key (#2568) */}
+            {hasRpmTrustedKeyConfig(createForm.format) && (
+              <div className="space-y-3 border-t pt-4">
+                <RpmTrustedKeyField
+                  idPrefix="create"
+                  value={rpmConfig}
+                  onChange={setRpmConfig}
+                />
+              </div>
+            )}
+
+            {/* Advanced Debian/APT config (#2407/#2460/#2489/#2459) */}
+            {hasDebianConfig(createForm.format) && (
+              <div className="space-y-3 border-t pt-4">
+                <Label>Debian / APT Configuration</Label>
+                <DebianConfigFields
+                  idPrefix="create"
+                  value={debianConfig}
+                  onChange={setDebianConfig}
+                />
+              </div>
+            )}
+
+            {/* npm scope policy (#2424) */}
+            {hasNpmScopePolicy(createForm.format, createForm.repo_type) && (
+              <div className="space-y-3 border-t pt-4">
+                <Label>npm Scope Policy</Label>
+                <NpmScopePolicyFields
+                  idPrefix="create"
+                  value={npmScopePolicy}
+                  onChange={setNpmScopePolicy}
+                />
               </div>
             )}
 

--- a/src/app/(app)/repositories/_components/repo-settings-tab.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-settings-tab.test.tsx
@@ -1252,3 +1252,200 @@ describe("RepoSettingsTab - Artifact Versioning Section (#571)", () => {
     expect(mockUpdate).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// 1.6.0 format-specific config sections (#602)
+// ---------------------------------------------------------------------------
+
+const rpmRepo: Repository = {
+  ...baseRepo,
+  id: "repo-rpm",
+  key: "rpm-proxy",
+  name: "RPM Proxy",
+  format: "rpm",
+  repo_type: "remote",
+  upstream_url: "https://mirror.example.com",
+  has_trusted_gpg_key: false,
+};
+
+const debianRepo: Repository = {
+  ...baseRepo,
+  id: "repo-deb",
+  key: "deb-proxy",
+  name: "Deb Proxy",
+  format: "debian",
+  repo_type: "remote",
+  upstream_url: "https://deb.example.com",
+  apt_origin: "acme",
+  apt_label: "Acme Mirror",
+  debian: {
+    distribution_paths: ["bookworm"],
+    components: ["main"],
+    architectures: ["amd64"],
+  },
+};
+
+const npmVirtualRepo: Repository = {
+  ...baseRepo,
+  id: "repo-npm",
+  key: "npm-virt",
+  name: "NPM Virtual",
+  format: "npm",
+  repo_type: "virtual",
+  npm_allowed_scopes: ["@acme"],
+  npm_allow_unscoped: false,
+};
+
+describe("RepoSettingsTab - 1.6.0 format-specific config (#602)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListPolicies.mockResolvedValue([]);
+    mockGetCacheTtl.mockResolvedValue({
+      repository_key: "x",
+      cache_ttl_seconds: 86400,
+    });
+  });
+
+  it("hides all format-specific sections for a plain maven repo", () => {
+    render(<RepoSettingsTab repository={baseRepo} />, {
+      wrapper: createWrapper(),
+    });
+    expect(screen.queryByText("RPM Curation Trust")).toBeNull();
+    expect(screen.queryByText("Debian / APT Configuration")).toBeNull();
+    expect(screen.queryByText("npm Scope Policy")).toBeNull();
+  });
+
+  it("shows the RPM section and saves a typed trusted key", async () => {
+    mockUpdate.mockResolvedValue({ ...rpmRepo, has_trusted_gpg_key: true });
+    const user = userEvent.setup();
+    render(<RepoSettingsTab repository={rpmRepo} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByText("RPM Curation Trust")).toBeTruthy();
+    await user.type(
+      screen.getByLabelText(/trusted gpg public key/i),
+      "NEWKEY"
+    );
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith(
+        "rpm-proxy",
+        expect.objectContaining({ trusted_gpg_key: "NEWKEY" })
+      );
+    });
+  });
+
+  it("clears the trusted key via Remove and saves null", async () => {
+    mockUpdate.mockResolvedValue({ ...rpmRepo, has_trusted_gpg_key: false });
+    const user = userEvent.setup();
+    render(
+      <RepoSettingsTab
+        repository={{ ...rpmRepo, has_trusted_gpg_key: true }}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    await user.click(screen.getByRole("button", { name: /^remove$/i }));
+    expect(
+      screen.getByText(/trusted key will be removed when you save/i)
+    ).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith(
+        "rpm-proxy",
+        expect.objectContaining({ trusted_gpg_key: null })
+      );
+    });
+  });
+
+  it("undoes a pending key removal", async () => {
+    const user = userEvent.setup();
+    render(
+      <RepoSettingsTab
+        repository={{ ...rpmRepo, has_trusted_gpg_key: true }}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    await user.click(screen.getByRole("button", { name: /^remove$/i }));
+    await user.click(screen.getByRole("button", { name: /^undo$/i }));
+    expect(
+      screen.queryByText(/trusted key will be removed when you save/i)
+    ).toBeNull();
+    // No pending change -> no unsaved-changes bar.
+    expect(screen.queryByText("You have unsaved changes")).toBeNull();
+  });
+
+  it("prefills and saves Debian config", async () => {
+    mockUpdate.mockResolvedValue(debianRepo);
+    const user = userEvent.setup();
+    render(<RepoSettingsTab repository={debianRepo} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByText("Debian / APT Configuration")).toBeTruthy();
+    expect(
+      (screen.getByLabelText(/^origin$/i) as HTMLInputElement).value
+    ).toBe("acme");
+    expect(
+      (screen.getByLabelText(/distributions/i) as HTMLInputElement).value
+    ).toBe("bookworm");
+
+    const compInput = screen.getByLabelText(/^components$/i);
+    await user.clear(compInput);
+    await user.type(compInput, "main, contrib");
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith(
+        "deb-proxy",
+        expect.objectContaining({
+          apt_origin: "acme",
+          debian: expect.objectContaining({
+            components: ["main", "contrib"],
+            distribution_paths: ["bookworm"],
+          }),
+        })
+      );
+    });
+  });
+
+  it("prefills and saves npm scope policy", async () => {
+    mockUpdate.mockResolvedValue(npmVirtualRepo);
+    const user = userEvent.setup();
+    render(<RepoSettingsTab repository={npmVirtualRepo} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByText("npm Scope Policy")).toBeTruthy();
+    expect(
+      (screen.getByLabelText(/allowed scopes/i) as HTMLTextAreaElement).value
+    ).toBe("@acme");
+
+    await user.click(screen.getByLabelText("Allow unscoped names"));
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith(
+        "npm-virt",
+        expect.objectContaining({
+          npm_allowed_scopes: ["@acme"],
+          npm_allow_unscoped: true,
+        })
+      );
+    });
+  });
+
+  it("does not show the npm section for an npm local repo", () => {
+    render(
+      <RepoSettingsTab
+        repository={{ ...npmVirtualRepo, repo_type: "local" }}
+      />,
+      { wrapper: createWrapper() }
+    );
+    expect(screen.queryByText("npm Scope Policy")).toBeNull();
+  });
+});

--- a/src/app/(app)/repositories/_components/repo-settings-tab.tsx
+++ b/src/app/(app)/repositories/_components/repo-settings-tab.tsx
@@ -11,12 +11,33 @@ import { useAdminSettings } from "@/hooks/use-admin-settings";
 import lifecycleApi from "@/lib/api/lifecycle";
 import { mutationErrorToast } from "@/lib/error-utils";
 import { formatBytes } from "@/lib/utils";
-import type { Repository } from "@/types";
+import type {
+  Repository,
+  DebianRepoConfig,
+  CreateRepositoryRequest,
+} from "@/types";
 import type { LifecyclePolicy, PolicyType } from "@/types/lifecycle";
 import { POLICY_TYPE_LABELS } from "@/types/lifecycle";
 import { quotaToBytes, bytesToQuota } from "./repo-dialogs";
+import {
+  hasRpmTrustedKeyConfig,
+  hasDebianConfig,
+  hasNpmScopePolicy,
+} from "../_lib/constants";
 import { ReleaseTargetSettings } from "./release-target-settings";
 import { RoutingRulesSettings } from "./routing-rules-settings";
+import {
+  RpmTrustedKeyField,
+  DebianConfigFields,
+  NpmScopePolicyFields,
+  buildDebianConfigFields,
+  buildNpmScopePolicyFields,
+  formatList,
+  EMPTY_RPM_CONFIG,
+  type RpmConfigValue,
+  type DebianConfigValue,
+  type NpmScopePolicyValue,
+} from "./format-config-fields";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -104,21 +125,26 @@ export interface UpdateRepositoryFields {
   quota_bytes?: number | null;
   /** First-class artifact versioning opt-in (#571, Generic/Mlmodel only). */
   versioning_enabled?: boolean;
+  // --- 1.6.0 format-specific config (#602) ---
+  /** RPM curation trusted GPG key (#2568): string to set, `null` to clear. */
+  trusted_gpg_key?: string | null;
+  apt_origin?: string;
+  apt_label?: string;
+  apt_release_version?: string;
+  apt_description?: string;
+  debian?: DebianRepoConfig;
+  npm_allowed_scopes?: string[];
+  npm_allowed_name_patterns?: string[];
+  npm_allow_unscoped?: boolean;
 }
 
 /** Convert UpdateRepositoryFields to the shape repositoriesApi.update expects. */
 function toUpdatePayload(
   fields: UpdateRepositoryFields
-): Partial<{
-  key: string;
-  name: string;
-  description: string;
-  is_public: boolean;
-  quota_bytes: number;
-  versioning_enabled: boolean;
-}> {
+): Partial<CreateRepositoryRequest> {
   const { quota_bytes, ...rest } = fields;
-  // The SDK type does not accept null for quota_bytes, so strip it.
+  // The SDK type does not accept null for quota_bytes, so strip it. A `null`
+  // trusted_gpg_key IS preserved (three-way clear semantics, #2568).
   if (quota_bytes != null) {
     return { ...rest, quota_bytes };
   }
@@ -162,6 +188,73 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
   }>({});
   const quotaValue = quotaOverrides.value ?? quotaDefaults.value;
   const quotaUnit = quotaOverrides.unit ?? quotaDefaults.unit;
+
+  // -- 1.6.0 format-specific config (#602) --
+  const isRpm = hasRpmTrustedKeyConfig(repository.format);
+  const isDebian = hasDebianConfig(repository.format);
+  const isNpmScoped = hasNpmScopePolicy(
+    repository.format,
+    repository.repo_type
+  );
+
+  // RPM trusted GPG key (#2568). The key is write-only: the textarea always
+  // starts empty and a stored key surfaces via `has_trusted_gpg_key`. Typing a
+  // key replaces it; toggling "remove" clears it (three-way semantics).
+  const [rpmConfig, setRpmConfig] = useState<RpmConfigValue>(EMPTY_RPM_CONFIG);
+  const [rpmClear, setRpmClear] = useState(false);
+  const rpmKeyTyped = rpmConfig.trusted_gpg_key.trim().length > 0;
+  const rpmChanged = isRpm && (rpmKeyTyped || rpmClear);
+
+  // Debian/APT config (#2407/#2460/#2489/#2459), override-based like the
+  // general fields so a repository prop change re-seeds the defaults.
+  const debianDefaults = useMemo<DebianConfigValue>(
+    () => ({
+      apt_origin: repository.apt_origin ?? "",
+      apt_label: repository.apt_label ?? "",
+      apt_release_version: repository.apt_release_version ?? "",
+      apt_description: repository.apt_description ?? "",
+      distribution_paths: formatList(repository.debian?.distribution_paths),
+      components: formatList(repository.debian?.components),
+      architectures: formatList(repository.debian?.architectures),
+    }),
+    [repository]
+  );
+  const [debianOverrides, setDebianOverrides] = useState<
+    Partial<DebianConfigValue>
+  >({});
+  const debianConfig = useMemo(
+    () => ({ ...debianDefaults, ...debianOverrides }),
+    [debianDefaults, debianOverrides]
+  );
+  const debianChanged =
+    isDebian &&
+    (Object.keys(debianConfig) as (keyof DebianConfigValue)[]).some(
+      (k) => debianConfig[k] !== debianDefaults[k]
+    );
+
+  // npm scope policy (#2424).
+  const npmDefaults = useMemo<NpmScopePolicyValue>(
+    () => ({
+      npm_allowed_scopes: formatList(repository.npm_allowed_scopes),
+      npm_allowed_name_patterns: formatList(
+        repository.npm_allowed_name_patterns
+      ),
+      npm_allow_unscoped: repository.npm_allow_unscoped ?? false,
+    }),
+    [repository]
+  );
+  const [npmOverrides, setNpmOverrides] = useState<
+    Partial<NpmScopePolicyValue>
+  >({});
+  const npmScopePolicy = useMemo(
+    () => ({ ...npmDefaults, ...npmOverrides }),
+    [npmDefaults, npmOverrides]
+  );
+  const npmChanged =
+    isNpmScoped &&
+    (Object.keys(npmScopePolicy) as (keyof NpmScopePolicyValue)[]).some(
+      (k) => npmScopePolicy[k] !== npmDefaults[k]
+    );
 
   // -- Proxy cache TTL state (#448) --
   // Only meaningful for Remote (proxy) repos; the section is hidden for
@@ -211,8 +304,18 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
     const originalQuotaBytes = repository.quota_bytes ?? null;
     if (currentQuotaBytes !== originalQuotaBytes) return true;
     if (cacheTtlChanged) return true;
+    if (rpmChanged || debianChanged || npmChanged) return true;
     return false;
-  }, [form, quotaValue, quotaUnit, repository, cacheTtlChanged]);
+  }, [
+    form,
+    quotaValue,
+    quotaUnit,
+    repository,
+    cacheTtlChanged,
+    rpmChanged,
+    debianChanged,
+    npmChanged,
+  ]);
 
   // -- Save mutation --
   const saveMutation = useMutation({
@@ -227,6 +330,12 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
       }
       setOverrides({});
       setQuotaOverrides({});
+      // Reset 1.6.0 format-specific config editors (#602). The RPM key is
+      // write-only, so the textarea always returns to empty after a save.
+      setRpmConfig(EMPTY_RPM_CONFIG);
+      setRpmClear(false);
+      setDebianOverrides({});
+      setNpmOverrides({});
       toast.success("Repository settings saved");
     },
     onError: mutationErrorToast("Failed to save repository settings"),
@@ -268,6 +377,20 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
       fields.quota_bytes = newQuota;
     }
 
+    // 1.6.0 format-specific config (#602). RPM key uses three-way semantics:
+    // a typed key replaces, an explicit remove clears (null), else unchanged.
+    if (isRpm) {
+      const typedKey = rpmConfig.trusted_gpg_key.trim();
+      if (typedKey) fields.trusted_gpg_key = typedKey;
+      else if (rpmClear) fields.trusted_gpg_key = null;
+    }
+    if (isDebian && debianChanged) {
+      Object.assign(fields, buildDebianConfigFields(debianConfig));
+    }
+    if (isNpmScoped && npmChanged) {
+      Object.assign(fields, buildNpmScopePolicyFields(npmScopePolicy));
+    }
+
     const promises: Promise<unknown>[] = [];
     if (Object.keys(fields).length > 0) {
       promises.push(saveMutation.mutateAsync(fields));
@@ -290,12 +413,25 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
     cacheTtlIsValid,
     parsedCacheTtl,
     setCacheTtlMutation,
+    isRpm,
+    rpmConfig,
+    rpmClear,
+    isDebian,
+    debianChanged,
+    debianConfig,
+    isNpmScoped,
+    npmChanged,
+    npmScopePolicy,
   ]);
 
   const handleDiscard = useCallback(() => {
     setOverrides({});
     setQuotaOverrides({});
     setCacheTtlOverride(undefined);
+    setRpmConfig(EMPTY_RPM_CONFIG);
+    setRpmClear(false);
+    setDebianOverrides({});
+    setNpmOverrides({});
   }, []);
 
   // -- Lifecycle policies --
@@ -592,6 +728,97 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
             </div>
           </section>
 
+          <Separator />
+        </>
+      )}
+
+      {/* -- RPM Curation Trust Section (#2568, RPM only) -- */}
+      {isRpm && (
+        <>
+          <section aria-labelledby="settings-rpm-heading">
+            <div className="mb-4">
+              <h3 id="settings-rpm-heading" className="text-base font-semibold">
+                RPM Curation Trust
+              </h3>
+            </div>
+            <RpmTrustedKeyField
+              idPrefix="settings"
+              value={rpmConfig}
+              onChange={setRpmConfig}
+              hasExistingKey={
+                (repository.has_trusted_gpg_key ?? false) && !rpmClear
+              }
+              onRemove={
+                repository.has_trusted_gpg_key
+                  ? () => setRpmClear(true)
+                  : undefined
+              }
+            />
+            {rpmClear && (
+              <div className="mt-2 flex items-center justify-between rounded border border-destructive/40 bg-destructive/5 p-2">
+                <p className="text-xs text-destructive">
+                  Trusted key will be removed when you save.
+                </p>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setRpmClear(false)}
+                >
+                  Undo
+                </Button>
+              </div>
+            )}
+          </section>
+          <Separator />
+        </>
+      )}
+
+      {/* -- Debian/APT Section (#2407/#2460/#2489/#2459, Debian only) -- */}
+      {isDebian && (
+        <>
+          <section aria-labelledby="settings-debian-heading">
+            <div className="mb-4">
+              <h3
+                id="settings-debian-heading"
+                className="text-base font-semibold"
+              >
+                Debian / APT Configuration
+              </h3>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Proxy distro/component/architecture filters and Release-file
+                metadata.
+              </p>
+            </div>
+            <DebianConfigFields
+              idPrefix="settings"
+              value={debianConfig}
+              onChange={(v) => setDebianOverrides(v)}
+            />
+          </section>
+          <Separator />
+        </>
+      )}
+
+      {/* -- npm Scope Policy Section (#2424, npm remote/virtual only) -- */}
+      {isNpmScoped && (
+        <>
+          <section aria-labelledby="settings-npm-heading">
+            <div className="mb-4">
+              <h3 id="settings-npm-heading" className="text-base font-semibold">
+                npm Scope Policy
+              </h3>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Restrict which npm scopes and names resolve through this
+                repository.
+              </p>
+            </div>
+            <NpmScopePolicyFields
+              idPrefix="settings"
+              value={npmScopePolicy}
+              onChange={(v) => setNpmOverrides(v)}
+            />
+          </section>
           <Separator />
         </>
       )}

--- a/src/app/(app)/repositories/_lib/constants.test.ts
+++ b/src/app/(app)/repositories/_lib/constants.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { TYPE_OPTIONS, FORMAT_OPTIONS, FORMAT_GROUPS } from './constants';
+import {
+  TYPE_OPTIONS,
+  FORMAT_OPTIONS,
+  FORMAT_GROUPS,
+  hasRpmTrustedKeyConfig,
+  hasDebianConfig,
+  hasNpmScopePolicy,
+} from './constants';
 
 describe('TYPE_OPTIONS', () => {
   it('includes staging type', () => {
@@ -40,5 +47,27 @@ describe('FORMAT_GROUPS', () => {
       0
     );
     expect(totalFromGroups).toBe(FORMAT_OPTIONS.length);
+  });
+});
+
+describe('1.6.0 format-specific config gating (#602)', () => {
+  it('hasRpmTrustedKeyConfig only for rpm', () => {
+    expect(hasRpmTrustedKeyConfig('rpm')).toBe(true);
+    expect(hasRpmTrustedKeyConfig('debian')).toBe(false);
+    expect(hasRpmTrustedKeyConfig('npm')).toBe(false);
+  });
+
+  it('hasDebianConfig only for debian', () => {
+    expect(hasDebianConfig('debian')).toBe(true);
+    expect(hasDebianConfig('rpm')).toBe(false);
+    expect(hasDebianConfig('generic')).toBe(false);
+  });
+
+  it('hasNpmScopePolicy only for npm remote/virtual', () => {
+    expect(hasNpmScopePolicy('npm', 'virtual')).toBe(true);
+    expect(hasNpmScopePolicy('npm', 'remote')).toBe(true);
+    expect(hasNpmScopePolicy('npm', 'local')).toBe(false);
+    expect(hasNpmScopePolicy('npm', 'staging')).toBe(false);
+    expect(hasNpmScopePolicy('maven', 'virtual')).toBe(false);
   });
 });

--- a/src/app/(app)/repositories/_lib/constants.ts
+++ b/src/app/(app)/repositories/_lib/constants.ts
@@ -77,3 +77,29 @@ export const TYPE_OPTIONS: { value: RepositoryType; label: string }[] = [
   { value: "remote", label: "Remote" },
   { value: "virtual", label: "Virtual" },
 ];
+
+// ---------------------------------------------------------------------------
+// 1.6.0 format-specific config gating (#602)
+//
+// Centralised predicates so the create dialog and the settings tab show the
+// same sections for the same repositories. Each maps to a distinct backend
+// feature; see `format-config-fields.tsx` for the field groups themselves.
+// ---------------------------------------------------------------------------
+
+/** RPM curation trusted GPG key (#2568) — RPM-format repositories. */
+export function hasRpmTrustedKeyConfig(format: string): boolean {
+  return format === "rpm";
+}
+
+/** Advanced Debian/APT config (#2407/#2460/#2489/#2459) — Debian repos. */
+export function hasDebianConfig(format: string): boolean {
+  return format === "debian";
+}
+
+/**
+ * npm scope policy (#2424). Framed by #602 as the npm virtual-repo scope
+ * policy; the backend also reads it for npm remotes, so both types qualify.
+ */
+export function hasNpmScopePolicy(format: string, repoType: string): boolean {
+  return format === "npm" && (repoType === "virtual" || repoType === "remote");
+}

--- a/src/lib/api/__tests__/repositories.test.ts
+++ b/src/lib/api/__tests__/repositories.test.ts
@@ -736,6 +736,166 @@ describe("repositoriesApi.setReleaseTarget", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// 1.6.0 format-specific config (#602): RPM GPG (#2568), Debian (#2407…),
+// npm scope policy (#2424)
+// ---------------------------------------------------------------------------
+
+describe("repositoriesApi.create — 1.6.0 format config (#602)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("forwards the RPM trusted_gpg_key to the SDK create body", async () => {
+    mockCreateRepository.mockResolvedValue({
+      data: sdkRepo({ format: "rpm", has_trusted_gpg_key: true }),
+      error: undefined,
+    });
+    await repositoriesApi.create({
+      key: "rpm-proxy",
+      name: "RPM Proxy",
+      format: "rpm",
+      repo_type: "remote",
+      trusted_gpg_key: "-----BEGIN PGP PUBLIC KEY BLOCK-----",
+    });
+    const body = mockCreateRepository.mock.calls[0][0].body;
+    expect(body.trusted_gpg_key).toBe(
+      "-----BEGIN PGP PUBLIC KEY BLOCK-----"
+    );
+  });
+
+  it("forwards Debian apt_* + debian filter config", async () => {
+    mockCreateRepository.mockResolvedValue({
+      data: sdkRepo({ format: "debian" }),
+      error: undefined,
+    });
+    await repositoriesApi.create({
+      key: "deb-proxy",
+      name: "Deb Proxy",
+      format: "debian",
+      repo_type: "remote",
+      apt_origin: "acme",
+      apt_label: "Acme",
+      debian: { distribution_paths: ["bookworm"], components: ["main"], architectures: ["amd64"] },
+    });
+    const body = mockCreateRepository.mock.calls[0][0].body;
+    expect(body.apt_origin).toBe("acme");
+    expect(body.apt_label).toBe("Acme");
+    expect(body.debian).toEqual({
+      distribution_paths: ["bookworm"],
+      components: ["main"],
+      architectures: ["amd64"],
+    });
+  });
+
+  it("forwards npm scope policy fields", async () => {
+    mockCreateRepository.mockResolvedValue({
+      data: sdkRepo({ format: "npm", repo_type: "virtual" }),
+      error: undefined,
+    });
+    await repositoriesApi.create({
+      key: "npm-virt",
+      name: "NPM Virtual",
+      format: "npm",
+      repo_type: "virtual",
+      npm_allowed_scopes: ["@acme"],
+      npm_allowed_name_patterns: ["internal-*"],
+      npm_allow_unscoped: false,
+    });
+    const body = mockCreateRepository.mock.calls[0][0].body;
+    expect(body.npm_allowed_scopes).toEqual(["@acme"]);
+    expect(body.npm_allowed_name_patterns).toEqual(["internal-*"]);
+    expect(body.npm_allow_unscoped).toBe(false);
+  });
+});
+
+describe("repositoriesApi.update — 1.6.0 format config (#602)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("forwards a trusted_gpg_key string to set it", async () => {
+    mockUpdateRepository.mockResolvedValue({
+      data: sdkRepo({ format: "rpm", has_trusted_gpg_key: true }),
+      error: undefined,
+    });
+    await repositoriesApi.update("rpm-proxy", { trusted_gpg_key: "KEY" });
+    const body = mockUpdateRepository.mock.calls[0][0].body;
+    expect(body.trusted_gpg_key).toBe("KEY");
+  });
+
+  it("preserves an explicit null trusted_gpg_key (three-way clear)", async () => {
+    mockUpdateRepository.mockResolvedValue({
+      data: sdkRepo({ format: "rpm", has_trusted_gpg_key: false }),
+      error: undefined,
+    });
+    await repositoriesApi.update("rpm-proxy", { trusted_gpg_key: null });
+    const body = mockUpdateRepository.mock.calls[0][0].body;
+    expect(body.trusted_gpg_key).toBeNull();
+  });
+
+  it("forwards debian + npm config on update", async () => {
+    mockUpdateRepository.mockResolvedValue({
+      data: sdkRepo({ format: "npm", repo_type: "remote" }),
+      error: undefined,
+    });
+    await repositoriesApi.update("npm-remote", {
+      npm_allowed_scopes: ["@acme"],
+      npm_allow_unscoped: true,
+      debian: { components: ["main"] },
+    });
+    const body = mockUpdateRepository.mock.calls[0][0].body;
+    expect(body.npm_allowed_scopes).toEqual(["@acme"]);
+    expect(body.npm_allow_unscoped).toBe(true);
+    expect(body.debian).toEqual({ components: ["main"] });
+  });
+});
+
+describe("repositoriesApi adaptation of 1.6.0 config (#602)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("exposes has_trusted_gpg_key, apt_*, debian and npm fields from the response", async () => {
+    mockGetRepository.mockResolvedValue({
+      data: sdkRepo({
+        format: "debian",
+        has_trusted_gpg_key: true,
+        apt_origin: "acme",
+        apt_label: "Acme",
+        apt_release_version: "12",
+        apt_description: "internal",
+        debian: {
+          distribution_paths: ["bookworm"],
+          components: ["main"],
+          architectures: ["amd64"],
+        },
+        npm_allowed_scopes: ["@acme"],
+        npm_allowed_name_patterns: ["internal-*"],
+        npm_allow_unscoped: false,
+      }),
+      error: undefined,
+    });
+    const repo = await repositoriesApi.get("deb-proxy");
+    expect(repo.has_trusted_gpg_key).toBe(true);
+    expect(repo.apt_origin).toBe("acme");
+    expect(repo.apt_label).toBe("Acme");
+    expect(repo.apt_release_version).toBe("12");
+    expect(repo.apt_description).toBe("internal");
+    expect(repo.debian).toEqual({
+      distribution_paths: ["bookworm"],
+      components: ["main"],
+      architectures: ["amd64"],
+    });
+    expect(repo.npm_allowed_scopes).toEqual(["@acme"]);
+    expect(repo.npm_allowed_name_patterns).toEqual(["internal-*"]);
+    expect(repo.npm_allow_unscoped).toBe(false);
+  });
+
+  it("defaults has_trusted_gpg_key to false and leaves optional config undefined when omitted", async () => {
+    mockGetRepository.mockResolvedValue({ data: sdkRepo(), error: undefined });
+    const repo = await repositoriesApi.get("maven-local");
+    expect(repo.has_trusted_gpg_key).toBe(false);
+    expect(repo.apt_origin).toBeUndefined();
+    expect(repo.debian).toBeUndefined();
+    expect(repo.npm_allowed_scopes).toBeUndefined();
+  });
+});
+
 describe("repositoriesApi.updateAgePolicy", () => {
   beforeEach(() => vi.clearAllMocks());
 

--- a/src/lib/api/repositories.ts
+++ b/src/lib/api/repositories.ts
@@ -169,6 +169,24 @@ function adaptRepository(sdk: RepositoryResponse): Repository {
     upstream_url: sdk.upstream_url ?? undefined,
     upstream_auth_type: sdk.upstream_auth_type ?? undefined,
     upstream_auth_configured: sdk.upstream_auth_configured,
+    // --- 1.6.0 format-specific config (#602) ---
+    // `has_trusted_gpg_key` (#2568) is required on the current SDK type but
+    // `?? false` stays defensive against a backend/list handler that omits it.
+    has_trusted_gpg_key: sdk.has_trusted_gpg_key ?? false,
+    apt_origin: sdk.apt_origin ?? undefined,
+    apt_label: sdk.apt_label ?? undefined,
+    apt_release_version: sdk.apt_release_version ?? undefined,
+    apt_description: sdk.apt_description ?? undefined,
+    debian: sdk.debian
+      ? {
+          distribution_paths: sdk.debian.distribution_paths ?? undefined,
+          components: sdk.debian.components ?? undefined,
+          architectures: sdk.debian.architectures ?? undefined,
+        }
+      : undefined,
+    npm_allowed_scopes: sdk.npm_allowed_scopes ?? undefined,
+    npm_allowed_name_patterns: sdk.npm_allowed_name_patterns ?? undefined,
+    npm_allow_unscoped: sdk.npm_allow_unscoped ?? undefined,
     created_at: sdk.created_at,
     updated_at: sdk.updated_at,
   };
@@ -229,6 +247,17 @@ export const repositoriesApi = {
       upstream_auth_type: input.upstream_auth_type,
       upstream_username: input.upstream_username,
       upstream_password: input.upstream_password,
+      // --- 1.6.0 format-specific config (#602). Undefined fields are dropped
+      // by JSON serialization, so a repo of another format sends none of them.
+      trusted_gpg_key: input.trusted_gpg_key,
+      apt_origin: input.apt_origin,
+      apt_label: input.apt_label,
+      apt_release_version: input.apt_release_version,
+      apt_description: input.apt_description,
+      debian: input.debian,
+      npm_allowed_scopes: input.npm_allowed_scopes,
+      npm_allowed_name_patterns: input.npm_allowed_name_patterns,
+      npm_allow_unscoped: input.npm_allow_unscoped,
     };
     const { data, error } = await createRepository({ body });
     if (error) throw error;
@@ -245,6 +274,18 @@ export const repositoriesApi = {
       quota_bytes: input.quota_bytes,
       key: input.key,
       versioning_enabled: input.versioning_enabled,
+      // --- 1.6.0 format-specific config (#602). `trusted_gpg_key` uses
+      // three-way semantics: omit (undefined) = unchanged, `null` = clear,
+      // string = set. Undefined fields are dropped by JSON serialization.
+      trusted_gpg_key: input.trusted_gpg_key,
+      apt_origin: input.apt_origin,
+      apt_label: input.apt_label,
+      apt_release_version: input.apt_release_version,
+      apt_description: input.apt_description,
+      debian: input.debian,
+      npm_allowed_scopes: input.npm_allowed_scopes,
+      npm_allowed_name_patterns: input.npm_allowed_name_patterns,
+      npm_allow_unscoped: input.npm_allow_unscoped,
     };
     const { data, error } = await updateRepository({ path: { key }, body });
     if (error) throw error;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -76,8 +76,36 @@ export interface Repository {
   upstream_auth_configured?: boolean;
   // For virtual repositories
   member_repos?: VirtualRepoMember[];
+  // --- 1.6.0 format-specific config (#602) ---
+  /**
+   * Whether an RPM curation trusted GPG public key is configured (#2568). The
+   * key material itself is never returned by the backend; this boolean is the
+   * only exposure. Only meaningful for RPM-format repositories.
+   */
+  has_trusted_gpg_key?: boolean;
+  /** Debian/APT `Release` metadata + proxy filters (#2407/#2460/#2489/#2459). */
+  apt_origin?: string;
+  apt_label?: string;
+  apt_release_version?: string;
+  apt_description?: string;
+  debian?: DebianRepoConfig;
+  /** npm scope policy (#2424). Only meaningful for npm remote/virtual repos. */
+  npm_allowed_scopes?: string[];
+  npm_allowed_name_patterns?: string[];
+  npm_allow_unscoped?: boolean;
   created_at: string;
   updated_at: string;
+}
+
+/**
+ * Debian/APT proxy filter allowlists (#2407). Empty or `["*"]` selects
+ * everything (today's full-proxy behaviour); otherwise only exact matches are
+ * proxied. Mirrors the SDK `DebianRepositoryConfig` fields the UI edits.
+ */
+export interface DebianRepoConfig {
+  distribution_paths?: string[];
+  components?: string[];
+  architectures?: string[];
 }
 
 export type RepositoryFormat =
@@ -153,6 +181,24 @@ export interface CreateRepositoryRequest {
   upstream_password?: string;
   // For virtual repositories - array of member repo keys with priorities
   member_repos?: VirtualRepoMemberInput[];
+  // --- 1.6.0 format-specific config (#602) ---
+  /**
+   * RPM curation trusted GPG *public* key (#2568). Write-only: ASCII-armored
+   * public key block to set, `null` to clear (update only). Only valid for
+   * RPM-format repositories.
+   */
+  trusted_gpg_key?: string | null;
+  /** Debian/APT `Release` metadata (#2460). */
+  apt_origin?: string | null;
+  apt_label?: string | null;
+  apt_release_version?: string | null;
+  apt_description?: string | null;
+  /** Debian/APT proxy distro filters (#2407). */
+  debian?: DebianRepoConfig | null;
+  /** npm scope policy (#2424). */
+  npm_allowed_scopes?: string[] | null;
+  npm_allowed_name_patterns?: string[] | null;
+  npm_allow_unscoped?: boolean | null;
 }
 
 export interface VirtualRepoMemberInput {


### PR DESCRIPTION
## Summary

Adds format-gated 1.6.0 configuration sections to **both** the repository create dialog and the settings/edit tab, built on the generated `@artifact-keeper/sdk@1.6.0` request/response fields (no new `apiFetch` workarounds).

Three groups, each shown only for the relevant format and wired into create + settings identically via a shared controlled component (`format-config-fields.tsx`):

1. **RPM trusted GPG key** (#2568) — RPM repos. A `trusted_gpg_key` textarea (the curation *trusted* / proxy-verification public key, not a server-side signing key). Key material is write-only: the field starts empty and a stored key is surfaced via `has_trusted_gpg_key`. Settings supports set / replace / clear using the SDK's three-way `Option<Option<String>>` semantics (`null` clears, string sets, omit leaves unchanged).
2. **Advanced Debian/APT** (#2407/#2460/#2489/#2459) — Debian repos. Distribution / component / architecture proxy-filter allowlists (`debian` config object) plus `Release` metadata (`apt_origin`, `apt_label`, `apt_release_version`, `apt_description`).
3. **npm scope policy** (#2424) — npm virtual/remote repos. `npm_allowed_scopes`, `npm_allowed_name_patterns` (glob lists), and an `npm_allow_unscoped` toggle.

Gating predicates are centralised in `_lib/constants.ts` so the two surfaces never drift.

## SDK fields used

- Create (`CreateRepositoryRequest`): `trusted_gpg_key`, `apt_origin`, `apt_label`, `apt_release_version`, `apt_description`, `debian` (`DebianRepositoryConfig`: `distribution_paths` / `components` / `architectures`), `npm_allowed_scopes`, `npm_allowed_name_patterns`, `npm_allow_unscoped`.
- Update (`UpdateRepositoryRequest`): same set; `debian` as `DebianConfigPatch`; `trusted_gpg_key` three-way clear.
- Response (`RepositoryResponse`): `has_trusted_gpg_key`, `apt_*`, `debian`, `npm_*` adapted onto the local `Repository` type.

## Components changed

- `src/app/(app)/repositories/_components/format-config-fields.tsx` (new) — shared field groups + pure builders (`parseList`/`formatList`/`build*`).
- `src/app/(app)/repositories/_components/repo-dialogs.tsx` — create dialog sections + submit wiring.
- `src/app/(app)/repositories/_components/repo-settings-tab.tsx` — settings sections, override/dirty state, save wiring.
- `src/app/(app)/repositories/_lib/constants.ts` — `hasRpmTrustedKeyConfig` / `hasDebianConfig` / `hasNpmScopePolicy`.
- `src/lib/api/repositories.ts` — create/update body forwarding + `adaptRepository` mapping.
- `src/types/index.ts` — `Repository` / `CreateRepositoryRequest` + `DebianRepoConfig`.

## Verification (run locally, foreground, as CI does)

- `npm install` — ok
- `npm run lint` — 0 errors (pre-existing warnings only)
- `npm run test:coverage` — 2727 tests pass across 146 files; lines 87.74% (> 80% gate). New/changed files: `format-config-fields.tsx` ~89%, `repo-settings-tab.tsx` ~92%, `repo-dialogs.tsx` ~94%, `_lib` ~98%.
- `npm run build` — compiled successfully.

New/extended unit tests cover the builders, the field components, the gating predicates, the API forwarding/adaptation, and the create + settings flows (including RPM set/clear/undo).

Closes #602
Refs #599