### PR TITLE
feat(repositories): default to Packages tab for package-oriented formats

### DIFF
--- a/e2e/suites/interactions/repositories/artifact-browser-grouping.spec.ts
+++ b/e2e/suites/interactions/repositories/artifact-browser-grouping.spec.ts
@@ -44,10 +44,15 @@ async function findRepoByFormat(
 async function gotoArtifactsTab(page: Page, repoKey: string): Promise<void> {
   await page.goto(`/repositories/${repoKey}`);
   await page.waitForLoadState('domcontentloaded');
-  // The Artifacts tab is the default tab on repo detail
-  await expect(
-    page.locator('[role="tablist"]').getByText(/artifacts/i).first(),
-  ).toBeVisible({ timeout: 10000 });
+  // Package-oriented formats (Maven/Gradle) now default to the Packages tab
+  // (#2793), so select the Artifacts tab explicitly rather than assuming it is
+  // the default. Clicking it is a no-op when it is already active.
+  const artifactsTab = page
+    .locator('[role="tablist"]')
+    .getByText(/artifacts/i)
+    .first();
+  await expect(artifactsTab).toBeVisible({ timeout: 10000 });
+  await artifactsTab.click();
 }
 
 test.describe('Artifact Browser Grouping (#254 Maven, #330 Docker)', () => {

--- a/e2e/suites/interactions/repositories/maven-gav-search-pom.spec.ts
+++ b/e2e/suites/interactions/repositories/maven-gav-search-pom.spec.ts
@@ -119,7 +119,9 @@ test.describe('Maven GAV search and POM', () => {
   });
 
   test('POM file is listed and linked in the grouped Maven browser (#442)', async ({ page }) => {
-    await page.goto(`/repositories/${REPO_KEY}`);
+    // `?view=grouped` pins the Artifacts tab (Maven now defaults to Packages,
+    // #2793) and opens its grouped browser directly.
+    await page.goto(`/repositories/${REPO_KEY}?view=grouped`);
     await page.waitForLoadState('domcontentloaded');
 
     // The grouped Maven view renders <MavenComponentList>; find our GAV row.

--- a/e2e/suites/interactions/repositories/packages-default-tab.spec.ts
+++ b/e2e/suites/interactions/repositories/packages-default-tab.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * #2793 — the repository-detail page chooses its default primary tab by format:
+ * package-oriented formats (Maven/npm/PyPI/…) open on the Packages tab, where
+ * their catalog lives, while RAW/Generic and container formats keep Artifacts.
+ * An explicit `?tab=` deep-link overrides the format default.
+ *
+ * These assert the initially-active tab via Radix's `aria-selected` marker.
+ * Each test skips gracefully when its seed repository is not present so the
+ * suite is safe on constrained environments.
+ */
+test.describe('Repository detail default tab (#2793)', () => {
+  async function repoExists(page: Page, key: string): Promise<boolean> {
+    const res = await page.request.get(`/api/v1/repositories/${key}`);
+    return res.ok();
+  }
+
+  /** Text label of the initially-selected primary tab. */
+  async function activeTabLabel(page: Page): Promise<string> {
+    const active = page
+      .locator('[role="tablist"]')
+      .first()
+      .locator('[role="tab"][aria-selected="true"]')
+      .first();
+    await expect(active).toBeVisible({ timeout: 10000 });
+    return ((await active.textContent()) || '').trim();
+  }
+
+  test('Maven (package-oriented) repo opens on the Packages tab', async ({ page }) => {
+    const key = 'e2e-maven-local';
+    test.skip(!(await repoExists(page, key)), `${key} not seeded`);
+
+    await page.goto(`/repositories/${key}`);
+    await page.waitForLoadState('domcontentloaded');
+
+    expect(await activeTabLabel(page)).toMatch(/packages/i);
+  });
+
+  test('Generic (RAW) repo opens on the Artifacts tab', async ({ page }) => {
+    const key = 'e2e-generic-versioned';
+    test.skip(!(await repoExists(page, key)), `${key} not seeded`);
+
+    await page.goto(`/repositories/${key}`);
+    await page.waitForLoadState('domcontentloaded');
+
+    expect(await activeTabLabel(page)).toMatch(/artifacts/i);
+  });
+
+  test('explicit ?tab=artifacts overrides the per-format default', async ({ page }) => {
+    const key = 'e2e-maven-local';
+    test.skip(!(await repoExists(page, key)), `${key} not seeded`);
+
+    await page.goto(`/repositories/${key}?tab=artifacts`);
+    await page.waitForLoadState('domcontentloaded');
+
+    expect(await activeTabLabel(page)).toMatch(/artifacts/i);
+  });
+});

--- a/e2e/suites/interactions/repositories/repo-detail.spec.ts
+++ b/e2e/suites/interactions/repositories/repo-detail.spec.ts
@@ -49,7 +49,7 @@ test.describe('Repository Detail Page', () => {
     expect(hasFormat).toBeTruthy();
   });
 
-  test('artifacts tab is default and shows artifacts or empty state', async ({ page }) => {
+  test('artifacts tab shows artifacts or empty state', async ({ page }) => {
     if (!repoKey) {
       const response = await page.request.get('/api/v1/repositories');
       if (response.ok()) {
@@ -65,9 +65,11 @@ test.describe('Repository Detail Page', () => {
     await page.goto(`/repositories/${repoKey}`);
     await page.waitForLoadState('domcontentloaded');
 
-    // Artifacts tab should be selected by default
+    // Select the Artifacts tab explicitly: package-oriented formats now default
+    // to the Packages tab (#2793), so we can't assume Artifacts is active.
     const artifactsTab = page.locator('[role="tablist"]').getByText(/artifacts/i);
     await expect(artifactsTab).toBeVisible({ timeout: 10000 });
+    await artifactsTab.first().click();
 
     // Should show either an artifacts table or an empty state message
     const hasTable = await page.locator('table').first().isVisible({ timeout: 5000 }).catch(() => false);

--- a/src/app/(app)/repositories/_components/repo-detail-content.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.test.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -188,6 +189,49 @@ describe("RepoDetailContent tab strip", () => {
   });
 });
 
+describe("RepoDetailContent default primary tab (#2793)", () => {
+  beforeEach(() => {
+    cleanup();
+    repository.format = "generic";
+  });
+  afterEach(() => {
+    cleanup();
+    repository.format = "generic";
+  });
+
+  it("defaults RAW/Generic repositories to the Artifacts tab", () => {
+    repository.format = "generic";
+    render(<RepoDetailContent repoKey="demo" />);
+
+    expect(screen.getByRole("tab", { name: /artifacts/i })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByRole("tab", { name: /packages/i })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+    // Active panel is the artifact browser (its stubbed row is mounted).
+    expect(screen.getByTestId("stub-row-a1")).toBeInTheDocument();
+  });
+
+  it("defaults package-oriented (Maven) repositories to the Packages tab", () => {
+    repository.format = "maven";
+    render(<RepoDetailContent repoKey="demo" />);
+
+    expect(screen.getByRole("tab", { name: /packages/i })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByRole("tab", { name: /artifacts/i })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+    // Active panel is the Packages view (stubbed), not the artifact browser.
+    expect(document.querySelector('[data-stub="packages"]')).toBeInTheDocument();
+  });
+});
+
 describe("RepoDetailContent artifact detail dialog — Versions tab (#571)", () => {
   beforeEach(() => {
     cleanup();
@@ -202,7 +246,11 @@ describe("RepoDetailContent artifact detail dialog — Versions tab (#571)", () 
 
   async function openDetailDialog() {
     render(<RepoDetailContent repoKey="demo" />);
-    const row = screen.getByTestId("stub-row-a1");
+    // The artifact row lives on the Artifacts tab. For package-oriented formats
+    // (e.g. maven) that tab is no longer the default (#2793), so select it
+    // explicitly before opening the detail dialog.
+    await userEvent.click(screen.getByRole("tab", { name: /artifacts/i }));
+    const row = await screen.findByTestId("stub-row-a1", {}, { timeout: 2000 });
     row.click();
     // The dialog tablist renders synchronously once selectedArtifact is set.
     return await screen.findByText("Artifact Details", {}, { timeout: 2000 }).catch(() => null);

--- a/src/app/(app)/repositories/_components/repo-detail-content.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.tsx
@@ -60,6 +60,7 @@ import { QuarantineBanner } from "@/components/common/quarantine-banner";
 import { RepoSettingsTab } from "./repo-settings-tab";
 import { RepoStoragePanel } from "./repo-storage-panel";
 import { RepoFolderStoragePanel } from "./repo-folder-storage-panel";
+import { resolveInitialRepoTab } from "@/lib/repo-tabs";
 import { formatBytes, REPO_TYPE_COLORS } from "@/lib/utils";
 import { useAuth } from "@/providers/auth-provider";
 import { useSystemConfig } from "@/providers/system-config-provider";
@@ -670,8 +671,19 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
         isAdmin={!!user?.is_admin}
       />
 
-      {/* Tabs */}
-      <Tabs defaultValue="artifacts">
+      {/* Tabs. The default primary tab is format-driven (#2793): package-oriented
+          formats (Maven/npm/PyPI/…) open on Packages, where their catalog lives;
+          RAW/Generic and container formats keep Artifacts. An explicit `?tab=`
+          wins, and any `?view=` artifact deep-link pins Artifacts. `repository`
+          is loaded before this renders (guards above), so the format is known
+          when the uncontrolled Tabs mounts. */}
+      <Tabs
+        defaultValue={resolveInitialRepoTab(
+          searchParams.get("tab"),
+          searchParams.get("view"),
+          repoFormat,
+        )}
+      >
         <TabsList variant="line">
           <TabsTrigger value="artifacts">
             <FileArchive className="size-3.5 mr-1" />

--- a/src/lib/__tests__/repo-tabs.test.ts
+++ b/src/lib/__tests__/repo-tabs.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  isPackageOrientedFormat,
+  defaultRepoTab,
+  resolveInitialRepoTab,
+} from "@/lib/repo-tabs";
+import type { RepositoryFormat } from "@/types";
+
+describe("isPackageOrientedFormat", () => {
+  it.each<[RepositoryFormat, boolean]>([
+    // package-oriented
+    ["maven", true],
+    ["gradle", true],
+    ["npm", true],
+    ["pypi", true],
+    ["cargo", true],
+    ["nuget", true],
+    ["rubygems", true],
+    ["go", true],
+    ["composer", true],
+    ["helm", true],
+    ["rpm", true],
+    ["debian", true],
+    // NOT package-oriented (artifact / image / blob)
+    ["generic", false],
+    ["docker", false],
+    ["podman", false],
+    ["oras", false],
+    ["wasm_oci", false],
+    ["gitlfs", false],
+  ])("returns %s => %s", (format, expected) => {
+    expect(isPackageOrientedFormat(format)).toBe(expected);
+  });
+});
+
+describe("defaultRepoTab", () => {
+  it("defaults package-oriented formats to the Packages tab", () => {
+    expect(defaultRepoTab("maven")).toBe("packages");
+    expect(defaultRepoTab("npm")).toBe("packages");
+    expect(defaultRepoTab("pypi")).toBe("packages");
+  });
+
+  it("defaults RAW/Generic and container formats to the Artifacts tab", () => {
+    expect(defaultRepoTab("generic")).toBe("artifacts");
+    expect(defaultRepoTab("docker")).toBe("artifacts");
+  });
+
+  it("defaults to Artifacts when the format is unknown/undefined", () => {
+    expect(defaultRepoTab(undefined)).toBe("artifacts");
+  });
+});
+
+describe("resolveInitialRepoTab", () => {
+  it("uses the per-format default when there is no override", () => {
+    expect(resolveInitialRepoTab(null, null, "maven")).toBe("packages");
+    expect(resolveInitialRepoTab(null, null, "generic")).toBe("artifacts");
+  });
+
+  it("honors an explicit, valid ?tab= override above everything", () => {
+    // force Artifacts on a package format
+    expect(resolveInitialRepoTab("artifacts", null, "maven")).toBe("artifacts");
+    // force Packages on a generic repo
+    expect(resolveInitialRepoTab("packages", null, "generic")).toBe("packages");
+    // ?tab wins even when ?view is also present
+    expect(resolveInitialRepoTab("packages", "grouped", "maven")).toBe(
+      "packages",
+    );
+  });
+
+  it("ignores an invalid ?tab= value and falls back", () => {
+    expect(resolveInitialRepoTab("bogus", null, "maven")).toBe("packages");
+    expect(resolveInitialRepoTab("", null, "generic")).toBe("artifacts");
+  });
+
+  it("pins the Artifacts tab whenever a ?view= artifact deep-link is present", () => {
+    // ?view is an Artifacts-browser concept, so even a package format lands on
+    // Artifacts when a view is requested (preserves existing artifact links).
+    expect(resolveInitialRepoTab(null, "flat", "maven")).toBe("artifacts");
+    expect(resolveInitialRepoTab(null, "grouped", "npm")).toBe("artifacts");
+    expect(resolveInitialRepoTab(null, "tree", "generic")).toBe("artifacts");
+  });
+
+  it("treats an empty ?view= as absent", () => {
+    expect(resolveInitialRepoTab(null, "", "maven")).toBe("packages");
+  });
+});

--- a/src/lib/repo-tabs.ts
+++ b/src/lib/repo-tabs.ts
@@ -1,0 +1,109 @@
+import type { RepositoryFormat } from "@/types";
+
+/**
+ * Repository-detail primary tabs whose default selection is format-driven
+ * (issue #2793). Other tabs (upload, members, security, settings, …) are never
+ * the default and are not modelled here.
+ */
+export type RepoDetailTab = "artifacts" | "packages";
+
+/**
+ * Formats that expose a first-class **package catalog** — a name/version
+ * grouping the backend surfaces via `GET /api/v1/packages` (Maven
+ * `groupId:artifactId`, npm package name, PyPI project, an OS package, …). For
+ * these, the Packages view is the primary way a user browses the repository, so
+ * the repository-detail page defaults to the Packages tab.
+ *
+ * Deliberately conservative: RAW/Generic and container/OCI image formats
+ * (`generic`, `docker`, `podman`, `buildx`, `oras`, `wasm_oci`, `incus`,
+ * `lxc`), blob stores (`gitlfs`), and formats whose "package" semantics are
+ * fuzzier (`terraform`, `opentofu`, `vagrant`, `bazel`, `protobuf`, `p2`,
+ * `huggingface`, `mlmodel`, `vscode`, `jetbrains`) are intentionally **not**
+ * included and keep the Artifacts tab as their default. Extend this set as more
+ * formats grow a stable package catalog.
+ */
+const PACKAGE_ORIENTED_FORMATS = new Set<RepositoryFormat>([
+  // JVM
+  "maven",
+  "gradle",
+  "sbt",
+  // JavaScript
+  "npm",
+  "yarn",
+  "pnpm",
+  "bower",
+  // Python
+  "pypi",
+  "poetry",
+  // Rust / Go / Ruby / PHP
+  "cargo",
+  "go",
+  "rubygems",
+  "composer",
+  // .NET / Windows
+  "nuget",
+  "chocolatey",
+  "powershell",
+  // Conda / Elixir / Dart / R / Swift-ecosystem
+  "conda",
+  "conda_native",
+  "hex",
+  "pub",
+  "cran",
+  "cocoapods",
+  "swift",
+  // Charts & OS packages
+  "helm",
+  "helm_oci",
+  "rpm",
+  "debian",
+  "alpine",
+  "opkg",
+  // Config-management modules
+  "puppet",
+  "chef",
+  "ansible",
+]);
+
+export function isPackageOrientedFormat(format: RepositoryFormat): boolean {
+  return PACKAGE_ORIENTED_FORMATS.has(format);
+}
+
+/**
+ * The per-format default primary tab: Packages for formats with a package
+ * catalog, Artifacts for everything else (RAW/Generic, containers, unknown).
+ */
+export function defaultRepoTab(
+  format: RepositoryFormat | undefined,
+): RepoDetailTab {
+  return format && isPackageOrientedFormat(format) ? "packages" : "artifacts";
+}
+
+const VALID_TABS = new Set<RepoDetailTab>(["artifacts", "packages"]);
+
+function isValidTab(value: string | null | undefined): value is RepoDetailTab {
+  return !!value && VALID_TABS.has(value as RepoDetailTab);
+}
+
+/**
+ * Resolve the initial primary tab for the repository-detail page.
+ *
+ * Precedence:
+ *  1. An explicit, valid `?tab=` deep-link always wins (shareable override).
+ *  2. A `?view=` param is an Artifacts-browser concept (flat/grouped/tree), so
+ *     its presence pins the Artifacts tab — this keeps existing artifact
+ *     deep-links landing on the artifact browser even for package formats.
+ *  3. Otherwise fall back to the per-format default.
+ *
+ * Used only to seed the Tabs `defaultValue` (uncontrolled), so it sets the
+ * initial tab without hijacking later user clicks.
+ */
+export function resolveInitialRepoTab(
+  urlTab: string | null | undefined,
+  urlView: string | null | undefined,
+  format: RepositoryFormat | undefined,
+): RepoDetailTab {
+  if (isValidTab(urlTab)) return urlTab;
+  if (urlView != null && urlView !== "") return "artifacts";
+  return defaultRepoTab(format);
+}


### PR DESCRIPTION
## Summary

Makes the repository-detail page open on the **Packages** tab for package-oriented formats (Maven, npm, PyPI, and other package-catalog formats), where their catalog lives — while keeping the **Artifacts** tab default for RAW/Generic and container/OCI formats.

Closes #632 — the web-frontend tracking issue for product request `artifact-keeper/artifact-keeper#2793`.

### What changed
- **`src/lib/repo-tabs.ts`** (new) — pure, tested tab-selection logic:
  - `isPackageOrientedFormat(format)` / `defaultRepoTab(format)` — a conservative set of package-catalog formats (JVM, JS, Python, Rust/Go/Ruby/PHP, .NET, Conda/Elixir/Dart/R/Swift, charts, OS packages, config-mgmt). RAW/Generic, containers/OCI, blob stores, and fuzzier formats keep Artifacts.
  - `resolveInitialRepoTab(urlTab, urlView, format)` — precedence: explicit `?tab=` deep-link → `?view=` (an Artifacts-browser concept) pins Artifacts → per-format default.
- **`repo-detail-content.tsx`** — seeds the `Tabs` `defaultValue` from `resolveInitialRepoTab(...)`. `repository` is loaded before the Tabs mount (guards above), so the format is known; the Tabs stay uncontrolled, so user clicks are unaffected.

### Approach note
The Packages catalog listing itself already exists (`GET /api/v1/packages` via the SDK, rendered by the existing Packages tab, which post-#2723/#2889 includes Maven `groupId:artifactId`). This PR is the **discoverability** half of #2793: it makes Packages the primary landing view where a catalog is meaningful, plus a shareable `?tab=` override. No SDK/API change.

### Default-tab decision (flagged for review)
The default-tab flip **is included** (the issue said "implement … if it's clean"). Two points for review:
1. The **format set** is intentionally conservative — please sanity-check membership (e.g., should `terraform`/`opentofu`, `huggingface`/`mlmodel`, `vscode`/`jetbrains`, `gitlfs`, or the OCI `oras`/`wasm_oci` be package-oriented? They are currently **not**).
2. `?view=` is treated as an Artifacts-only concept and pins the Artifacts tab, which preserves existing artifact deep-links.

## Test Checklist
- [x] Unit tests added/updated
- [x] E2E Playwright tests added/updated
- [x] Manually tested locally *(build + component/RTL; no live backend here — see below)*
- [x] No regressions in existing tests

## UI Changes
- [x] Playwright E2E spec covers the change (`packages-default-tab.spec.ts`)
- [x] Responsive layout verified (no new layout; existing tabs)
- [x] Dark mode verified (no new styling)
- [x] Accessibility checked (default tab set via Radix `defaultValue`; active tab exposes `aria-selected`)
- [ ] N/A - no UI changes

### Validation performed
- `npm run lint` — 0 errors (pre-existing warnings only, none in changed files)
- `npx vitest run` — full suite green (2828 tests)
- `npm run build` — succeeds
- New-code coverage: `repo-tabs.ts` 100%; changed `repo-detail-content` lines covered by the new default-tab tests

E2E was not run here (no backend in this environment). To keep CI E2E green with the new default, the Artifacts-tab specs now select the Artifacts tab explicitly (grouping helper, grouped-Maven POM test, repo-detail smoke test) — strictly-more-robust changes (clicking an already-active tab is a no-op) — and a new `packages-default-tab.spec.ts` asserts the format-driven default and the `?tab=` override against the seeded Maven and Generic repos.
