### PR TITLE
feat(login): render backend-provided first-run setup hint

### DIFF
--- a/src/app/(auth)/__tests__/login-lockout.test.tsx
+++ b/src/app/(auth)/__tests__/login-lockout.test.tsx
@@ -73,10 +73,19 @@ const mockRefreshUser = vi.fn();
 const mockVerifyTotp = vi.fn();
 const mockClearTotpRequired = vi.fn();
 
-let authState = {
+let authState: {
+  login: typeof mockLogin;
+  refreshUser: typeof mockRefreshUser;
+  setupRequired: boolean;
+  setupPasswordHint: string | null;
+  totpRequired: boolean;
+  verifyTotp: typeof mockVerifyTotp;
+  clearTotpRequired: typeof mockClearTotpRequired;
+} = {
   login: mockLogin,
   refreshUser: mockRefreshUser,
   setupRequired: false,
+  setupPasswordHint: null,
   totpRequired: false,
   verifyTotp: mockVerifyTotp,
   clearTotpRequired: mockClearTotpRequired,
@@ -122,6 +131,7 @@ describe("LoginPage lockout UI", () => {
       login: mockLogin,
       refreshUser: mockRefreshUser,
       setupRequired: false,
+      setupPasswordHint: null,
       totpRequired: false,
       verifyTotp: mockVerifyTotp,
       clearTotpRequired: mockClearTotpRequired,
@@ -293,6 +303,37 @@ describe("LoginPage lockout UI", () => {
     render(<LoginPage />);
 
     expect(screen.queryByText("First-Time Setup")).not.toBeInTheDocument();
+  });
+
+  it("shows the built-in docker compose instruction when no hint is provided", () => {
+    authState.setupRequired = true;
+
+    render(<LoginPage />);
+
+    expect(
+      screen.getByText(
+        "docker exec artifact-keeper-backend cat /data/storage/admin.password"
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("renders the backend-provided setup hint in place of the default", () => {
+    authState.setupRequired = true;
+    authState.setupPasswordHint =
+      "kubectl exec deploy/artifact-keeper -- cat /data/storage/admin.password";
+
+    render(<LoginPage />);
+
+    expect(
+      screen.getByText(
+        "kubectl exec deploy/artifact-keeper -- cat /data/storage/admin.password"
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "docker exec artifact-keeper-backend cat /data/storage/admin.password"
+      )
+    ).not.toBeInTheDocument();
   });
 
   it("renders the TOTP form when totpRequired is true", () => {

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -67,7 +67,7 @@ export function ssoButtonLabel(provider: SsoProvider): string {
 function LoginContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { login, refreshUser, setupRequired, totpRequired, verifyTotp, clearTotpRequired } = useAuth();
+  const { login, refreshUser, setupRequired, setupPasswordHint, totpRequired, verifyTotp, clearTotpRequired } = useAuth();
   const [error, setError] = useState<string | null>(null);
   const [accountLocked, setAccountLocked] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -193,8 +193,16 @@ function LoginContent() {
           <AlertTitle className="text-amber-800 dark:text-amber-200">First-Time Setup</AlertTitle>
           <AlertDescription>
             <p>A random admin password was generated. Retrieve it from the server:</p>
-            <code className="mt-1.5 block rounded bg-amber-100 px-2 py-1.5 font-mono text-xs break-all dark:bg-amber-950/50">
-              docker exec artifact-keeper-backend cat /data/storage/admin.password
+            {/*
+              The deployment default (Docker Compose) is baked in here, but an
+              operator can override the retrieval instruction via the backend's
+              SETUP_PASSWORD_HINT env var (artifact-keeper#2802) so Kubernetes
+              and packaged installs can show the right command. When the backend
+              provides a hint we render it verbatim; otherwise the built-in
+              Docker Compose instruction below is shown unchanged.
+            */}
+            <code className="mt-1.5 block rounded bg-amber-100 px-2 py-1.5 font-mono text-xs break-all whitespace-pre-wrap dark:bg-amber-950/50">
+              {setupPasswordHint ?? "docker exec artifact-keeper-backend cat /data/storage/admin.password"}
             </code>
             <p className="mt-1.5">
               Log in with username <strong>admin</strong> and the password from the file.

--- a/src/providers/auth-provider.tsx
+++ b/src/providers/auth-provider.tsx
@@ -34,6 +34,7 @@ interface AuthContextType {
   mustChangePassword: boolean;
   passwordExpiresAt: string | null;
   setupRequired: boolean;
+  setupPasswordHint: string | null;
   totpRequired: boolean;
   totpToken: string | null;
   login: (username: string, password: string) => Promise<boolean | "totp">;
@@ -66,6 +67,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [mustChangePassword, setMustChangePassword] = useState(false);
   const [passwordExpiresAt, setPasswordExpiresAt] = useState<string | null>(null);
   const [setupRequired, setSetupRequired] = useState(false);
+  const [setupPasswordHint, setSetupPasswordHint] = useState<string | null>(null);
   const [totpRequired, setTotpRequired] = useState(false);
   const [totpToken, setTotpToken] = useState<string | null>(null);
 
@@ -182,10 +184,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // Check if first-boot setup is required
       try {
         const { data: setupData } = await sdkSetupStatus();
-        const status = setupData as unknown as SetupStatusResponse | undefined;
+        // The backend ships an optional `setup_password_hint` via
+        // artifact-keeper#2802, but the generated SDK type doesn't carry it
+        // until the SDK regenerates from the upgraded OpenAPI spec. Read it off
+        // the runtime object via a narrowed cast so the deployment-aware hint
+        // plumbs through as soon as the backend rolls out. Once the SDK is
+        // regenerated with the field, this extra type can collapse away.
+        const status = setupData as unknown as
+          | (SetupStatusResponse & { setup_password_hint?: string | null })
+          | undefined;
         if (status?.setup_required) {
           setSetupRequired(true);
         }
+        const hint = status?.setup_password_hint?.trim();
+        setSetupPasswordHint(hint ? hint : null);
       } catch {
         // Setup endpoint not available, continue normally
       }
@@ -247,6 +259,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         mustChangePassword,
         passwordExpiresAt,
         setupRequired,
+        setupPasswordHint,
         totpRequired,
         totpToken,
         login,


### PR DESCRIPTION
## Summary

The first-time-setup alert on the login screen hardcoded a Docker Compose instruction for retrieving the generated admin password:

```
docker exec artifact-keeper-backend cat /data/storage/admin.password
```

That is wrong on Kubernetes and on packaged or managed installs. This change reads the optional `setup_password_hint` field the backend now returns on the public `GET /api/v1/setup/status` response and renders it in the alert in place of the hardcoded instruction. When the backend does not provide a hint (the default), the existing Docker Compose text is shown unchanged, so behavior is identical for existing deployments.

The generated SDK type does not carry `setup_password_hint` yet, so it is read off the runtime response via the narrowed-cast fallback pattern already used across `src/lib/api` (documented inline with a reference to the backend issue). The value is trimmed and treated as absent when blank. It is plumbed through the auth context (`setupPasswordHint`) alongside the existing `setupRequired` flag.

Depends on the backend change: artifact-keeper#2802 (backend PR artifact-keeper#2804). Safe to merge independently, since it falls back to the current default when the field is absent.

Closes #619

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

Added two component tests to `login-lockout.test.tsx`: one asserting the built-in Docker Compose instruction renders when no hint is provided, and one asserting a backend-provided hint replaces it. The full `(auth)` and auth-provider suites pass (58 tests). Typecheck and lint are clean for the changed files.

## UI Changes
- [ ] Playwright E2E spec covers the change
- [x] Responsive layout verified (mobile + desktop)
- [x] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes

The change swaps the text content of the existing `<code>` block in the setup alert and adds `whitespace-pre-wrap` so a multi-line operator hint wraps cleanly. No new components, layout, or color changes; dark-mode and responsive styling are inherited from the existing alert.
