### PR TITLE
Add age-gate review queue admin page

### DIFF
--- a/src/app/(app)/(admin)/age-gate/page.test.tsx
+++ b/src/app/(app)/(admin)/age-gate/page.test.tsx
@@ -1,0 +1,220 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+  Element.prototype.scrollIntoView = vi.fn();
+  Element.prototype.hasPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+});
+
+interface MutationConfig {
+  mutationFn: (...a: unknown[]) => unknown;
+  onSuccess?: (...a: unknown[]) => void;
+  onError?: (...a: unknown[]) => void;
+}
+const mutationConfigs: MutationConfig[] = [];
+const mutateFns: Array<ReturnType<typeof vi.fn>> = [];
+const mockInvalidate = vi.fn();
+let reviewsData: { data: unknown; isLoading?: boolean; isError?: boolean; error?: unknown } = {
+  data: [],
+  isLoading: false,
+};
+let repoConfigsData: unknown = {};
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (opts: { queryKey: unknown[]; queryFn: () => unknown; enabled?: boolean }) => {
+    const key = (opts.queryKey as string[])[0];
+    if (key === "age-gate-repo-configs") return { data: repoConfigsData };
+    if (opts.enabled !== false) {
+      try {
+        opts.queryFn();
+      } catch {
+        /* ignore */
+      }
+    }
+    return { refetch: vi.fn(), isFetching: false, ...reviewsData };
+  },
+  useMutation: (config: MutationConfig) => {
+    mutationConfigs.push(config);
+    const mutate = vi.fn();
+    mutateFns.push(mutate);
+    return { mutate, isPending: false };
+  },
+  useQueryClient: () => ({ invalidateQueries: mockInvalidate }),
+}));
+
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({ toast: { success: (...a: unknown[]) => mockToastSuccess(...a), error: vi.fn() } }));
+
+const api = {
+  listReviews: vi.fn(),
+  getReview: vi.fn(),
+  approveReview: vi.fn(),
+  rejectReview: vi.fn(),
+  getRepoConfigs: vi.fn(),
+};
+vi.mock("@/lib/api/age-gate", () => ({
+  default: {
+    listReviews: (...a: unknown[]) => api.listReviews(...a),
+    getReview: (...a: unknown[]) => api.getReview(...a),
+    approveReview: (...a: unknown[]) => api.approveReview(...a),
+    rejectReview: (...a: unknown[]) => api.rejectReview(...a),
+    getRepoConfigs: (...a: unknown[]) => api.getRepoConfigs(...a),
+  },
+}));
+
+let isAdmin = true;
+vi.mock("@/providers/auth-provider", () => ({
+  useAuth: () => ({ user: isAdmin ? { is_admin: true } : { is_admin: false } }),
+}));
+
+// Native <select> that forwards aria-label so tests can target each one.
+vi.mock("@/components/ui/select", () => ({
+  Select: ({ value, onValueChange, children }: { value?: string; onValueChange?: (v: string) => void; children: React.ReactNode }) => {
+    const items: Array<{ value: string; label: string }> = [];
+    let ariaLabel = "";
+    React.Children.forEach(children, (child) => {
+      if (!React.isValidElement(child)) return;
+      const el = child as React.ReactElement<{ "aria-label"?: string; children?: React.ReactNode }>;
+      if (el.props["aria-label"]) ariaLabel = el.props["aria-label"];
+      React.Children.forEach(el.props.children, (sub) => {
+        if (React.isValidElement(sub) && (sub.props as Record<string, unknown>).value) {
+          const p = sub.props as { value: string; children: React.ReactNode };
+          items.push({ value: p.value, label: String(p.children) });
+        }
+      });
+    });
+    return (
+      <select aria-label={ariaLabel} value={value} onChange={(e) => onValueChange?.(e.target.value)}>
+        {items.map((i) => (
+          <option key={i.value} value={i.value}>{i.label}</option>
+        ))}
+      </select>
+    );
+  },
+  SelectTrigger: ({ children, ...p }: { children: React.ReactNode }) => <span {...p}>{children}</span>,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => <option value={value}>{children}</option>,
+}));
+
+import AgeGatePage from "./page";
+
+const REVIEW = {
+  id: "rv1",
+  packageName: "leftpad-clone",
+  packageVersion: "0.0.1",
+  repositoryKey: "npm-remote",
+  status: "pending",
+  requestCount: 4,
+  requestedAt: "2026-07-15T00:00:00Z",
+  lastRequestedAt: "2026-07-20T00:00:00Z",
+  upstreamPublishedAt: "2026-07-10T00:00:00Z",
+  ageDaysAtRequest: 5,
+  reviewReason: null,
+  reviewedAt: null,
+  reviewedBy: null,
+};
+
+const approveMutate = () => mutateFns[mutateFns.length - 1];
+
+beforeEach(() => {
+  mutationConfigs.length = 0;
+  mutateFns.length = 0;
+  vi.clearAllMocks();
+  isAdmin = true;
+  reviewsData = { data: [], isLoading: false };
+  repoConfigsData = {};
+});
+afterEach(() => cleanup());
+
+describe("AgeGatePage", () => {
+  it("gates non-admins", () => {
+    isAdmin = false;
+    render(<AgeGatePage />);
+    expect(screen.getByText(/requires administrator access/i)).toBeInTheDocument();
+  });
+
+  it("shows the empty queue by default (pending)", () => {
+    render(<AgeGatePage />);
+    expect(screen.getByText(/No pending releases/i)).toBeInTheDocument();
+    expect(api.listReviews).toHaveBeenCalledWith({ status: "pending" });
+  });
+
+  it("shows an error state with retry", () => {
+    reviewsData = { data: undefined, isLoading: false, isError: true, error: new Error("x") };
+    render(<AgeGatePage />);
+    expect(screen.getByText(/Couldn't load the age gate queue/i)).toBeInTheDocument();
+  });
+
+  it("lists held releases with age-at-request and repository", () => {
+    reviewsData = { data: [REVIEW], isLoading: false };
+    repoConfigsData = { "npm-remote": { repositoryKey: "npm-remote", enabled: true, minAgeDays: 14 } };
+    render(<AgeGatePage />);
+    expect(screen.getByText("leftpad-clone")).toBeInTheDocument();
+    expect(screen.getByText("npm-remote")).toBeInTheDocument();
+    expect(screen.getByText(/5d old \(min 14d\)/)).toBeInTheDocument();
+  });
+
+  it("approves a held release with a reason", async () => {
+    const user = userEvent.setup();
+    reviewsData = { data: [REVIEW], isLoading: false };
+    render(<AgeGatePage />);
+    await user.click(screen.getByRole("button", { name: /Approve leftpad-clone/i }));
+    const dialog = await screen.findByRole("dialog");
+    await user.type(within(dialog).getByLabelText("Reason"), "verified safe");
+    await user.click(within(dialog).getByRole("button", { name: /confirm/i }));
+    expect(approveMutate()).toHaveBeenCalledWith({ review: REVIEW, action: "approve", why: "verified safe" });
+  });
+
+  it("rejects a held release without requiring a reason", async () => {
+    const user = userEvent.setup();
+    reviewsData = { data: [REVIEW], isLoading: false };
+    render(<AgeGatePage />);
+    await user.click(screen.getByRole("button", { name: /Reject leftpad-clone/i }));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: /confirm/i }));
+    expect(approveMutate()).toHaveBeenCalledWith({ review: REVIEW, action: "reject", why: "" });
+  });
+
+  it("clears the reason when the dialog is cancelled", async () => {
+    const user = userEvent.setup();
+    reviewsData = { data: [REVIEW], isLoading: false };
+    render(<AgeGatePage />);
+    await user.click(screen.getByRole("button", { name: /Approve leftpad-clone/i }));
+    let dialog = await screen.findByRole("dialog");
+    await user.type(within(dialog).getByLabelText("Reason"), "typed");
+    await user.click(within(dialog).getByRole("button", { name: /cancel/i }));
+    await user.click(screen.getByRole("button", { name: /Approve leftpad-clone/i }));
+    dialog = await screen.findByRole("dialog");
+    expect((within(dialog).getByLabelText("Reason") as HTMLInputElement).value).toBe("");
+  });
+
+  it("hides the Approve action on the approved queue and Reject on the rejected queue", async () => {
+    const user = userEvent.setup();
+    reviewsData = { data: [{ ...REVIEW, status: "approved" }], isLoading: false };
+    render(<AgeGatePage />);
+    await user.selectOptions(screen.getByLabelText("Status filter"), "approved");
+    expect(screen.queryByRole("button", { name: /Approve leftpad-clone/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Reject leftpad-clone/i })).toBeInTheDocument();
+  });
+
+  it("mutation callbacks invalidate and toast on success, and call the API on submit", () => {
+    render(<AgeGatePage />);
+    const [action] = mutationConfigs;
+    action.mutationFn({ review: REVIEW, action: "approve", why: "ok" });
+    expect(api.approveReview).toHaveBeenCalledWith("rv1", "ok");
+    action.onSuccess?.(REVIEW, { review: REVIEW, action: "approve" });
+    expect(mockInvalidate).toHaveBeenCalled();
+    expect(mockToastSuccess).toHaveBeenCalled();
+  });
+});

