### PR TITLE
fix(migration): label test-connection toast by connector type

### DIFF
--- a/src/app/(app)/(admin)/migration/__tests__/page.test.tsx
+++ b/src/app/(app)/(admin)/migration/__tests__/page.test.tsx
@@ -708,7 +708,9 @@ describe("MigrationPage — connections list and actions", () => {
       fireEvent.click(btn!);
     });
     expect(capturedMutations.testConn).toBeDefined();
-    expect(capturedMutations.testConn.mutate).toHaveBeenCalledWith("c1");
+    expect(capturedMutations.testConn.mutate).toHaveBeenCalledWith(
+      makeConnection({ id: "c1" }),
+    );
   });
 
   it("toasts success with version when testConnection succeeds and a version is returned", () => {
@@ -716,13 +718,42 @@ describe("MigrationPage — connections list and actions", () => {
     return renderPage().then(() => {
       const opts = capturedMutations.testConn.opts;
       // Drive the success branch directly so we exercise the success copy.
-      opts.onSuccess?.({
-        success: true,
-        message: "ok",
-        artifactory_version: "7.55.10",
-      });
+      opts.onSuccess?.(
+        {
+          success: true,
+          message: "ok",
+          artifactory_version: "7.55.10",
+        },
+        makeConnection(),
+      );
       expect(toast.success).toHaveBeenCalledWith(
-        expect.stringContaining("Artifactory 7.55.10"),
+        expect.stringContaining("Artifactory version 7.55.10"),
+      );
+    });
+  });
+
+  it("labels the toast with the connector type (nexus, not Artifactory)", () => {
+    configureQueries({ connections: { data: [makeConnection()], isLoading: false } });
+    return renderPage().then(() => {
+      capturedMutations.testConn.opts.onSuccess?.(
+        { success: true, message: "ok", artifactory_version: "3.61.0" },
+        makeConnection({ source_type: "nexus" }),
+      );
+      const msg = (toast.success as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(msg).toContain("Nexus version 3.61.0");
+      expect(msg).not.toContain("Artifactory");
+    });
+  });
+
+  it("falls back to 'unknown' when the backend supplies no version", () => {
+    configureQueries({ connections: { data: [makeConnection()], isLoading: false } });
+    return renderPage().then(() => {
+      capturedMutations.testConn.opts.onSuccess?.(
+        { success: true, message: "ok", artifactory_version: undefined },
+        makeConnection({ source_type: "nexus" }),
+      );
+      expect(toast.success).toHaveBeenCalledWith(
+        "Connection verified. Nexus version unknown",
       );
     });
   });

--- a/src/app/(app)/(admin)/migration/page.tsx
+++ b/src/app/(app)/(admin)/migration/page.tsx
@@ -403,11 +403,13 @@ export default function MigrationPage() {
   });
 
   const testConnMutation = useMutation({
-    mutationFn: (id: string) => migrationApi.testConnection(id),
-    onSuccess: (result) => {
+    mutationFn: (c: SourceConnection) => migrationApi.testConnection(c.id),
+    onSuccess: (result, c) => {
       if (result.success) {
+        const label =
+          c.source_type.charAt(0).toUpperCase() + c.source_type.slice(1);
         toast.success(
-          `Connection verified. ${result.artifactory_version ? `Artifactory ${result.artifactory_version}` : ""}`
+          `Connection verified. ${label} version ${result.artifactory_version || "unknown"}`
         );
       } else {
         toast.error(`Connection failed: ${result.message}`);
@@ -609,7 +611,7 @@ export default function MigrationPage() {
               <Button
                 variant="ghost"
                 size="icon-xs"
-                onClick={() => testConnMutation.mutate(c.id)}
+                onClick={() => testConnMutation.mutate(c)}
                 disabled={testConnMutation.isPending}
               >
                 <Unplug className="size-3.5" />


### PR DESCRIPTION
## Summary
Test connection hardcoded "Artifactory" for every source; now uses the actual type. Small, but it made Nexus migrations look broken from the first click.

Fixes #624 

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [ ] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [x] N/A - no UI changes
