### PR TITLE
Authz hardening: plugin-config Configure gate + signing key-owner gate decision (1.6.0)

### DIFF
--- a/src/app/(app)/(admin)/signing/page.test.tsx
+++ b/src/app/(app)/(admin)/signing/page.test.tsx
@@ -127,6 +127,22 @@ describe("SigningPage", () => {
     expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
   });
 
+  it("shows a dedicated permission state on a 403 (no crash, no retry)", () => {
+    queryResponse = {
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: { status: 403 },
+      refetch: vi.fn(),
+    };
+    render(<SigningPage />);
+    expect(
+      screen.getByText(/don't have permission to manage signing keys/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Couldn't load signing keys/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /retry/i })).not.toBeInTheDocument();
+  });
+
   it("lists keys with type and status badges", () => {
     queryResponse = { data: [KEY], isLoading: false };
     render(<SigningPage />);

--- a/src/app/(app)/(admin)/signing/page.tsx
+++ b/src/app/(app)/(admin)/signing/page.tsx
@@ -15,7 +15,7 @@ import {
 import { toast } from "sonner";
 
 import signingApi, { type SigningKey, type CreateSigningKeyRequest } from "@/lib/api/signing";
-import { mutationErrorToast, toUserMessage } from "@/lib/error-utils";
+import { mutationErrorToast, toUserMessage, isForbiddenError } from "@/lib/error-utils";
 import { useAuth } from "@/providers/auth-provider";
 
 import { Button } from "@/components/ui/button";
@@ -154,7 +154,17 @@ export default function SigningPage() {
         </div>
       )}
 
-      {!isLoading && isError && (
+      {!isLoading && isError && isForbiddenError(error) && (
+        <div className="flex flex-col items-center justify-center py-12 text-center" role="alert">
+          <AlertCircle className="size-8 mb-2 text-destructive opacity-80" />
+          <p className="text-sm font-medium">You don&apos;t have permission to manage signing keys</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Signing-key management is restricted to administrators.
+          </p>
+        </div>
+      )}
+
+      {!isLoading && isError && !isForbiddenError(error) && (
         <div className="flex flex-col items-center justify-center py-12 text-center" role="alert">
           <AlertCircle className="size-8 mb-2 text-destructive opacity-80" />
           <p className="text-sm font-medium">Couldn&apos;t load signing keys</p>

--- a/src/app/(app)/(protected)/plugins/page.test.tsx
+++ b/src/app/(app)/(protected)/plugins/page.test.tsx
@@ -1,0 +1,244 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// jsdom is missing APIs that Radix Dialog relies on.
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+  Element.prototype.scrollIntoView = vi.fn();
+  Element.prototype.hasPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+});
+
+// -- react-query mock: distinguish the plugins list from the plugin-config query --
+interface MutationConfig {
+  mutationFn: (...a: unknown[]) => unknown;
+  onSuccess?: (...a: unknown[]) => void;
+  onError?: (...a: unknown[]) => void;
+}
+const mutationConfigs: MutationConfig[] = [];
+const mockInvalidate = vi.fn();
+let pluginsResp: {
+  data: unknown;
+  isLoading?: boolean;
+  isFetching?: boolean;
+} = { data: { items: [], total: 0 }, isLoading: false };
+let configResp: { data: unknown; isError?: boolean; error?: unknown } = {
+  data: [],
+  isError: false,
+};
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (opts: {
+    queryKey: unknown[];
+    queryFn: () => unknown;
+    enabled?: boolean;
+  }) => {
+    const key = (opts.queryKey as string[])[0];
+    if (opts.enabled !== false) {
+      try {
+        opts.queryFn();
+      } catch {
+        /* ignore */
+      }
+    }
+    return key === "plugin-config" ? configResp : pluginsResp;
+  },
+  useMutation: (config: MutationConfig) => {
+    mutationConfigs.push(config);
+    return { mutate: vi.fn(), isPending: false };
+  },
+  useQueryClient: () => ({ invalidateQueries: mockInvalidate }),
+}));
+
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...a: unknown[]) => mockToastSuccess(...a),
+    error: (...a: unknown[]) => mockToastError(...a),
+  },
+}));
+
+// SDK is imported for its side effect + named functions.
+vi.mock("@/lib/sdk-client", () => ({}));
+const sdk = vi.hoisted(() => ({
+  listPlugins: vi.fn(async () => ({ data: { items: [] }, error: null })),
+  getPluginConfig: vi.fn(async () => ({ data: { items: [] }, error: null })),
+  enablePlugin: vi.fn(async () => ({ error: null })),
+  disablePlugin: vi.fn(async () => ({ error: null })),
+  uninstallPlugin: vi.fn(async () => ({ error: null })),
+  updatePluginConfig: vi.fn(async () => ({ error: null })),
+  installFromGit: vi.fn(async () => ({ data: { name: "p" }, error: null })),
+  installFromZip: vi.fn(async () => ({ data: { name: "p" }, error: null })),
+}));
+vi.mock("@artifact-keeper/sdk", () => sdk);
+
+let isAdmin = true;
+vi.mock("@/providers/auth-provider", () => ({
+  useAuth: () => ({ user: { is_admin: isAdmin } }),
+}));
+
+// -- lightweight UI mocks so Radix-heavy primitives render deterministically --
+vi.mock("@/components/common/data-table", () => ({
+  DataTable: ({
+    columns,
+    data,
+  }: {
+    columns: Array<{ id: string; cell?: (row: unknown) => React.ReactNode }>;
+    data: unknown[];
+  }) => (
+    <table>
+      <tbody>
+        {data.map((row, i) => (
+          <tr key={i}>
+            {columns.map((c) => (
+              <td key={c.id}>{c.cell ? c.cell(row) : null}</td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  ),
+}));
+
+const passthrough = vi.hoisted(
+  () =>
+    ({ children }: { children?: React.ReactNode }) =>
+      children,
+);
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: passthrough,
+  TooltipTrigger: passthrough,
+  // Wrap content in its own element so each tooltip label is individually
+  // queryable by text (bare-string children would merge into one node).
+  TooltipContent: ({ children }: { children?: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+}));
+vi.mock("@/components/ui/tabs", () => ({
+  Tabs: passthrough,
+  TabsList: passthrough,
+  TabsTrigger: passthrough,
+  TabsContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("@/components/ui/select", () => ({
+  Select: passthrough,
+  SelectTrigger: passthrough,
+  SelectValue: passthrough,
+  SelectContent: passthrough,
+  SelectItem: passthrough,
+}));
+vi.mock("@/components/common/page-header", () => ({
+  PageHeader: ({ actions }: { actions?: React.ReactNode }) => <div>{actions}</div>,
+}));
+vi.mock("@/components/common/empty-state", () => ({
+  EmptyState: ({ title }: { title?: string }) => <div>{title}</div>,
+}));
+vi.mock("@/components/common/status-badge", () => ({
+  StatusBadge: ({ status }: { status?: string }) => <span>{status}</span>,
+}));
+
+import PluginsPage from "./page";
+
+const PLUGIN = {
+  id: "p1",
+  name: "acme-handler",
+  version: "1.0.0",
+  plugin_type: "format_handler" as const,
+  status: "active" as const,
+  installed_at: "2026-06-01T00:00:00Z",
+  updated_at: "2026-06-01T00:00:00Z",
+};
+
+beforeEach(() => {
+  mutationConfigs.length = 0;
+  vi.clearAllMocks();
+  isAdmin = true;
+  pluginsResp = { data: { items: [PLUGIN], total: 1 }, isLoading: false };
+  configResp = { data: [], isError: false };
+});
+afterEach(() => cleanup());
+
+describe("PluginsPage — Configure gating (#2512)", () => {
+  it("shows the Configure affordance to admins", () => {
+    render(<PluginsPage />);
+    expect(
+      screen.getByRole("button", { name: /configure acme-handler/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the Configure affordance from non-admins", () => {
+    isAdmin = false;
+    render(<PluginsPage />);
+    expect(
+      screen.queryByRole("button", { name: /configure acme-handler/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps other plugin actions available to non-admins", () => {
+    isAdmin = false;
+    render(<PluginsPage />);
+    // enable/disable + uninstall tooltips still render their content text
+    expect(screen.getByText("Disable")).toBeInTheDocument();
+    expect(screen.getByText("Uninstall")).toBeInTheDocument();
+  });
+
+  it("does not fetch plugin config for non-admins (query disabled)", () => {
+    isAdmin = false;
+    render(<PluginsPage />);
+    expect(sdk.getPluginConfig).not.toHaveBeenCalled();
+  });
+});
+
+describe("PluginsPage — config 403 handling", () => {
+  it("shows a not-authorized state when the config fetch is forbidden", async () => {
+    const user = userEvent.setup();
+    configResp = { data: undefined, isError: true, error: { status: 403 } };
+    render(<PluginsPage />);
+    await user.click(
+      screen.getByRole("button", { name: /configure acme-handler/i }),
+    );
+    expect(
+      await screen.findByText(/don't have permission to view or edit/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a generic error state for a non-403 config failure", async () => {
+    const user = userEvent.setup();
+    configResp = { data: undefined, isError: true, error: new Error("boom") };
+    render(<PluginsPage />);
+    await user.click(
+      screen.getByRole("button", { name: /configure acme-handler/i }),
+    );
+    expect(await screen.findByText("boom")).toBeInTheDocument();
+  });
+
+  it("renders the config form when the fetch succeeds", async () => {
+    const user = userEvent.setup();
+    configResp = {
+      data: [{ key: "webhook_url", value: "https://x", description: "hook" }],
+      isError: false,
+    };
+    render(<PluginsPage />);
+    await user.click(
+      screen.getByRole("button", { name: /configure acme-handler/i }),
+    );
+    expect(await screen.findByLabelText("webhook_url")).toBeInTheDocument();
+  });
+
+  it("save-config mutation reports a 403 via an error toast (graceful)", () => {
+    render(<PluginsPage />);
+    // order: enable, disable, uninstall, saveConfig, installGit, installZip
+    const saveConfig = mutationConfigs[3];
+    saveConfig.onError?.({ status: 403 });
+    expect(mockToastError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/(app)/(protected)/plugins/page.tsx
+++ b/src/app/(app)/(protected)/plugins/page.tsx
@@ -30,7 +30,8 @@ import {
   installFromGit,
   installFromZip,
 } from "@artifact-keeper/sdk";
-import { mutationErrorToast } from "@/lib/error-utils";
+import { mutationErrorToast, isForbiddenError, toUserMessage } from "@/lib/error-utils";
+import { useAuth } from "@/providers/auth-provider";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -133,6 +134,11 @@ const STATUS_COLORS: Record<string, "green" | "red" | "default"> = {
 
 export default function PluginsPage() {
   const queryClient = useQueryClient();
+  const { user } = useAuth();
+  // Plugin configuration read/write is admin-only on the backend
+  // (#2512 / AK-SEC-001). Gate the Configure affordance accordingly and lean
+  // on backend 403s for defense in depth.
+  const canConfigure = !!user?.is_admin;
 
   const [statusFilter, setStatusFilter] = useState<string>("__all__");
   const [installOpen, setInstallOpen] = useState(false);
@@ -162,7 +168,11 @@ export default function PluginsPage() {
     },
   });
 
-  const { data: pluginConfig } = useQuery({
+  const {
+    data: pluginConfig,
+    isError: configIsError,
+    error: configError,
+  } = useQuery({
     queryKey: ["plugin-config", configPlugin?.id],
     queryFn: async () => {
       const { data, error } = await getPluginConfig({
@@ -171,7 +181,10 @@ export default function PluginsPage() {
       if (error) throw error;
       return (data as any).items as PluginConfig[];
     },
-    enabled: !!configPlugin,
+    // Config is admin-only (#2512). Non-admins never trigger the request; the
+    // Configure affordance is hidden for them, and a stale-admin 403 is handled
+    // gracefully in the dialog below.
+    enabled: !!configPlugin && canConfigure,
   });
 
   const plugins = data?.items ?? [];
@@ -363,21 +376,24 @@ export default function PluginsPage() {
           className="flex items-center gap-1 justify-end"
           onClick={(e) => e.stopPropagation()}
         >
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                onClick={() => {
-                  setConfigPlugin(p);
-                  setConfigValues({});
-                }}
-              >
-                <Settings className="size-3.5" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Configure</TooltipContent>
-          </Tooltip>
+          {canConfigure && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  aria-label={`Configure ${p.name}`}
+                  onClick={() => {
+                    setConfigPlugin(p);
+                    setConfigValues({});
+                  }}
+                >
+                  <Settings className="size-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Configure</TooltipContent>
+            </Tooltip>
+          )}
           {p.status === "disabled" ? (
             <Tooltip>
               <TooltipTrigger asChild>
@@ -765,7 +781,23 @@ export default function PluginsPage() {
                   </div>
                 </TabsContent>
                 <TabsContent value="config" className="mt-4">
-                  {pluginConfig && pluginConfig.length > 0 ? (
+                  {!canConfigure || (configIsError && isForbiddenError(configError)) ? (
+                    <p
+                      className="text-sm text-muted-foreground py-8 text-center"
+                      role="alert"
+                    >
+                      You don&apos;t have permission to view or edit this
+                      plugin&apos;s configuration. Plugin configuration is
+                      restricted to administrators.
+                    </p>
+                  ) : configIsError ? (
+                    <p
+                      className="text-sm text-red-500 py-8 text-center"
+                      role="alert"
+                    >
+                      {toUserMessage(configError, "Failed to load configuration.")}
+                    </p>
+                  ) : pluginConfig && pluginConfig.length > 0 ? (
                     <form
                       className="space-y-4"
                       onSubmit={(e) => {

--- a/src/lib/__tests__/error-utils.test.ts
+++ b/src/lib/__tests__/error-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   toUserMessage,
   isAccountLocked,
+  isForbiddenError,
   isPasswordReuseError,
   mutationErrorToast,
   PASSWORD_REUSE_MESSAGE,
@@ -487,5 +488,34 @@ describe("mutationErrorToast", () => {
     handlerB({});
     expect(errorMock).toHaveBeenNthCalledWith(1, "Label A");
     expect(errorMock).toHaveBeenNthCalledWith(2, "Label B");
+  });
+});
+
+describe("isForbiddenError", () => {
+  it("detects an HTTP 403 status field", () => {
+    expect(isForbiddenError({ status: 403 })).toBe(true);
+    expect(isForbiddenError({ statusCode: 403 })).toBe(true);
+    expect(isForbiddenError({ body: { status: 403 } })).toBe(true);
+  });
+
+  it("detects a forbidden code field", () => {
+    expect(isForbiddenError({ code: "FORBIDDEN" })).toBe(true);
+    expect(isForbiddenError({ code: "not_authorized" })).toBe(true);
+  });
+
+  it("detects authorization phrasing in the message", () => {
+    expect(isForbiddenError({ error: "Forbidden" })).toBe(true);
+    expect(isForbiddenError({ message: "Admin access required" })).toBe(true);
+    expect(isForbiddenError(new Error("Permission denied"))).toBe(true);
+    expect(isForbiddenError({ detail: "You are not authorized" })).toBe(true);
+    expect(isForbiddenError("(HTTP 403) something")).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isForbiddenError({ status: 500 })).toBe(false);
+    expect(isForbiddenError(new Error("network down"))).toBe(false);
+    expect(isForbiddenError("Repository is locked for maintenance")).toBe(false);
+    expect(isForbiddenError(null)).toBe(false);
+    expect(isForbiddenError(undefined)).toBe(false);
   });
 });

--- a/src/lib/error-utils.ts
+++ b/src/lib/error-utils.ts
@@ -161,6 +161,39 @@ export function toUserMessage(error: unknown, fallback: string): string {
 }
 
 /**
+ * Detect whether an error represents an HTTP 403 / authorization denial.
+ *
+ * Used by access-controlled pages to render a clear "not authorized" state
+ * instead of a generic error when the backend rejects a read/write because
+ * the caller lacks the required role (see backend #2512 plugin config and
+ * #2513 signing-key management, both now admin-gated).
+ *
+ * Checks the structured HTTP status first (most reliable), then an error/code
+ * field, then falls back to message text. Message matching is kept specific to
+ * authorization phrasing to avoid false positives from unrelated errors.
+ */
+export function isForbiddenError(error: unknown): boolean {
+  if (isPlainObject(error)) {
+    if (extractHttpStatus(error) === 403) return true;
+
+    const code = nonEmptyString(error.code);
+    if (code && /forbidden|not[_\s-]?authorized|unauthorized/i.test(code)) {
+      return true;
+    }
+  }
+
+  const msg = toUserMessage(error, '').toLowerCase();
+  return (
+    msg.includes('forbidden') ||
+    msg.includes('not authorized') ||
+    msg.includes('permission denied') ||
+    msg.includes('requires admin') ||
+    msg.includes('admin access') ||
+    /\bhttp 403\b/.test(msg)
+  );
+}
+
+/**
  * Patterns the backend uses when rejecting a password that was recently used.
  * Kept as a single source of truth so both the change-password page and
  * the profile security tab can detect this specific error.


### PR DESCRIPTION
Verification/hardening pass against the 1.6.0 authz model (epic #599, audit item 7). UI gating + 403 handling only — no new pages, no net-new features.

## Signing page — gate KEPT (no evidence to loosen)
Investigated whether 1.6.0 lets repo-scoped signing-key owners manage keys here. Evidence says **no**, so the admin-only gate is preserved:

- Backend #2513 (AK-SEC-002) tightens signing authz — key **listing** and **every** mutation (create/delete/revoke/rotate + repo signing-config updates) are gated by `require_signing_admin()`. The fix restricts, not relaxes.
- The page lives under the `(admin)` route group, whose layout wraps everything in `RequireAdmin` (redirects non-admins to `/error/403`). Relaxing the page-level `is_admin` check alone would be dead/misleading code.
- The `User` object exposes only `is_admin` — no per-repo ownership/permission signal to base a relaxed gate on. Repo-scoped signing config (`getRepoSigningConfig`) is a separate, currently-unwired surface.

Change: the key-list error branch now renders a dedicated "You don't have permission to manage signing keys" state on a 403 (instead of the generic error + Retry). Mutation 403s were already surfaced gracefully via `mutationErrorToast`.

## Plugins page — Configure affordance gated + 403 handled
Plugin config read/write is now admin-only (backend #2512 / AK-SEC-001: `POST/GET /:id/config` moved behind `require_admin`). The Configure gear was shown to any logged-in user.

- Hide the Configure affordance for non-admins (`canConfigure = user.is_admin`).
- Skip the `getPluginConfig` fetch entirely for non-admins.
- If the config fetch returns 403 (e.g. a stale-admin), the Configuration tab shows a clear "not authorized" state; other errors show a generic error message — no broken/empty form, no crash.
- `updatePluginConfig` 403s remain handled via the existing error toast.
- Added an `aria-label` to the Configure button (a11y + testability).

## Shared
- New `isForbiddenError()` helper in `error-utils` (HTTP 403 status / code / message detection), with unit tests.

## Verification (as CI)
- `npm run lint` — 0 errors (pre-existing warnings only).
- `npm run test:coverage` — 2792 tests pass; global 86.4% stmts / 81.4% branches / 81.6% funcs / 87.2% lines (all >80%). Added a full test suite for the plugins page (previously untested) + new signing/error-utils cases.
- `npm run build` — succeeds.

Closes #611
Refs #599