--- a/src/app/(app)/(admin)/age-gate/page.tsx
+++ b/src/app/(app)/(admin)/age-gate/page.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Hourglass, Check, X, RefreshCw, AlertCircle, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import ageGateApi, { type AgeGateReview } from "@/lib/api/age-gate";
+import { mutationErrorToast, toUserMessage } from "@/lib/error-utils";
+import { useAuth } from "@/providers/auth-provider";
+import { formatDate } from "@/lib/utils";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+
+const STATUSES = ["pending", "approved", "rejected"] as const;
+
+/** How far a held release fell short of its repository's minimum age. */
+function formatAge(review: AgeGateReview, minAgeDays: number | undefined): string {
+  const age = review.ageDaysAtRequest === null ? "—" : `${review.ageDaysAtRequest}d old`;
+  if (minAgeDays === undefined) return age;
+  return `${age} (min ${minAgeDays}d)`;
+}
+
+export default function AgeGatePage() {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+
+  const [status, setStatus] = useState<string>("pending");
+  const [actionTarget, setActionTarget] = useState<
+    { review: AgeGateReview; action: "approve" | "reject" } | null
+  >(null);
+  const [reason, setReason] = useState("");
+
+  const reviewsQueryKey = ["age-gate-reviews", status];
+  const {
+    data: reviews,
+    isLoading,
+    isError,
+    error,
+    refetch,
+    isFetching,
+  } = useQuery({
+    queryKey: reviewsQueryKey,
+    queryFn: () => ageGateApi.listReviews({ status }),
+    enabled: !!user?.is_admin,
+  });
+
+  const rows = reviews ?? [];
+  const repositoryKeys = useMemo(
+    () => [...new Set((reviews ?? []).map((r) => r.repositoryKey))],
+    [reviews],
+  );
+
+  const { data: repoConfigs } = useQuery({
+    queryKey: ["age-gate-repo-configs", repositoryKeys],
+    queryFn: () => ageGateApi.getRepoConfigs(repositoryKeys),
+    enabled: !!user?.is_admin && repositoryKeys.length > 0,
+  });
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ["age-gate-reviews"] });
+  };
+
+  const closeDialog = () => {
+    setActionTarget(null);
+    setReason("");
+  };
+
+  const actionMutation = useMutation({
+    mutationFn: ({
+      review,
+      action,
+      why,
+    }: {
+      review: AgeGateReview;
+      action: "approve" | "reject";
+      why: string;
+    }) =>
+      action === "approve"
+        ? ageGateApi.approveReview(review.id, why || undefined)
+        : ageGateApi.rejectReview(review.id, why || undefined),
+    onSuccess: (_result, { review, action }) => {
+      invalidate();
+      closeDialog();
+      toast.success(
+        `${action === "approve" ? "Approved" : "Rejected"} ${review.packageName}@${review.packageVersion}`,
+      );
+    },
+    onError: mutationErrorToast("Age gate review failed"),
+  });
+
+  if (!user?.is_admin) {
+    return (
+      <div className="p-8 text-center text-muted-foreground" role="alert">
+        <Hourglass className="mx-auto mb-2 size-8 opacity-50" />
+        <p className="text-sm">The age gate review queue requires administrator access.</p>
+      </div>
+    );
+  }
+
+  const canApprove = status !== "approved";
+  const canReject = status !== "rejected";
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex items-center gap-2">
+        <Hourglass className="size-6" />
+        <div>
+          <h1 className="text-xl font-semibold">Age Gate Review Queue</h1>
+          <p className="text-sm text-muted-foreground">
+            Review upstream releases held back for being younger than a repository&apos;s minimum age.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Select value={status} onValueChange={setStatus}>
+          <SelectTrigger className="w-40" aria-label="Status filter">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {STATUSES.map((s) => (
+              <SelectItem key={s} value={s} className="capitalize">{s}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Button
+          variant="outline"
+          size="sm"
+          className="ml-auto"
+          disabled={isFetching}
+          onClick={() => refetch()}
+        >
+          <RefreshCw className={`size-4 ${isFetching ? "animate-spin" : ""}`} />
+          Refresh
+        </Button>
+      </div>
+
+      {isLoading && (
+        <div className="space-y-2" role="status" aria-busy="true">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+      )}
+
+      {!isLoading && isError && (
+        <div className="flex flex-col items-center justify-center py-12 text-center" role="alert">
+          <AlertCircle className="size-8 mb-2 text-destructive opacity-80" />
+          <p className="text-sm font-medium">Couldn&apos;t load the age gate queue</p>
+          <p className="mt-1 text-xs text-muted-foreground">{toUserMessage(error, "Unknown error")}</p>
+          <Button variant="outline" size="sm" className="mt-4" onClick={() => refetch()} disabled={isFetching}>
+            <RefreshCw className={`size-4 ${isFetching ? "animate-spin" : ""}`} />
+            Retry
+          </Button>
+        </div>
+      )}
+
+      {!isLoading && !isError && rows.length === 0 && (
+        <div className="rounded-md border border-dashed py-12 text-center text-sm text-muted-foreground">
+          No {status} releases in the age gate queue.
+        </div>
+      )}
+
+      {!isLoading && !isError && rows.length > 0 && (
+        <div className="overflow-hidden rounded-md border">
+          <table className="w-full text-sm">
+            <thead className="border-b bg-muted/50 text-left">
+              <tr>
+                <th className="px-3 py-2 font-medium">Package</th>
+                <th className="px-3 py-2 font-medium">Version</th>
+                <th className="px-3 py-2 font-medium">Repository</th>
+                <th className="px-3 py-2 font-medium">Age at request</th>
+                <th className="px-3 py-2 font-medium">Requested</th>
+                <th className="px-3 py-2 font-medium">Status</th>
+                <th className="px-3 py-2" />
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {rows.map((r) => (
+                <tr key={r.id}>
+                  <td className="px-3 py-2 font-medium">{r.packageName}</td>
+                  <td className="px-3 py-2 font-mono text-xs">{r.packageVersion}</td>
+                  <td className="px-3 py-2">
+                    <Badge variant="outline">{r.repositoryKey}</Badge>
+                  </td>
+                  <td className="px-3 py-2 text-xs text-muted-foreground">
+                    {formatAge(r, repoConfigs?.[r.repositoryKey]?.minAgeDays)}
+                  </td>
+                  <td className="px-3 py-2 text-xs text-muted-foreground">{formatDate(r.requestedAt)}</td>
+                  <td className="px-3 py-2">
+                    <Badge
+                      variant={r.status === "rejected" ? "destructive" : r.status === "approved" ? "secondary" : "outline"}
+                      className="capitalize"
+                    >
+                      {r.status}
+                    </Badge>
+                  </td>
+                  <td className="px-3 py-2">
+                    <div className="flex justify-end gap-1">
+                      {canApprove && (
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          aria-label={`Approve ${r.packageName}`}
+                          onClick={() => setActionTarget({ review: r, action: "approve" })}
+                        >
+                          <Check className="size-4 text-emerald-600" />
+                        </Button>
+                      )}
+                      {canReject && (
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          aria-label={`Reject ${r.packageName}`}
+                          onClick={() => setActionTarget({ review: r, action: "reject" })}
+                        >
+                          <X className="size-4 text-destructive" />
+                        </Button>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <Dialog open={actionTarget !== null} onOpenChange={(o) => { if (!o) closeDialog(); }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {actionTarget?.action === "approve" ? "Approve" : "Reject"} {actionTarget?.review.packageName}@{actionTarget?.review.packageVersion}
+            </DialogTitle>
+            <DialogDescription>
+              A reason is recorded in the audit log for this decision.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="py-2">
+            <Input
+              placeholder="Reason (optional)"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              aria-label="Reason"
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={closeDialog}>Cancel</Button>
+            <Button
+              variant={actionTarget?.action === "reject" ? "destructive" : "default"}
+              disabled={actionMutation.isPending}
+              onClick={() =>
+                actionTarget &&
+                actionMutation.mutate({ review: actionTarget.review, action: actionTarget.action, why: reason.trim() })
+              }
+            >
+              {actionMutation.isPending ? <Loader2 className="size-4 animate-spin" /> : null}
+              Confirm
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/layout/__tests__/app-sidebar.test.tsx
+++ b/src/components/layout/__tests__/app-sidebar.test.tsx
@@ -105,6 +105,7 @@ vi.mock("lucide-react", () => {
     ScrollText: icon,
     Network: icon,
     Crosshair: icon,
+    Hourglass: icon,
   };
 });
 

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -45,6 +45,7 @@ import {
   ScrollText,
   Network,
   Crosshair,
+  Hourglass,
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { useAuth } from "@/providers/auth-provider";
@@ -102,6 +103,7 @@ const securityItems: NavItem[] = [
   { title: "Policies", href: "/security/policies", icon: FileCheck },
   { title: "License Policies", href: "/license-policies", icon: Scale },
   { title: "Curation", href: "/curation", icon: PackageCheck },
+  { title: "Age Gate", href: "/age-gate", icon: Hourglass },
   { title: "Signing", href: "/signing", icon: FileSignature },
   { title: "Permissions", href: "/permissions", icon: Lock },
 ];

--- a/src/lib/api/__tests__/age-gate.test.ts
+++ b/src/lib/api/__tests__/age-gate.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../fetch", () => ({ assertData: <T,>(d: T) => d }));
+vi.mock("@/lib/sdk-client", () => ({}));
+
+const m = {
+  listReviews: vi.fn(),
+  getReview: vi.fn(),
+  approveReview: vi.fn(),
+  rejectReview: vi.fn(),
+  getRepoAgeGate: vi.fn(),
+};
+vi.mock("@artifact-keeper/sdk", () => ({
+  listReviews: (...a: unknown[]) => m.listReviews(...a),
+  getReview: (...a: unknown[]) => m.getReview(...a),
+  approveReview: (...a: unknown[]) => m.approveReview(...a),
+  rejectReview: (...a: unknown[]) => m.rejectReview(...a),
+  getRepoAgeGate: (...a: unknown[]) => m.getRepoAgeGate(...a),
+}));
+
+import ageGateApi from "../age-gate";
+
+const REVIEW = {
+  id: "rv1",
+  package_name: "leftpad-clone",
+  package_version: "0.0.1",
+  repository_key: "npm-remote",
+  status: "pending",
+  request_count: 4,
+  requested_at: "2026-07-15T00:00:00Z",
+  last_requested_at: "2026-07-20T00:00:00Z",
+  review_reason: null,
+  reviewed_at: null,
+  reviewed_by: null,
+  upstream_published_at: "2026-07-10T00:00:00Z",
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("ageGateApi", () => {
+  it("listReviews sends the status filter and maps results, computing age at request", async () => {
+    m.listReviews.mockResolvedValue({
+      data: { items: [REVIEW], pagination: { page: 1, per_page: 20, total: 1 } },
+      error: undefined,
+    });
+    const out = await ageGateApi.listReviews({ status: "pending" });
+    expect(m.listReviews).toHaveBeenCalledWith({
+      query: { status: "pending", repository_key: undefined, page: undefined, per_page: undefined },
+    });
+    expect(out[0]).toMatchObject({
+      id: "rv1",
+      packageName: "leftpad-clone",
+      packageVersion: "0.0.1",
+      repositoryKey: "npm-remote",
+      status: "pending",
+      ageDaysAtRequest: 5,
+    });
+  });
+
+  it("listReviews throws on error", async () => {
+    m.listReviews.mockResolvedValue({ data: undefined, error: { status: 400 } });
+    await expect(ageGateApi.listReviews()).rejects.toEqual({ status: 400 });
+  });
+
+  it("listReviews leaves ageDaysAtRequest null when the upstream publish date is unknown", async () => {
+    m.listReviews.mockResolvedValue({
+      data: { items: [{ ...REVIEW, upstream_published_at: null }], pagination: { page: 1, per_page: 20, total: 1 } },
+      error: undefined,
+    });
+    const out = await ageGateApi.listReviews();
+    expect(out[0].ageDaysAtRequest).toBeNull();
+  });
+
+  it("getReview / approveReview / rejectReview pass the id path param and an optional reason", async () => {
+    m.getReview.mockResolvedValue({ data: REVIEW, error: undefined });
+    m.approveReview.mockResolvedValue({ data: REVIEW, error: undefined });
+    m.rejectReview.mockResolvedValue({ data: REVIEW, error: undefined });
+    await ageGateApi.getReview("rv1");
+    await ageGateApi.approveReview("rv1", "known-good release");
+    await ageGateApi.rejectReview("rv1");
+    expect(m.getReview).toHaveBeenCalledWith({ path: { id: "rv1" } });
+    expect(m.approveReview).toHaveBeenCalledWith({ path: { id: "rv1" }, body: { reason: "known-good release" } });
+    expect(m.rejectReview).toHaveBeenCalledWith({ path: { id: "rv1" }, body: { reason: null } });
+  });
+
+  it("approveReview throws on error", async () => {
+    m.approveReview.mockResolvedValue({ data: undefined, error: { status: 500 } });
+    await expect(ageGateApi.approveReview("rv1")).rejects.toEqual({ status: 500 });
+  });
+
+  it("getRepoConfigs dedupes keys and returns a map keyed by repository_key", async () => {
+    m.getRepoAgeGate.mockResolvedValue({
+      data: { repository_key: "npm-remote", enabled: true, min_age_days: 14 },
+      error: undefined,
+    });
+    const out = await ageGateApi.getRepoConfigs(["npm-remote", "npm-remote"]);
+    expect(m.getRepoAgeGate).toHaveBeenCalledTimes(1);
+    expect(m.getRepoAgeGate).toHaveBeenCalledWith({ path: { key: "npm-remote" } });
+    expect(out).toEqual({ "npm-remote": { repositoryKey: "npm-remote", enabled: true, minAgeDays: 14 } });
+  });
+
+  it("getRepoConfigs omits repositories whose policy lookup errors", async () => {
+    m.getRepoAgeGate.mockResolvedValue({ data: undefined, error: { status: 404 } });
+    const out = await ageGateApi.getRepoConfigs(["no-policy-repo"]);
+    expect(out).toEqual({});
+  });
+});

--- a/src/lib/api/age-gate.ts
+++ b/src/lib/api/age-gate.ts
@@ -1,0 +1,145 @@
+import '@/lib/sdk-client';
+import {
+  listReviews,
+  getReview,
+  approveReview,
+  rejectReview,
+  getRepoAgeGate,
+} from '@artifact-keeper/sdk';
+import type { AgeGateReviewResponse, AgeGateConfigResponse } from '@artifact-keeper/sdk';
+import { assertData } from '@/lib/api/fetch';
+
+/**
+ * A package version the age gate held back: an upstream release younger
+ * than the repository's configured minimum age, waiting for an admin to
+ * approve or reject early access to it.
+ */
+export interface AgeGateReview {
+  id: string;
+  packageName: string;
+  packageVersion: string;
+  repositoryKey: string;
+  /** `pending` | `approved` | `rejected`. */
+  status: string;
+  /** How many times a client has requested this held version. */
+  requestCount: number;
+  requestedAt: string;
+  lastRequestedAt: string;
+  /** When the upstream registry published this release, if known. */
+  upstreamPublishedAt: string | null;
+  /**
+   * How old the release was, in days, at first request (`requestedAt` minus
+   * `upstreamPublishedAt`). Null when the upstream publish date is unknown.
+   */
+  ageDaysAtRequest: number | null;
+  reviewReason: string | null;
+  reviewedAt: string | null;
+  reviewedBy: string | null;
+}
+
+export interface ListAgeGateReviewsParams {
+  /** `pending` | `approved` | `rejected` (server-side filter). */
+  status?: string;
+  repositoryKey?: string;
+  page?: number;
+  perPage?: number;
+}
+
+/** A repository's age gate policy: hold releases younger than `minAgeDays`. */
+export interface AgeGateRepoConfig {
+  repositoryKey: string;
+  enabled: boolean;
+  minAgeDays: number;
+}
+
+function daysBetween(earlier: string, later: string): number | null {
+  const from = new Date(earlier).getTime();
+  const to = new Date(later).getTime();
+  if (!Number.isFinite(from) || !Number.isFinite(to)) return null;
+  return Math.max(0, Math.round((to - from) / 86_400_000));
+}
+
+function adaptReview(sdk: AgeGateReviewResponse): AgeGateReview {
+  const upstreamPublishedAt = sdk.upstream_published_at ?? null;
+  return {
+    id: sdk.id,
+    packageName: sdk.package_name,
+    packageVersion: sdk.package_version,
+    repositoryKey: sdk.repository_key,
+    status: sdk.status,
+    requestCount: sdk.request_count,
+    requestedAt: sdk.requested_at,
+    lastRequestedAt: sdk.last_requested_at,
+    upstreamPublishedAt,
+    ageDaysAtRequest: upstreamPublishedAt ? daysBetween(upstreamPublishedAt, sdk.requested_at) : null,
+    reviewReason: sdk.review_reason ?? null,
+    reviewedAt: sdk.reviewed_at ?? null,
+    reviewedBy: sdk.reviewed_by ?? null,
+  };
+}
+
+function adaptConfig(sdk: AgeGateConfigResponse): AgeGateRepoConfig {
+  return {
+    repositoryKey: sdk.repository_key,
+    enabled: sdk.enabled,
+    minAgeDays: sdk.min_age_days,
+  };
+}
+
+const ageGateApi = {
+  /** List package versions in the age gate review queue. */
+  listReviews: async (params: ListAgeGateReviewsParams = {}): Promise<AgeGateReview[]> => {
+    const { data, error } = await listReviews({
+      query: {
+        status: params.status,
+        repository_key: params.repositoryKey,
+        page: params.page,
+        per_page: params.perPage,
+      },
+    });
+    if (error) throw error;
+    return assertData(data, 'ageGateApi.listReviews').items.map(adaptReview);
+  },
+
+  getReview: async (id: string): Promise<AgeGateReview> => {
+    const { data, error } = await getReview({ path: { id } });
+    if (error) throw error;
+    return adaptReview(assertData(data, 'ageGateApi.getReview'));
+  },
+
+  approveReview: async (id: string, reason?: string): Promise<AgeGateReview> => {
+    const { data, error } = await approveReview({ path: { id }, body: { reason: reason ?? null } });
+    if (error) throw error;
+    return adaptReview(assertData(data, 'ageGateApi.approveReview'));
+  },
+
+  rejectReview: async (id: string, reason?: string): Promise<AgeGateReview> => {
+    const { data, error } = await rejectReview({ path: { id }, body: { reason: reason ?? null } });
+    if (error) throw error;
+    return adaptReview(assertData(data, 'ageGateApi.rejectReview'));
+  },
+
+  /**
+   * Fetch the age gate policy for each distinct repository key so the queue
+   * can show how far a held release fell short of the minimum age. A repo
+   * with no policy configured errors on lookup; that's treated as "no
+   * policy" rather than surfaced, since it isn't a review-queue failure.
+   */
+  getRepoConfigs: async (repositoryKeys: string[]): Promise<Record<string, AgeGateRepoConfig>> => {
+    const unique = [...new Set(repositoryKeys)];
+    const entries = await Promise.all(
+      unique.map(async (key) => {
+        const { data, error } = await getRepoAgeGate({ path: { key } });
+        if (error) return null;
+        return adaptConfig(assertData(data, 'ageGateApi.getRepoConfigs'));
+      }),
+    );
+    const configs: Record<string, AgeGateRepoConfig> = {};
+    for (const cfg of entries) {
+      if (cfg) configs[cfg.repositoryKey] = cfg;
+    }
+    return configs;
+  },
+};
+
+export default ageGateApi;


### PR DESCRIPTION
## Summary

Adds an age-gate review queue admin page so operators can see and act on package versions held by the publish-age policy, instead of only via the API. The backend endpoints already exist and are in the OpenAPI spec; this wires them into the app, modeled closely on the existing curation review-queue page. Closes #634.

New: `src/app/(app)/(admin)/age-gate/page.tsx` (status-filtered table of held reviews with approve/reject and a reason dialog), `src/lib/api/age-gate.ts` (SDK-backed client: listReviews/getReview/approveReview/rejectReview, plus getRepoAgeGate for per-repo min_age_days), and an "Age Gate" sidebar entry next to Curation. Uses `@artifact-keeper/sdk` 1.6.0, which exports the age-gate endpoints. No new dependencies.

Note: the "requested age vs min age" column is computed client-side (days between the version's upstream publish date and the request, compared to each repo's configured min age), since the review record does not carry an age field. Repos with no configured policy show the age without a min-age suffix.

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

New tests: `src/lib/api/__tests__/age-gate.test.ts` and `src/app/(app)/(admin)/age-gate/page.test.tsx` (list renders, filter, approve/reject fire the mutations). Full vitest suite passed (2808 tests); `npm run build` succeeds with the /age-gate route present.

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [x] Modeled on the existing curation page (same components, layout, and conventions); a manual on-screen pass and the E2E/responsive/a11y checks are recommended before merge.
