### PR TITLE
chore: allowlist known E2E JWT_SECRET test fixture in GitGuardian

### DIFF
--- a/.gitguardian.yml
+++ b/.gitguardian.yml
@@ -1,0 +1,17 @@
+# GitGuardian / ggshield configuration
+# https://docs.gitguardian.com/ggshield-docs/configuration
+version: 2
+
+secret:
+  # Allowlist known, non-live test fixtures so they do not surface as
+  # "new" secrets when older PR branches are previewed against main.
+  ignored-matches:
+    # JWT_SECRET in docker-compose.e2e.yml — a static value used only by the
+    # end-to-end test stack (no production reach). Not a live secret.
+    # match = SHA256 of the fixture value.
+    - name: "E2E test fixture JWT_SECRET (docker-compose.e2e.yml)"
+      match: 5688dbb9bba09072e0aec7b2094b2256f8c5c39087028395a9c0879b076087cd
+
+  # Belt-and-suspenders: the e2e compose file only ever holds test fixtures.
+  ignored-paths:
+    - "docker-compose.e2e.yml"


### PR DESCRIPTION
## What

Adds a minimal `.gitguardian.yml` allowlisting the static `JWT_SECRET` in `docker-compose.e2e.yml`.

## Why

That value is an **E2E test fixture** (added back in a 1.2.2 commit, not by any recent PR) with no production reach. When older dependabot branches merge-preview against `main` from a stale base, GitGuardian reports the fixture as a *newly introduced* secret, leaving those PRs UNSTABLE (GitGuardian is a non-required check, so it never blocked merges, but it is persistent noise).

Allowlisting by the value's SHA256 (plus a path fallback) makes GitGuardian go green for these once rebased and stops the recurring false positive.

No functional change; only affects secret-scanning config.