### PR TITLE
feat(repositories): browseable folder tree for RAW/Generic repositories

### DIFF
--- a/e2e/suites/interactions/repositories/artifact-browser-grouping.spec.ts
+++ b/e2e/suites/interactions/repositories/artifact-browser-grouping.spec.ts
@@ -216,10 +216,14 @@ test.describe('Artifact Browser Grouping (#254 Maven, #330 Docker)', () => {
   // Non-groupable formats — toggle hidden
   // -------------------------------------------------------------------------
 
-  test('Non-groupable repos (npm, helm) do NOT show the grouping toggle', async ({
+  test('Non-groupable repos (npm, helm, pypi) do NOT show the grouping toggle', async ({
     page,
   }) => {
-    const key = await findRepoByFormat(page, ['npm', 'helm', 'pypi', 'generic']);
+    // `generic` is intentionally excluded: RAW/Generic repos now render the
+    // browser toggle for the Flat/Tree folder view (#2791), so they are no
+    // longer toggle-free. npm/helm/pypi remain neither groupable nor
+    // tree-capable, so the toggle must still be absent for them.
+    const key = await findRepoByFormat(page, ['npm', 'helm', 'pypi']);
     test.skip(!key, 'No non-groupable repository available');
     await gotoArtifactsTab(page, key!);
 
@@ -227,5 +231,23 @@ test.describe('Artifact Browser Grouping (#254 Maven, #330 Docker)', () => {
     expect(await toggle.isVisible({ timeout: 2000 }).catch(() => false)).toBe(
       false,
     );
+  });
+
+  // -------------------------------------------------------------------------
+  // RAW/Generic — Flat/Tree folder-view toggle (#2791)
+  // -------------------------------------------------------------------------
+
+  test('Generic (RAW) repos show the Flat/Tree browser toggle (#2791)', async ({
+    page,
+  }) => {
+    const key = await findRepoByFormat(page, ['generic']);
+    test.skip(!key, 'No generic repository available');
+    await gotoArtifactsTab(page, key!);
+
+    await expect(page.getByTestId('artifact-browser-toggle')).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(page.getByTestId('toggle-flat')).toBeVisible();
+    await expect(page.getByTestId('toggle-tree')).toBeVisible();
   });
 });

--- a/src/app/(app)/repositories/_components/__tests__/artifact-browser-toggle.test.tsx
+++ b/src/app/(app)/repositories/_components/__tests__/artifact-browser-toggle.test.tsx
@@ -8,6 +8,7 @@ import userEvent from "@testing-library/user-event";
 import {
   ArtifactBrowserToggle,
   supportsGrouping,
+  supportsTree,
 } from "../artifact-browser-toggle";
 import type { RepositoryFormat } from "@/types";
 
@@ -25,6 +26,62 @@ describe("supportsGrouping", () => {
     ["podman", false],
   ])("returns %s for %s repos", (format, expected) => {
     expect(supportsGrouping(format)).toBe(expected);
+  });
+});
+
+describe("supportsTree", () => {
+  it.each<[RepositoryFormat, boolean]>([
+    ["generic", true],
+    ["maven", false],
+    ["docker", false],
+    ["npm", false],
+    ["helm", false],
+  ])("returns %s for %s repos", (format, expected) => {
+    expect(supportsTree(format)).toBe(expected);
+  });
+});
+
+describe("ArtifactBrowserToggle — tree (RAW/Generic)", () => {
+  afterEach(cleanup);
+
+  it("renders a Flat/Tree toggle for generic repositories", () => {
+    render(
+      <ArtifactBrowserToggle value="flat" onChange={NOOP} format="generic" />,
+    );
+    expect(screen.getByTestId("artifact-browser-toggle")).toBeInTheDocument();
+    expect(screen.getByTestId("toggle-flat")).toBeInTheDocument();
+    expect(screen.getByTestId("toggle-tree")).toBeInTheDocument();
+    expect(screen.queryByTestId("toggle-grouped")).not.toBeInTheDocument();
+  });
+
+  it("marks the tree button pressed when value=tree", () => {
+    render(
+      <ArtifactBrowserToggle value="tree" onChange={NOOP} format="generic" />,
+    );
+    expect(screen.getByTestId("toggle-tree")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByTestId("toggle-flat")).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("invokes onChange('tree') when the Tree button is clicked", async () => {
+    const onChange = vi.fn();
+    render(
+      <ArtifactBrowserToggle value="flat" onChange={onChange} format="generic" />,
+    );
+    await userEvent.click(screen.getByTestId("toggle-tree"));
+    expect(onChange).toHaveBeenCalledWith("tree");
+  });
+
+  it("renders nothing for formats with neither grouping nor tree (npm)", () => {
+    const { container } = render(
+      <ArtifactBrowserToggle value="flat" onChange={NOOP} format="npm" />,
+    );
+    expect(container).toBeEmptyDOMElement();
   });
 });
 

--- a/src/app/(app)/repositories/_components/__tests__/artifact-folder-tree.test.tsx
+++ b/src/app/(app)/repositories/_components/__tests__/artifact-folder-tree.test.tsx
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ArtifactFolderTree } from "../artifact-folder-tree";
+import type { Artifact } from "@/types";
+
+function makeArtifact(path: string, overrides: Partial<Artifact> = {}): Artifact {
+  const name = path.split("/").filter(Boolean).pop() ?? path;
+  return {
+    id: `id-${path}`,
+    repository_key: "raw-repo",
+    path,
+    name,
+    size_bytes: 1024,
+    checksum_sha256: "abc",
+    content_type: "application/octet-stream",
+    download_count: 0,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const NOOP = () => {};
+
+describe("ArtifactFolderTree", () => {
+  afterEach(cleanup);
+
+  it("renders a loading skeleton when loading", () => {
+    render(
+      <ArtifactFolderTree artifacts={[]} onFileSelect={NOOP} loading />,
+    );
+    expect(screen.getByTestId("artifact-tree-loading")).toBeInTheDocument();
+    expect(screen.queryByTestId("artifact-folder-tree")).not.toBeInTheDocument();
+  });
+
+  it("renders the empty state with a custom message when there are no artifacts", () => {
+    render(
+      <ArtifactFolderTree
+        artifacts={[]}
+        onFileSelect={NOOP}
+        emptyMessage="Nothing here yet."
+      />,
+    );
+    expect(screen.getByTestId("artifact-tree-empty")).toBeInTheDocument();
+    expect(screen.getByText("Nothing here yet.")).toBeInTheDocument();
+  });
+
+  it("renders top-level files and folders", () => {
+    render(
+      <ArtifactFolderTree
+        artifacts={[
+          makeArtifact("top.txt"),
+          makeArtifact("builds/app.tar.gz"),
+        ]}
+        onFileSelect={NOOP}
+      />,
+    );
+    expect(screen.getByRole("tree", { name: /repository folder tree/i })).toBeInTheDocument();
+    expect(screen.getByText("builds")).toBeInTheDocument();
+    expect(screen.getByText("top.txt")).toBeInTheDocument();
+  });
+
+  it("expands top-level folders by default so their children are visible", () => {
+    render(
+      <ArtifactFolderTree
+        artifacts={[makeArtifact("builds/app.tar.gz")]}
+        onFileSelect={NOOP}
+      />,
+    );
+    // Top-level folder auto-expands; child file is visible without a click.
+    expect(screen.getByText("app.tar.gz")).toBeInTheDocument();
+    const folder = screen.getByRole("treeitem", { name: /folder builds/i });
+    expect(folder).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("collapses and re-expands a folder on click", async () => {
+    const user = userEvent.setup();
+    render(
+      <ArtifactFolderTree
+        artifacts={[makeArtifact("builds/app.tar.gz")]}
+        onFileSelect={NOOP}
+      />,
+    );
+    const folderButton = screen.getByTestId("artifact-tree-folder");
+
+    // Starts expanded -> child visible
+    expect(screen.getByText("app.tar.gz")).toBeInTheDocument();
+
+    // Collapse -> child hidden
+    await user.click(folderButton);
+    expect(screen.queryByText("app.tar.gz")).not.toBeInTheDocument();
+
+    // Re-expand -> child visible again
+    await user.click(folderButton);
+    expect(screen.getByText("app.tar.gz")).toBeInTheDocument();
+  });
+
+  it("keeps a nested folder collapsed until expanded", async () => {
+    const user = userEvent.setup();
+    render(
+      <ArtifactFolderTree
+        artifacts={[makeArtifact("builds/2026/app.tar.gz")]}
+        onFileSelect={NOOP}
+      />,
+    );
+    // 'builds' auto-expands and reveals the nested '2026' folder, but the deep
+    // file is hidden until '2026' is expanded.
+    expect(screen.getByText("2026")).toBeInTheDocument();
+    expect(screen.queryByText("app.tar.gz")).not.toBeInTheDocument();
+
+    const nested = screen.getByRole("treeitem", { name: /folder builds\/2026/i });
+    await user.click(within(nested).getByTestId("artifact-tree-folder"));
+    expect(screen.getByText("app.tar.gz")).toBeInTheDocument();
+  });
+
+  it("invokes onFileSelect with the artifact when a file is clicked", async () => {
+    const user = userEvent.setup();
+    const onFileSelect = vi.fn();
+    const artifact = makeArtifact("builds/app.tar.gz", { id: "target" });
+    render(
+      <ArtifactFolderTree artifacts={[artifact]} onFileSelect={onFileSelect} />,
+    );
+    await user.click(screen.getByTestId("artifact-tree-file"));
+    expect(onFileSelect).toHaveBeenCalledTimes(1);
+    expect(onFileSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "target" }),
+    );
+  });
+
+  it("renders a download count and a generic-file glyph, and highlights the selected file", () => {
+    const artifact = makeArtifact("dir/LICENSE", {
+      download_count: 1234,
+    });
+    render(
+      <ArtifactFolderTree
+        artifacts={[artifact]}
+        onFileSelect={NOOP}
+        selectedPath="dir/LICENSE"
+      />,
+    );
+    // download_count > 0 renders the compact-formatted count (formatNumber)
+    expect(screen.getByText("1.2K")).toBeInTheDocument();
+    // selected file carries aria-selected=true
+    const file = screen.getByTestId("artifact-tree-file");
+    expect(file).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("shows a recursive file total in the header", () => {
+    render(
+      <ArtifactFolderTree
+        artifacts={[
+          makeArtifact("a.txt"),
+          makeArtifact("dir/b.txt"),
+          makeArtifact("dir/sub/c.txt"),
+        ]}
+        onFileSelect={NOOP}
+      />,
+    );
+    expect(screen.getByText("3 files")).toBeInTheDocument();
+  });
+});

--- a/src/app/(app)/repositories/_components/artifact-browser-toggle.tsx
+++ b/src/app/(app)/repositories/_components/artifact-browser-toggle.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { List, Boxes } from "lucide-react";
+import { List, Boxes, FolderTree } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { RepositoryFormat } from "@/types";
 
-export type ArtifactViewMode = "flat" | "grouped";
+export type ArtifactViewMode = "flat" | "grouped" | "tree";
 
 /**
  * Repository formats for which a "grouped" artifact view is meaningful.
@@ -19,22 +19,36 @@ const GROUPABLE_FORMATS = new Set<RepositoryFormat>([
   "docker",
 ]);
 
+/**
+ * Repository formats for which a folder-tree view is meaningful (issue #2791).
+ * RAW/Generic repos have no package/version semantics — just files at arbitrary
+ * paths — so a directory tree built client-side from the flat artifact list is
+ * the natural way to browse them.
+ */
+const TREE_FORMATS = new Set<RepositoryFormat>(["generic"]);
+
 export function supportsGrouping(format: RepositoryFormat): boolean {
   return GROUPABLE_FORMATS.has(format);
+}
+
+export function supportsTree(format: RepositoryFormat): boolean {
+  return TREE_FORMATS.has(format);
 }
 
 interface ArtifactBrowserToggleProps {
   value: ArtifactViewMode;
   onChange: (next: ArtifactViewMode) => void;
-  /** Repository format — toggle only renders for groupable formats. */
+  /** Repository format — toggle only renders for formats that offer an
+   *  alternate (grouped or tree) view. */
   format: RepositoryFormat;
   className?: string;
 }
 
 /**
- * Two-state toggle between flat artifact list and grouped (by Maven
- * component or Docker tag) view.  Renders nothing for formats that don't
- * support grouping.
+ * Two-state toggle between the flat artifact list and an alternate view. The
+ * alternate is format-dependent: groupable formats (Maven/Gradle/Docker) toggle
+ * to a grouped view; RAW/Generic formats toggle to a folder tree (#2791).
+ * Renders nothing for formats that offer neither.
  *
  * Behaves as a single-select radio group for screen readers: each button
  * exposes `aria-pressed` so the selected state is announced.
@@ -45,9 +59,19 @@ export function ArtifactBrowserToggle({
   format,
   className,
 }: ArtifactBrowserToggleProps) {
-  if (!supportsGrouping(format)) return null;
+  const groupable = supportsGrouping(format);
+  const treeable = supportsTree(format);
+  if (!groupable && !treeable) return null;
 
-  const groupedLabel = format === "docker" ? "Group by tag" : "Group by component";
+  // Groupable formats keep their existing grouped alternate; otherwise offer
+  // the folder-tree alternate.
+  const altMode: ArtifactViewMode = groupable ? "grouped" : "tree";
+  const altLabel = groupable
+    ? format === "docker"
+      ? "Group by tag"
+      : "Group by component"
+    : "Folder tree view";
+  const AltIcon = groupable ? Boxes : FolderTree;
 
   return (
     <div
@@ -74,16 +98,16 @@ export function ArtifactBrowserToggle({
       </Button>
       <Button
         type="button"
-        variant={value === "grouped" ? "secondary" : "ghost"}
+        variant={value === altMode ? "secondary" : "ghost"}
         size="sm"
         className="h-8 px-3 text-xs"
-        aria-pressed={value === "grouped"}
-        aria-label={groupedLabel}
-        data-testid="toggle-grouped"
-        onClick={() => onChange("grouped")}
+        aria-pressed={value === altMode}
+        aria-label={altLabel}
+        data-testid={groupable ? "toggle-grouped" : "toggle-tree"}
+        onClick={() => onChange(altMode)}
       >
-        <Boxes className="size-3.5" aria-hidden="true" />
-        Grouped
+        <AltIcon className="size-3.5" aria-hidden="true" />
+        {groupable ? "Grouped" : "Tree"}
       </Button>
     </div>
   );

--- a/src/app/(app)/repositories/_components/artifact-folder-tree.tsx
+++ b/src/app/(app)/repositories/_components/artifact-folder-tree.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  ChevronRight,
+  ChevronDown,
+  Folder,
+  FolderOpen,
+  File,
+  FileCode,
+  FileArchive,
+  Download,
+} from "lucide-react";
+
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn, formatBytes, formatNumber } from "@/lib/utils";
+import {
+  buildArtifactTree,
+  countTreeFiles,
+  type ArtifactTreeNode,
+} from "@/lib/artifact-tree";
+import type { Artifact } from "@/types";
+
+const ARCHIVE_EXT = [
+  ".tar.gz",
+  ".tgz",
+  ".zip",
+  ".jar",
+  ".war",
+  ".gz",
+  ".bz2",
+  ".xz",
+  ".7z",
+  ".rar",
+];
+const CODE_EXT = [
+  ".json",
+  ".xml",
+  ".yaml",
+  ".yml",
+  ".toml",
+  ".txt",
+  ".md",
+  ".sh",
+  ".py",
+  ".rs",
+  ".js",
+  ".ts",
+];
+
+function FileGlyph({ name }: { name: string }) {
+  const lower = name.toLowerCase();
+  if (ARCHIVE_EXT.some((ext) => lower.endsWith(ext))) {
+    return <FileArchive className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />;
+  }
+  if (CODE_EXT.some((ext) => lower.endsWith(ext))) {
+    return <FileCode className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />;
+  }
+  return <File className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />;
+}
+
+const INDENT_PX = 16;
+const BASE_PAD_PX = 8;
+
+function TreeNodeRow({
+  node,
+  depth,
+  onFileSelect,
+  selectedPath,
+}: {
+  node: ArtifactTreeNode;
+  depth: number;
+  onFileSelect: (artifact: Artifact) => void;
+  selectedPath?: string | null;
+}) {
+  const paddingLeft = depth * INDENT_PX + BASE_PAD_PX;
+
+  // --- File leaf ---
+  if (node.type === "file") {
+    const isSelected = selectedPath === node.path;
+    const { artifact } = node;
+    return (
+      <button
+        type="button"
+        role="treeitem"
+        aria-selected={isSelected}
+        aria-label={`File ${node.path}`}
+        data-testid="artifact-tree-file"
+        className={cn(
+          "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-muted/50",
+          isSelected && "bg-muted",
+        )}
+        style={{ paddingLeft }}
+        onClick={() => onFileSelect(artifact)}
+      >
+        {/* spacer to align with folder chevrons */}
+        <span className="size-4 shrink-0" aria-hidden="true" />
+        <FileGlyph name={node.name} />
+        <span className="flex-1 truncate">{node.name}</span>
+        <span className="flex shrink-0 items-center gap-3 text-xs text-muted-foreground">
+          <span>{formatBytes(artifact.size_bytes)}</span>
+          {artifact.download_count > 0 && (
+            <span className="flex items-center gap-1">
+              <Download className="size-3" aria-hidden="true" />
+              {formatNumber(artifact.download_count)}
+            </span>
+          )}
+        </span>
+      </button>
+    );
+  }
+
+  // --- Folder node ---
+  return (
+    <FolderRow
+      node={node}
+      depth={depth}
+      onFileSelect={onFileSelect}
+      selectedPath={selectedPath}
+    />
+  );
+}
+
+function FolderRow({
+  node,
+  depth,
+  onFileSelect,
+  selectedPath,
+}: {
+  node: Extract<ArtifactTreeNode, { type: "folder" }>;
+  depth: number;
+  onFileSelect: (artifact: Artifact) => void;
+  selectedPath?: string | null;
+}) {
+  // Top-level folders start expanded so the browser isn't a wall of collapsed
+  // rows; deeper folders start collapsed for progressive disclosure.
+  const [isOpen, setIsOpen] = useState(depth === 0);
+  const paddingLeft = depth * INDENT_PX + BASE_PAD_PX;
+
+  return (
+    <div
+      role="treeitem"
+      aria-expanded={isOpen}
+      aria-selected={false}
+      aria-label={`Folder ${node.path}`}
+    >
+      <button
+        type="button"
+        data-testid="artifact-tree-folder"
+        className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-muted/50"
+        style={{ paddingLeft }}
+        onClick={() => setIsOpen((prev) => !prev)}
+      >
+        {isOpen ? (
+          <ChevronDown className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+        ) : (
+          <ChevronRight className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+        )}
+        {isOpen ? (
+          <FolderOpen className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+        ) : (
+          <Folder className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+        )}
+        <span className="flex-1 truncate font-medium">{node.name}</span>
+        <span className="flex shrink-0 items-center gap-3 text-xs text-muted-foreground">
+          <span>
+            {node.fileCount} {node.fileCount === 1 ? "file" : "files"}
+          </span>
+          <span>{formatBytes(node.totalSize)}</span>
+        </span>
+      </button>
+      {isOpen && (
+        <div role="group">
+          {node.children.map((child) => (
+            <TreeNodeRow
+              key={child.path}
+              node={child}
+              depth={depth + 1}
+              onFileSelect={onFileSelect}
+              selectedPath={selectedPath}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export interface ArtifactFolderTreeProps {
+  artifacts: Artifact[];
+  onFileSelect: (artifact: Artifact) => void;
+  loading?: boolean;
+  selectedPath?: string | null;
+  emptyMessage?: string;
+}
+
+/**
+ * Folder-tree browser for RAW/Generic repositories (issue #2791).
+ *
+ * Groups the repository's flat artifact list into a navigable directory tree
+ * (client-side, via `buildArtifactTree`), with expandable/collapsible folders
+ * and clickable file leaves. Selecting a file hands the full `Artifact` back to
+ * the caller, which opens the existing artifact detail dialog (view / download).
+ */
+export function ArtifactFolderTree({
+  artifacts,
+  onFileSelect,
+  loading = false,
+  selectedPath,
+  emptyMessage = "No artifacts in this repository.",
+}: ArtifactFolderTreeProps) {
+  const tree = useMemo(() => buildArtifactTree(artifacts), [artifacts]);
+  const totalFiles = useMemo(() => countTreeFiles(tree), [tree]);
+
+  if (loading) {
+    return (
+      <div className="space-y-2 p-4" data-testid="artifact-tree-loading">
+        <Skeleton className="h-6 w-56" />
+        <Skeleton className="h-6 w-44" />
+        <Skeleton className="h-6 w-52" />
+        <Skeleton className="h-6 w-40" />
+        <Skeleton className="h-6 w-48" />
+      </div>
+    );
+  }
+
+  if (tree.length === 0) {
+    return (
+      <div
+        className="flex flex-col items-center justify-center py-12 text-center"
+        data-testid="artifact-tree-empty"
+      >
+        <Folder className="mb-2 size-8 text-muted-foreground/40" aria-hidden="true" />
+        <p className="text-sm text-muted-foreground">{emptyMessage}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border">
+      <div className="flex items-center justify-between border-b px-3 py-2 text-xs text-muted-foreground">
+        <span className="flex items-center gap-1.5">
+          <FolderOpen className="size-3.5" aria-hidden="true" />
+          Folder tree
+        </span>
+        <span>
+          {totalFiles} {totalFiles === 1 ? "file" : "files"}
+        </span>
+      </div>
+      <div
+        role="tree"
+        aria-label="Repository folder tree"
+        data-testid="artifact-folder-tree"
+        className="py-1"
+      >
+        {tree.map((node) => (
+          <TreeNodeRow
+            key={node.path}
+            node={node}
+            depth={0}
+            onFileSelect={onFileSelect}
+            selectedPath={selectedPath}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default ArtifactFolderTree;

--- a/src/app/(app)/repositories/_components/repo-detail-content.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.test.tsx
@@ -120,9 +120,11 @@ vi.mock("./packages-tab-content", () => ({ PackagesTabContent: () => <div data-s
 vi.mock("./repo-settings-tab", () => ({ RepoSettingsTab: () => <div data-stub="settings" /> }));
 vi.mock("./maven-component-list", () => ({ MavenComponentList: () => <div data-stub="maven" /> }));
 vi.mock("./docker-tag-list", () => ({ DockerTagList: () => <div data-stub="docker" /> }));
+vi.mock("./artifact-folder-tree", () => ({ ArtifactFolderTree: () => <div data-stub="folder-tree" /> }));
 vi.mock("./artifact-browser-toggle", () => ({
   ArtifactBrowserToggle: () => <div data-stub="ArtifactBrowserToggle" />,
   supportsGrouping: () => false,
+  supportsTree: () => false,
 }));
 vi.mock("@/components/common/data-table", () => ({
   // Minimal row rendering so tests can open the artifact detail dialog via

--- a/src/app/(app)/repositories/_components/repo-detail-content.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.tsx
@@ -51,10 +51,12 @@ import { PackagesTabContent } from "./packages-tab-content";
 import {
   ArtifactBrowserToggle,
   supportsGrouping,
+  supportsTree,
   type ArtifactViewMode,
 } from "./artifact-browser-toggle";
 import { MavenComponentList } from "./maven-component-list";
 import { DockerTagList } from "./docker-tag-list";
+import { ArtifactFolderTree } from "./artifact-folder-tree";
 import { QuarantineBadge } from "@/components/common/quarantine-badge";
 import { QuarantineBanner } from "@/components/common/quarantine-banner";
 import { RepoSettingsTab } from "./repo-settings-tab";
@@ -132,13 +134,15 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(20);
 
-  // Grouped vs flat artifact-browser view (issues #254, #330).  The URL
-  // `?view=flat|grouped` query param is the source of truth so the choice
-  // survives a refresh and is shareable.  Absence falls back to the
+  // Grouped vs flat vs tree artifact-browser view (issues #254, #330, #2791).
+  // The URL `?view=flat|grouped|tree` query param is the source of truth so the
+  // choice survives a refresh and is shareable.  Absence falls back to the
   // per-format default.
   const urlView = searchParams.get("view");
   const viewModeOverride: ArtifactViewMode | null =
-    urlView === "flat" || urlView === "grouped" ? urlView : null;
+    urlView === "flat" || urlView === "grouped" || urlView === "tree"
+      ? urlView
+      : null;
 
   // artifact detail dialog
   const [detailOpen, setDetailOpen] = useState(false);
@@ -172,6 +176,11 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
     viewMode === "grouped" &&
     (repoFormat === "maven" || repoFormat === "gradle");
   const isDockerGrouped = viewMode === "grouped" && repoFormat === "docker";
+  // Folder-tree view for RAW/Generic repos (#2791): the tree is grouped
+  // client-side from the flat artifact list, so — like Docker grouping — it
+  // needs the whole listing on one page (bounded) rather than a paginated slice.
+  const isTreeView =
+    viewMode === "tree" && !!repoFormat && supportsTree(repoFormat);
   // First-class version history (#571, backend artifact-keeper#2367): only
   // repositories that opted in via `versioning_enabled` AND whose format
   // participates (Generic/Mlmodel) get the Versions tab in the artifact
@@ -183,8 +192,9 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
   // For Docker grouping we need all artifacts on one page so the client
   // aggregation sees everything.  Bound by a high cap to avoid runaway
   // responses on huge registries.
-  const effectivePageSize = isDockerGrouped ? 500 : pageSize;
-  const effectivePage = isDockerGrouped ? 1 : page;
+  const loadAllOnePage = isDockerGrouped || isTreeView;
+  const effectivePageSize = loadAllOnePage ? 500 : pageSize;
+  const effectivePage = loadAllOnePage ? 1 : page;
 
   const handleViewModeChange = useCallback(
     (next: ArtifactViewMode) => {
@@ -742,13 +752,14 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
                 }}
               />
             </div>
-            {repoFormat && supportsGrouping(repoFormat) && (
-              <ArtifactBrowserToggle
-                value={viewMode}
-                onChange={handleViewModeChange}
-                format={repoFormat}
-              />
-            )}
+            {repoFormat &&
+              (supportsGrouping(repoFormat) || supportsTree(repoFormat)) && (
+                <ArtifactBrowserToggle
+                  value={viewMode}
+                  onChange={handleViewModeChange}
+                  format={repoFormat}
+                />
+              )}
             {user?.is_admin && (
               <Button
                 variant="outline"
@@ -771,7 +782,9 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
           <div role="status" aria-live="polite" className="sr-only">
             {viewMode === "grouped"
               ? `Showing grouped ${repoFormat === "docker" ? "tag" : "component"} view`
-              : "Showing flat list view"}
+              : viewMode === "tree"
+                ? "Showing folder tree view"
+                : "Showing flat list view"}
           </div>
 
           {/* Outcome announcements for destructive actions (delete / cache
@@ -795,6 +808,14 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
               }}
               onFileSelect={showDetailByPath}
               emptyMessage="No Maven components could be grouped — switch to flat view to see raw files."
+            />
+          ) : isTreeView ? (
+            <ArtifactFolderTree
+              artifacts={artifactsData?.items ?? []}
+              loading={artifactsLoading}
+              onFileSelect={showDetail}
+              selectedPath={selectedArtifact?.path ?? null}
+              emptyMessage="No artifacts in this repository."
             />
           ) : isDockerGrouped ? (
             <DockerTagList

--- a/src/lib/__tests__/artifact-tree.test.ts
+++ b/src/lib/__tests__/artifact-tree.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  buildArtifactTree,
+  splitArtifactPath,
+  countTreeFiles,
+  type ArtifactTreeFolder,
+  type ArtifactTreeNode,
+} from "@/lib/artifact-tree";
+import type { Artifact } from "@/types";
+
+/** Minimal Artifact factory — only the fields the tree builder reads matter. */
+function makeArtifact(path: string, overrides: Partial<Artifact> = {}): Artifact {
+  const name = path.split("/").filter(Boolean).pop() ?? path;
+  return {
+    id: `id-${path}`,
+    repository_key: "raw-repo",
+    path,
+    name,
+    size_bytes: 100,
+    checksum_sha256: "abc",
+    content_type: "application/octet-stream",
+    download_count: 0,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function asFolder(node: ArtifactTreeNode): ArtifactTreeFolder {
+  if (node.type !== "folder") throw new Error(`expected folder, got ${node.type}`);
+  return node;
+}
+
+describe("splitArtifactPath", () => {
+  it("splits a simple nested path", () => {
+    expect(splitArtifactPath("a/b/c.txt")).toEqual(["a", "b", "c.txt"]);
+  });
+
+  it("ignores leading, trailing and repeated separators", () => {
+    expect(splitArtifactPath("/a//b/")).toEqual(["a", "b"]);
+  });
+
+  it("tolerates backslash separators", () => {
+    expect(splitArtifactPath("a\\b\\c.txt")).toEqual(["a", "b", "c.txt"]);
+  });
+
+  it("returns an empty array for an empty or slash-only path", () => {
+    expect(splitArtifactPath("")).toEqual([]);
+    expect(splitArtifactPath("///")).toEqual([]);
+  });
+});
+
+describe("buildArtifactTree", () => {
+  it("returns an empty tree for no artifacts", () => {
+    expect(buildArtifactTree([])).toEqual([]);
+  });
+
+  it("places a bare filename at the top level as a file", () => {
+    const tree = buildArtifactTree([makeArtifact("readme.txt")]);
+    expect(tree).toHaveLength(1);
+    expect(tree[0].type).toBe("file");
+    expect(tree[0].name).toBe("readme.txt");
+    expect(tree[0].path).toBe("readme.txt");
+  });
+
+  it("nests files under their folder segments", () => {
+    const tree = buildArtifactTree([makeArtifact("builds/2026/app.tar.gz")]);
+    const builds = asFolder(tree[0]);
+    expect(builds.name).toBe("builds");
+    expect(builds.path).toBe("builds");
+
+    const year = asFolder(builds.children[0]);
+    expect(year.name).toBe("2026");
+    expect(year.path).toBe("builds/2026");
+
+    const file = year.children[0];
+    expect(file.type).toBe("file");
+    expect(file.name).toBe("app.tar.gz");
+    expect(file.path).toBe("builds/2026/app.tar.gz");
+  });
+
+  it("merges files that share folder prefixes into one subtree", () => {
+    const tree = buildArtifactTree([
+      makeArtifact("builds/a.txt"),
+      makeArtifact("builds/b.txt"),
+    ]);
+    expect(tree).toHaveLength(1);
+    const builds = asFolder(tree[0]);
+    expect(builds.children.map((c) => c.name)).toEqual(["a.txt", "b.txt"]);
+    expect(builds.fileCount).toBe(2);
+  });
+
+  it("sorts folders before files, each alphabetically (case-insensitive)", () => {
+    const tree = buildArtifactTree([
+      makeArtifact("zeta.txt"),
+      makeArtifact("Alpha/one.txt"),
+      makeArtifact("beta/two.txt"),
+      makeArtifact("apple.txt"),
+    ]);
+    // Alpha (folder), beta (folder), then files apple.txt, zeta.txt
+    expect(tree.map((n) => [n.type, n.name])).toEqual([
+      ["folder", "Alpha"],
+      ["folder", "beta"],
+      ["file", "apple.txt"],
+      ["file", "zeta.txt"],
+    ]);
+  });
+
+  it("aggregates recursive fileCount and totalSize on folders", () => {
+    const tree = buildArtifactTree([
+      makeArtifact("dir/a.bin", { size_bytes: 10 }),
+      makeArtifact("dir/sub/b.bin", { size_bytes: 30 }),
+      makeArtifact("dir/sub/c.bin", { size_bytes: 60 }),
+    ]);
+    const dir = asFolder(tree[0]);
+    expect(dir.fileCount).toBe(3);
+    expect(dir.totalSize).toBe(100);
+
+    const sub = asFolder(dir.children.find((c) => c.type === "folder")!);
+    expect(sub.fileCount).toBe(2);
+    expect(sub.totalSize).toBe(90);
+  });
+
+  it("de-duplicates identical paths, keeping the last artifact", () => {
+    const tree = buildArtifactTree([
+      makeArtifact("dup/file.txt", { id: "first", size_bytes: 1 }),
+      makeArtifact("dup/file.txt", { id: "second", size_bytes: 2 }),
+    ]);
+    const dup = asFolder(tree[0]);
+    expect(dup.children).toHaveLength(1);
+    const file = dup.children[0];
+    expect(file.type).toBe("file");
+    if (file.type === "file") {
+      expect(file.artifact.id).toBe("second");
+    }
+    expect(dup.fileCount).toBe(1);
+    expect(dup.totalSize).toBe(2);
+  });
+
+  it("skips artifacts whose path is empty", () => {
+    const tree = buildArtifactTree([
+      makeArtifact("keep.txt"),
+      { ...makeArtifact("x"), path: "", name: "" },
+    ]);
+    expect(tree).toHaveLength(1);
+    expect(tree[0].name).toBe("keep.txt");
+  });
+
+  it("falls back to the artifact name when path is missing", () => {
+    const artifact = { ...makeArtifact("ignored"), path: "", name: "fromname.txt" };
+    const tree = buildArtifactTree([artifact]);
+    expect(tree).toHaveLength(1);
+    expect(tree[0].name).toBe("fromname.txt");
+  });
+});
+
+describe("countTreeFiles", () => {
+  it("counts all file leaves recursively", () => {
+    const tree = buildArtifactTree([
+      makeArtifact("a.txt"),
+      makeArtifact("dir/b.txt"),
+      makeArtifact("dir/sub/c.txt"),
+    ]);
+    expect(countTreeFiles(tree)).toBe(3);
+  });
+
+  it("returns 0 for an empty tree", () => {
+    expect(countTreeFiles([])).toBe(0);
+  });
+});

--- a/src/lib/artifact-tree.ts
+++ b/src/lib/artifact-tree.ts
@@ -1,0 +1,161 @@
+import type { Artifact } from "@/types";
+
+/**
+ * Client-side folder-tree model for RAW/Generic repositories (issue #2791).
+ *
+ * RAW/Generic repos have no package/version semantics — they are just a flat
+ * set of files identified by their storage `path` (e.g. `builds/2026/app.tar.gz`).
+ * The backend artifacts listing returns that flat list; this module groups those
+ * paths into a navigable directory tree purely on the client so the UI can offer
+ * an expand/collapse folder browser without a new backend endpoint.
+ *
+ * The functions here are deliberately pure (no React, no fetching) so the
+ * grouping logic can be unit-tested in isolation.
+ */
+
+/** A directory node aggregating its descendant files. */
+export interface ArtifactTreeFolder {
+  type: "folder";
+  /** Segment name of this folder (last path component). */
+  name: string;
+  /** Full repository-relative path of this folder, e.g. `builds/2026`. */
+  path: string;
+  /** Sorted children (folders first, then files, each alphabetical). */
+  children: ArtifactTreeNode[];
+  /** Recursive count of file descendants. */
+  fileCount: number;
+  /** Recursive sum of descendant file sizes, in bytes. */
+  totalSize: number;
+}
+
+/** A leaf node wrapping a single artifact file. */
+export interface ArtifactTreeFile {
+  type: "file";
+  /** File name (last path component). */
+  name: string;
+  /** Full repository-relative path, e.g. `builds/2026/app.tar.gz`. */
+  path: string;
+  /** The underlying artifact record, carried through so a click can open
+   *  the existing artifact detail / download flow without a refetch. */
+  artifact: Artifact;
+}
+
+export type ArtifactTreeNode = ArtifactTreeFolder | ArtifactTreeFile;
+
+/**
+ * Split an artifact path into clean, non-empty segments.
+ *
+ * Tolerates leading/trailing slashes, Windows-style backslashes, and repeated
+ * separators so a slightly irregular backend path (`/a//b/`) still nests
+ * sensibly instead of producing empty folder nodes.
+ */
+export function splitArtifactPath(rawPath: string): string[] {
+  return rawPath
+    .split(/[/\\]+/)
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+}
+
+/** Internal mutable builder shape, collapsed to the public folder type on emit. */
+interface FolderBuilder {
+  name: string;
+  path: string;
+  folders: Map<string, FolderBuilder>;
+  files: ArtifactTreeFile[];
+}
+
+function newFolder(name: string, path: string): FolderBuilder {
+  return { name, path, folders: new Map(), files: [] };
+}
+
+/** Case-insensitive, locale-aware name comparison used across the tree. */
+function byName(a: { name: string }, b: { name: string }): number {
+  return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+}
+
+/**
+ * Recursively convert a builder into the public, sorted, aggregated node.
+ * Folders sort before files; within each group nodes sort alphabetically.
+ */
+function emitFolder(builder: FolderBuilder): ArtifactTreeFolder {
+  const childFolders = Array.from(builder.folders.values())
+    .map(emitFolder)
+    .sort(byName);
+  const childFiles = [...builder.files].sort(byName);
+
+  const fileCount =
+    childFiles.length +
+    childFolders.reduce((sum, folder) => sum + folder.fileCount, 0);
+  const totalSize =
+    childFiles.reduce((sum, file) => sum + (file.artifact.size_bytes || 0), 0) +
+    childFolders.reduce((sum, folder) => sum + folder.totalSize, 0);
+
+  return {
+    type: "folder",
+    name: builder.name,
+    path: builder.path,
+    children: [...childFolders, ...childFiles],
+    fileCount,
+    totalSize,
+  };
+}
+
+/**
+ * Group a flat list of artifacts into a directory tree.
+ *
+ * Each artifact's `path` is split into folder segments; the final segment is
+ * the file leaf. Artifacts with no folder component (a bare filename) become
+ * top-level files. The result is fully sorted (folders first, then files, each
+ * alphabetical) with recursive `fileCount` / `totalSize` aggregates on every
+ * folder.
+ *
+ * Duplicate paths keep the last artifact seen. An empty input yields `[]`.
+ */
+export function buildArtifactTree(artifacts: Artifact[]): ArtifactTreeNode[] {
+  const root = newFolder("", "");
+
+  for (const artifact of artifacts) {
+    const segments = splitArtifactPath(artifact.path || artifact.name || "");
+    if (segments.length === 0) continue;
+
+    const fileName = segments[segments.length - 1];
+    const folderSegments = segments.slice(0, -1);
+
+    let cursor = root;
+    let prefix = "";
+    for (const segment of folderSegments) {
+      prefix = prefix ? `${prefix}/${segment}` : segment;
+      let next = cursor.folders.get(segment);
+      if (!next) {
+        next = newFolder(segment, prefix);
+        cursor.folders.set(segment, next);
+      }
+      cursor = next;
+    }
+
+    const filePath = prefix ? `${prefix}/${fileName}` : fileName;
+    const fileNode: ArtifactTreeFile = {
+      type: "file",
+      name: fileName,
+      path: filePath,
+      artifact,
+    };
+    // De-dupe on file name within the same folder (last wins).
+    const existingIndex = cursor.files.findIndex((f) => f.name === fileName);
+    if (existingIndex >= 0) {
+      cursor.files[existingIndex] = fileNode;
+    } else {
+      cursor.files.push(fileNode);
+    }
+  }
+
+  return emitFolder(root).children;
+}
+
+/** Total number of file leaves across a tree (recursive). */
+export function countTreeFiles(nodes: ArtifactTreeNode[]): number {
+  return nodes.reduce((sum, node) => {
+    if (node.type === "file") return sum + 1;
+    return sum + node.fileCount;
+  }, 0);
+}


### PR DESCRIPTION
## Summary

Adds a browseable **folder tree** view for **RAW/Generic** repositories, so their contents can be explored as a navigable directory tree (expand/collapse folders, drill into paths) instead of only a flat, paginated list.

Closes #631 — the web-frontend tracking issue for product request `artifact-keeper/artifact-keeper#2791`.

### What changed
- **`src/lib/artifact-tree.ts`** — a pure `buildArtifactTree()` that groups a flat artifact list (by each artifact's `path`) into a sorted directory tree with recursive per-folder file-count and size aggregates. No React, no fetching — fully unit-testable. Also `splitArtifactPath` and `countTreeFiles` helpers.
- **`ArtifactFolderTree`** (`_components/artifact-folder-tree.tsx`) — renders the tree: expandable/collapsible folders (top level expanded by default, deeper levels collapsed for progressive disclosure), clickable file leaves that hand the full `Artifact` back to the caller. Reuses the existing artifact **detail dialog** (view/download/SBOM/security) so there is no parallel file-view path. Loading skeleton + empty state; `tree`/`treeitem`/`group` ARIA roles with `aria-expanded`/`aria-selected`.
- **`ArtifactBrowserToggle`** — extended with a `tree` mode and `supportsTree(format)` (currently `generic`). Groupable formats (Maven/Gradle/Docker) keep their existing Flat/Grouped toggle unchanged; tree-capable formats get a Flat/Tree toggle.
- **`repo-detail-content.tsx`** — the Artifacts tab renders the tree when `?view=tree` is active on a tree-capable repo (the `?view=` param is already the shareable, refresh-surviving source of truth). Tree mode loads the listing on a single bounded page (same pattern as Docker grouping) so the whole tree is built client-side. **Other repo types are untouched.**

### Approach note
The grouping is done **client-side from the existing flat artifacts listing** (the issue's "group flat artifact paths into a directory tree"), so no new backend endpoint or SDK change is required. A separate server-driven `FileTree` already exists for single-package file browsing; this is deliberately a different, whole-repo view for path-only RAW/Generic repos.

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally *(build + component/RTL render; no live backend in this environment — see below)*
- [x] No regressions in existing tests

## UI Changes
- [ ] Playwright E2E spec covers the change
- [x] Responsive layout verified (uses existing tokens/primitives; tree scrolls within its container)
- [x] Dark mode verified (semantic Tailwind tokens only — `bg-muted`, `text-muted-foreground`, `border`)
- [x] Accessibility checked (keyboard-focusable buttons, `tree`/`treeitem` roles, `aria-expanded`/`aria-selected`, SR-only live status for the view toggle)
- [ ] N/A - no UI changes

### Validation performed
- `npm run lint` — 0 errors (pre-existing warnings only, none in changed files)
- `npx vitest run` — full suite green (2833 tests)
- `npm run build` — succeeds
- New-code coverage: `artifact-tree.ts` 100%, `artifact-folder-tree.tsx` ~100% on changed lines (above the 80% gate)

E2E against a live backend was not run (no backend in this environment); the pure tree-building/grouping logic and the component's expand/collapse, selection, and empty/loading states are covered by unit + RTL tests instead.


<!-- linked-issue: #631 (web) tracks artifact-keeper/artifact-keeper#2791 -->