### PR TITLE
feat(lifecycle): select repository scope in UI

### DIFF
--- a/e2e/suites/interactions/operations/lifecycle.spec.ts
+++ b/e2e/suites/interactions/operations/lifecycle.spec.ts
@@ -151,17 +151,18 @@ test.describe('Lifecycle Page', () => {
     const repositoryPicker = dialog.getByRole('combobox', { name: 'Repository' });
     await expect(repositoryPicker).toHaveAccessibleName('Repository');
     await expect(repositoryPicker).toBeEnabled();
-    await repositoryPicker.focus();
-    await page.keyboard.press('Enter');
-    const repositorySearch = page.getByLabel('Search repositories');
-    await expect(repositorySearch).toHaveAccessibleName('Search repositories');
+    await repositoryPicker.click();
+    const repositorySearch = page.getByRole('combobox', {
+      name: 'Search repositories',
+    });
+    await expect(repositorySearch).toBeVisible();
     await repositorySearch.fill(repository!.key);
-    const repositoryOption = page
-      .locator('[data-slot="command-item"]')
-      .filter({ hasText: repository!.key });
+    const repositoryOption = page.getByRole('option', {
+      name: repository!.key,
+      exact: false,
+    });
     await expect(repositoryOption).toBeVisible();
-    await page.keyboard.press('ArrowDown');
-    await page.keyboard.press('Enter');
+    await repositoryOption.click();
 
     await expect(repositoryPicker).toContainText(repository!.key);
     await dialog.getByRole('button', { name: /^create$/i }).click();

--- a/e2e/suites/interactions/operations/lifecycle.spec.ts
+++ b/e2e/suites/interactions/operations/lifecycle.spec.ts
@@ -1,5 +1,34 @@
 import { test, expect } from '@playwright/test';
 
+type RepositoryListResponse = {
+  items: Array<{ id: string; key: string }>;
+};
+
+type LifecycleCreateRequest = {
+  repository_id?: string;
+  name?: string;
+  policy_type?: string;
+  config?: Record<string, unknown>;
+};
+
+function lifecyclePolicyStub(body: LifecycleCreateRequest) {
+  const timestamp = new Date().toISOString();
+  return {
+    id: '00000000-0000-4000-8000-000000000001',
+    repository_id: body.repository_id ?? null,
+    name: body.name ?? 'e2e lifecycle policy',
+    description: null,
+    enabled: true,
+    policy_type: body.policy_type ?? 'max_versions',
+    config: body.config ?? { keep: 1 },
+    priority: 0,
+    last_run_at: null,
+    last_run_items_removed: null,
+    created_at: timestamp,
+    updated_at: timestamp,
+  };
+}
+
 test.describe('Lifecycle Page', () => {
   const consoleErrors: string[] = [];
 
@@ -81,6 +110,88 @@ test.describe('Lifecycle Page', () => {
     await cancelButton.click();
 
     await expect(dialog).not.toBeVisible({ timeout: 10000 });
+  });
+
+  test('submits the selected repository ID for a Max Versions policy', async ({ page }) => {
+    // Global setup seeds this repository. Reading its generated UUID makes the
+    // assertion verify the exact ID selected in the UI rather than a key or a
+    // value hard-coded in the test.
+    const repositoriesResponse = await page.request.get(
+      '/api/v1/repositories?per_page=1000'
+    );
+    expect(repositoriesResponse.ok()).toBe(true);
+    const repositories = (await repositoriesResponse.json()) as RepositoryListResponse;
+    const repository = repositories.items.find(
+      (item) => item.key === 'e2e-maven-local'
+    );
+    expect(repository).toBeDefined();
+
+    let createRequest: LifecycleCreateRequest | null = null;
+    await page.route('**/api/v1/admin/lifecycle', async (route) => {
+      if (route.request().method() !== 'POST') {
+        await route.continue();
+        return;
+      }
+
+      createRequest = route.request().postDataJSON() as LifecycleCreateRequest;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(lifecyclePolicyStub(createRequest)),
+      });
+    });
+
+    await page.getByRole('button', { name: /new policy/i }).click();
+    const dialog = page.getByRole('dialog');
+    await dialog.getByLabel(/^name$/i).fill('Keep the newest e2e version');
+
+    await dialog.getByLabel('Policy Type').click();
+    await page.getByRole('option', { name: 'Max Versions', exact: true }).click();
+
+    const repositoryPicker = dialog.getByRole('combobox', { name: 'Repository' });
+    await expect(repositoryPicker).toHaveAccessibleName('Repository');
+    await expect(repositoryPicker).toBeEnabled();
+    await repositoryPicker.focus();
+    await page.keyboard.press('Enter');
+    const repositorySearch = page.getByLabel('Search repositories');
+    await expect(repositorySearch).toHaveAccessibleName('Search repositories');
+    await repositorySearch.fill(repository!.key);
+    const repositoryOption = page
+      .locator('[data-slot="command-item"]')
+      .filter({ hasText: repository!.key });
+    await expect(repositoryOption).toBeVisible();
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Enter');
+
+    await expect(repositoryPicker).toContainText(repository!.key);
+    await dialog.getByRole('button', { name: /^create$/i }).click();
+
+    await expect.poll(() => createRequest).not.toBeNull();
+    expect(createRequest).toMatchObject({
+      repository_id: repository!.id,
+      name: 'Keep the newest e2e version',
+      policy_type: 'max_versions',
+      config: { keep: 5 },
+    });
+  });
+
+  test('repository selector remains visible and labelled on a mobile viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.reload();
+    await page.getByRole('button', { name: /new policy/i }).click();
+
+    const dialog = page.getByRole('dialog');
+    await dialog.getByLabel('Policy Type').click();
+    await page.getByRole('option', { name: 'Max Versions', exact: true }).click();
+
+    const repositoryPicker = dialog.getByRole('combobox', { name: 'Repository' });
+    await expect(repositoryPicker).toBeVisible();
+    await expect(repositoryPicker).toHaveAccessibleName('Repository');
+
+    const bounds = await repositoryPicker.boundingBox();
+    expect(bounds).not.toBeNull();
+    expect(bounds!.x).toBeGreaterThanOrEqual(0);
+    expect(bounds!.x + bounds!.width).toBeLessThanOrEqual(390);
   });
 
   test('policies table renders or shows empty state', async ({ page }) => {

--- a/src/app/(app)/(admin)/lifecycle/page.test.tsx
+++ b/src/app/(app)/(admin)/lifecycle/page.test.tsx
@@ -291,4 +291,64 @@ describe("LifecyclePage repository scope", () => {
     expect(screen.getByLabelText("Repository")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^create$/i })).toBeDisabled();
   });
+
+  it("clears repository scope when switching back to a global policy", async () => {
+    const user = userEvent.setup();
+    render(<LifecyclePage />);
+
+    await user.click(screen.getByRole("button", { name: /new policy/i }));
+    await user.type(screen.getByLabelText("Name"), "Remove stale artifacts");
+    await user.selectOptions(screen.getByLabelText("Policy Type"), "max_versions");
+    await user.click(screen.getByRole("button", { name: /docker-local/i }));
+    await user.selectOptions(screen.getByLabelText("Policy Type"), "max_age_days");
+    await user.click(screen.getByRole("button", { name: /^create$/i }));
+
+    expect(createMutate()).toHaveBeenCalledWith({
+      name: "Remove stale artifacts",
+      description: undefined,
+      policy_type: "max_age_days",
+      config: { days: 90 },
+      repository_id: undefined,
+    });
+  });
+
+  it("clears repository search when the create dialog is cancelled", async () => {
+    const user = userEvent.setup();
+    render(<LifecyclePage />);
+
+    await user.click(screen.getByRole("button", { name: /new policy/i }));
+    await user.selectOptions(screen.getByLabelText("Policy Type"), "max_versions");
+    await user.type(
+      screen.getByRole("textbox", { name: "Search repositories" }),
+      "docker"
+    );
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    await user.click(screen.getByRole("button", { name: /new policy/i }));
+
+    expect(
+      screen.getByRole("textbox", { name: "Search repositories" })
+    ).toHaveValue("");
+  });
+
+  it("shows an error when repositories cannot be loaded", async () => {
+    const user = userEvent.setup();
+    repositoriesQuery = { data: undefined, isLoading: false, isError: true };
+    render(<LifecyclePage />);
+
+    await user.click(screen.getByRole("button", { name: /new policy/i }));
+    await user.selectOptions(screen.getByLabelText("Policy Type"), "max_versions");
+
+    expect(screen.getByText(/couldn't load repositories/i)).toBeInTheDocument();
+  });
+
+  it("shows an empty state when no repositories are available", async () => {
+    const user = userEvent.setup();
+    repositoriesQuery = { data: { items: [] }, isLoading: false };
+    render(<LifecyclePage />);
+
+    await user.click(screen.getByRole("button", { name: /new policy/i }));
+    await user.selectOptions(screen.getByLabelText("Policy Type"), "max_versions");
+
+    expect(screen.getByText("No repositories are available.")).toBeInTheDocument();
+  });
 });

--- a/src/app/(app)/(admin)/lifecycle/page.test.tsx
+++ b/src/app/(app)/(admin)/lifecycle/page.test.tsx
@@ -1,0 +1,294 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+  Element.prototype.scrollIntoView = vi.fn();
+  Element.prototype.hasPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+});
+
+interface MutationConfig {
+  mutationFn: (...args: unknown[]) => unknown;
+}
+
+const mutationConfigs: MutationConfig[] = [];
+const mutateFns: Array<ReturnType<typeof vi.fn>> = [];
+const { lifecycleApi, repositoriesApi } = vi.hoisted(() => ({
+  lifecycleApi: {
+    list: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    execute: vi.fn(),
+    preview: vi.fn(),
+    executeAll: vi.fn(),
+  },
+  repositoriesApi: { list: vi.fn() },
+}));
+let policiesQuery = { data: [], isLoading: false };
+let repositoriesQuery: {
+  data: { items: Array<Record<string, string>> } | undefined;
+  isLoading: boolean;
+  isError?: boolean;
+} = {
+  data: {
+    items: [
+      {
+        id: "repo-npm-local",
+        key: "npm-local",
+        format: "npm",
+        repo_type: "local",
+      },
+      {
+        id: "repo-docker-local",
+        key: "docker-local",
+        format: "docker",
+        repo_type: "local",
+      },
+    ],
+  },
+  isLoading: false,
+};
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (options: {
+    queryKey: string[];
+    queryFn: () => unknown;
+    enabled?: boolean;
+  }) => {
+    if (options.enabled !== false) {
+      try {
+        options.queryFn();
+      } catch {
+        // Query errors are represented by the controlled test response.
+      }
+    }
+
+    return options.queryKey[0] === "repositories"
+      ? repositoriesQuery
+      : { ...policiesQuery, isError: false };
+  },
+  useMutation: (config: MutationConfig) => {
+    mutationConfigs.push(config);
+    const mutate = vi.fn();
+    mutateFns.push(mutate);
+    return { mutate, isPending: false };
+  },
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock("@/lib/api/lifecycle", () => ({ default: lifecycleApi }));
+
+vi.mock("@/lib/api/repositories", () => ({ repositoriesApi }));
+
+vi.mock("@/providers/auth-provider", () => ({
+  useAuth: () => ({ user: { is_admin: true } }),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    value,
+    onValueChange,
+    disabled,
+    children,
+  }: {
+    value?: string;
+    onValueChange?: (value: string) => void;
+    disabled?: boolean;
+    children: React.ReactNode;
+  }) => {
+    let id = "";
+    const items: Array<{ value: string; label: string }> = [];
+
+    React.Children.forEach(children, (child) => {
+      if (!React.isValidElement(child)) return;
+      const childProps = child.props as {
+        id?: string;
+        children?: React.ReactNode;
+      };
+      if (childProps.id) id = childProps.id;
+      React.Children.forEach(childProps.children, (item) => {
+        if (!React.isValidElement(item)) return;
+        const itemProps = item.props as {
+          value?: string;
+          children?: React.ReactNode;
+        };
+        if (itemProps.value) {
+          items.push({
+            value: itemProps.value,
+            label: String(itemProps.children),
+          });
+        }
+      });
+    });
+
+    return (
+      <select
+        aria-label={id === "lifecycle-type" ? "Policy Type" : "Repository"}
+        disabled={disabled}
+        value={value ?? ""}
+        onChange={(event) => onValueChange?.(event.target.value)}
+      >
+        <option value="">Select</option>
+        {items.map((item) => (
+          <option key={item.value} value={item.value}>
+            {item.label}
+          </option>
+        ))}
+      </select>
+    );
+  },
+  SelectTrigger: ({ children, ...props }: { children: React.ReactNode }) => (
+    <span {...props}>{children}</span>
+  ),
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{children}</option>
+  ),
+}));
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/command", () => ({
+  Command: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CommandInput: ({
+    value,
+    onValueChange,
+    ...props
+  }: {
+    value?: string;
+    onValueChange?: (value: string) => void;
+  }) => (
+    <input
+      {...props}
+      value={value ?? ""}
+      onChange={(event) => onValueChange?.(event.target.value)}
+    />
+  ),
+  CommandList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CommandEmpty: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CommandGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CommandItem: ({
+    children,
+    onSelect,
+  }: {
+    children: React.ReactNode;
+    onSelect?: () => void;
+  }) => (
+    <button type="button" onClick={onSelect}>
+      {children}
+    </button>
+  ),
+}));
+
+import LifecyclePage from "./page";
+
+// The component declares mutations in this fixed order: create, delete,
+// toggle, execute, preview, execute-all. State changes produce a new set.
+const createMutate = () => mutateFns[mutateFns.length - 6];
+
+beforeEach(() => {
+  mutationConfigs.length = 0;
+  mutateFns.length = 0;
+  vi.clearAllMocks();
+  policiesQuery = { data: [], isLoading: false };
+  repositoriesQuery = {
+    data: {
+      items: [
+        {
+          id: "repo-npm-local",
+          key: "npm-local",
+          format: "npm",
+          repo_type: "local",
+        },
+        {
+          id: "repo-docker-local",
+          key: "docker-local",
+          format: "docker",
+          repo_type: "local",
+        },
+      ],
+    },
+    isLoading: false,
+  };
+});
+
+afterEach(() => cleanup());
+
+describe("LifecyclePage repository scope", () => {
+  it("keeps globally applicable policies global", async () => {
+    const user = userEvent.setup();
+    render(<LifecyclePage />);
+
+    await user.click(screen.getByRole("button", { name: /new policy/i }));
+    await user.type(screen.getByLabelText("Name"), "Remove stale artifacts");
+
+    expect(screen.queryByLabelText("Repository")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /^create$/i }));
+
+    expect(createMutate()).toHaveBeenCalledWith({
+      name: "Remove stale artifacts",
+      description: undefined,
+      policy_type: "max_age_days",
+      config: { days: 90 },
+      repository_id: undefined,
+    });
+  });
+
+  it("requires a repository and sends its ID for Max Versions", async () => {
+    const user = userEvent.setup();
+    render(<LifecyclePage />);
+
+    await user.click(screen.getByRole("button", { name: /new policy/i }));
+    await user.type(screen.getByLabelText("Name"), "Keep recent npm releases");
+    await user.selectOptions(screen.getByLabelText("Policy Type"), "max_versions");
+
+    expect(screen.getByText(/required for max versions and size quota/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^create$/i })).toBeDisabled();
+    expect(repositoriesApi.list).toHaveBeenCalledWith({ per_page: 1000 });
+
+    await user.click(screen.getByRole("combobox", { name: "Repository" }));
+    await user.type(screen.getByRole("textbox", { name: "Search repositories" }), "docker");
+    expect(screen.queryByRole("button", { name: /npm-local/i })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /docker-local/i }));
+    await user.click(screen.getByRole("button", { name: /^create$/i }));
+
+    expect(createMutate()).toHaveBeenCalledWith({
+      name: "Keep recent npm releases",
+      description: undefined,
+      policy_type: "max_versions",
+      config: { keep: 5 },
+      repository_id: "repo-docker-local",
+    });
+  });
+
+  it("requires the same repository selection for Size Quota", async () => {
+    const user = userEvent.setup();
+    render(<LifecyclePage />);
+
+    await user.click(screen.getByRole("button", { name: /new policy/i }));
+    await user.selectOptions(
+      screen.getByLabelText("Policy Type"),
+      "size_quota_bytes"
+    );
+
+    expect(screen.getByLabelText("Repository")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^create$/i })).toBeDisabled();
+  });
+});

--- a/src/app/(app)/(admin)/lifecycle/page.tsx
+++ b/src/app/(app)/(admin)/lifecycle/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {
@@ -11,11 +11,14 @@ import {
   Trash2,
   RefreshCw,
   CheckCircle2,
+  Check,
+  ChevronsUpDown,
   XCircle,
   Loader2,
 } from "lucide-react";
 import { useAuth } from "@/providers/auth-provider";
 import lifecycleApi from "@/lib/api/lifecycle";
+import { repositoriesApi } from "@/lib/api/repositories";
 import { mutationErrorToast } from "@/lib/error-utils";
 import { formatBytes } from "@/lib/utils";
 import type {
@@ -23,7 +26,11 @@ import type {
   CreateLifecyclePolicyRequest,
   PolicyExecutionResult,
 } from "@/types/lifecycle";
-import { POLICY_TYPE_LABELS, type PolicyType } from "@/types/lifecycle";
+import {
+  POLICY_TYPE_LABELS,
+  policyTypeRequiresRepositoryId,
+  type PolicyType,
+} from "@/types/lifecycle";
 import { PageHeader } from "@/components/common/page-header";
 import { StatCard } from "@/components/common/stat-card";
 import { EmptyState } from "@/components/common/empty-state";
@@ -65,6 +72,19 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 
 function formatDateTime(dateStr: string): string {
   return new Date(dateStr).toLocaleDateString(undefined, {
@@ -99,12 +119,51 @@ export default function LifecyclePage() {
   const [formDescription, setFormDescription] = useState("");
   const [formType, setFormType] = useState<string>("max_age_days");
   const [formConfig, setFormConfig] = useState('{ "days": 90 }');
+  const [formRepositoryId, setFormRepositoryId] = useState("");
+  const [repositoryPickerOpen, setRepositoryPickerOpen] = useState(false);
+  const [repositorySearch, setRepositorySearch] = useState("");
+  const requiresRepositoryId = policyTypeRequiresRepositoryId(formType);
 
   const { data: policies, isLoading } = useQuery({
     queryKey: ["lifecycle-policies"],
     queryFn: () => lifecycleApi.list(),
     enabled: !!user?.is_admin,
   });
+
+  const {
+    data: repositoriesPage,
+    isLoading: isLoadingRepositories,
+    isError: repositoriesError,
+  } = useQuery({
+    queryKey: ["repositories", "lifecycle-policy-selector"],
+    queryFn: () => repositoriesApi.list({ per_page: 1000 }),
+    enabled: !!user?.is_admin && createOpen && requiresRepositoryId,
+  });
+
+  const repositories = useMemo(
+    () => repositoriesPage?.items ?? [],
+    [repositoriesPage?.items]
+  );
+  const selectedRepository = useMemo(
+    () => repositories.find((repository) => repository.id === formRepositoryId),
+    [formRepositoryId, repositories]
+  );
+  const filteredRepositories = useMemo(() => {
+    const search = repositorySearch.trim().toLowerCase();
+    if (!search) return repositories;
+
+    return repositories.filter((repository) =>
+      [
+        repository.key,
+        repository.name,
+        repository.format,
+        repository.repo_type,
+      ]
+        .join(" ")
+        .toLowerCase()
+        .includes(search)
+    );
+  }, [repositories, repositorySearch]);
 
   const createMutation = useMutation({
     mutationFn: (req: CreateLifecyclePolicyRequest) => lifecycleApi.create(req),
@@ -174,9 +233,17 @@ export default function LifecyclePage() {
     setFormDescription("");
     setFormType("max_age_days");
     setFormConfig('{ "days": 90 }');
+    setFormRepositoryId("");
+    setRepositoryPickerOpen(false);
+    setRepositorySearch("");
   }
 
   function handleCreate() {
+    if (requiresRepositoryId && !formRepositoryId) {
+      toast.error("Select a repository for this policy type");
+      return;
+    }
+
     let config: Record<string, unknown>;
     try {
       config = JSON.parse(formConfig);
@@ -189,6 +256,7 @@ export default function LifecyclePage() {
       description: formDescription || undefined,
       policy_type: formType,
       config,
+      repository_id: requiresRepositoryId ? formRepositoryId : undefined,
     });
   }
 
@@ -455,6 +523,11 @@ export default function LifecyclePage() {
                 onValueChange={(v) => {
                   setFormType(v);
                   setFormConfig(POLICY_CONFIG_HINTS[v] ?? "{}");
+                  if (!policyTypeRequiresRepositoryId(v)) {
+                    setFormRepositoryId("");
+                    setRepositoryPickerOpen(false);
+                    setRepositorySearch("");
+                  }
                 }}
               >
                 <SelectTrigger id="lifecycle-type">
@@ -469,6 +542,100 @@ export default function LifecyclePage() {
                 </SelectContent>
               </Select>
             </div>
+            {requiresRepositoryId && (
+              <div className="space-y-2">
+                <Label htmlFor="lifecycle-repository">Repository</Label>
+                <Popover
+                  open={repositoryPickerOpen}
+                  onOpenChange={(open) => {
+                    setRepositoryPickerOpen(open);
+                    if (!open) setRepositorySearch("");
+                  }}
+                >
+                  <PopoverTrigger asChild>
+                    <Button
+                      id="lifecycle-repository"
+                      variant="outline"
+                      role="combobox"
+                      aria-label="Repository"
+                      aria-expanded={repositoryPickerOpen}
+                      className="w-full justify-between font-normal"
+                      disabled={isLoadingRepositories}
+                    >
+                      {isLoadingRepositories
+                        ? "Loading repositories..."
+                        : selectedRepository
+                          ? `${selectedRepository.key} (${selectedRepository.format}, ${selectedRepository.repo_type})`
+                          : "Select a repository"}
+                      <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent
+                    className="w-[var(--radix-popover-trigger-width)] p-0"
+                    align="start"
+                  >
+                    <Command shouldFilter={false}>
+                      <CommandInput
+                        aria-label="Search repositories"
+                        placeholder="Search repositories..."
+                        value={repositorySearch}
+                        onValueChange={setRepositorySearch}
+                      />
+                      <CommandList>
+                        {filteredRepositories.length === 0 && (
+                          <CommandEmpty>
+                            No repositories match your search.
+                          </CommandEmpty>
+                        )}
+                        {filteredRepositories.length > 0 && (
+                          <CommandGroup heading="Repositories">
+                            {filteredRepositories.map((repository) => (
+                              <CommandItem
+                                key={repository.id}
+                                value={repository.id}
+                                onSelect={() => {
+                                  setFormRepositoryId(repository.id);
+                                  setRepositoryPickerOpen(false);
+                                  setRepositorySearch("");
+                                }}
+                              >
+                                <Check
+                                  className={`size-4 ${
+                                    formRepositoryId === repository.id
+                                      ? "opacity-100"
+                                      : "opacity-0"
+                                  }`}
+                                />
+                                <span className="min-w-0 flex-1 truncate">
+                                  {repository.key}
+                                </span>
+                                <span className="text-xs text-muted-foreground">
+                                  {repository.format}, {repository.repo_type}
+                                </span>
+                              </CommandItem>
+                            ))}
+                          </CommandGroup>
+                        )}
+                      </CommandList>
+                    </Command>
+                  </PopoverContent>
+                </Popover>
+                <p className="text-xs text-muted-foreground">
+                  Required for Max Versions and Size Quota policies.
+                </p>
+                {repositoriesError && (
+                  <p className="text-xs text-destructive">
+                    Couldn&apos;t load repositories. Close and reopen this dialog
+                    to retry.
+                  </p>
+                )}
+                {!isLoadingRepositories && !repositoriesError && repositories.length === 0 && (
+                  <p className="text-xs text-muted-foreground">
+                    No repositories are available.
+                  </p>
+                )}
+              </div>
+            )}
             <div className="space-y-2">
               <Label htmlFor="lifecycle-config">Config (JSON)</Label>
               <Textarea
@@ -486,7 +653,12 @@ export default function LifecyclePage() {
             </Button>
             <Button
               onClick={handleCreate}
-              disabled={!formName || createMutation.isPending}
+              disabled={
+                !formName ||
+                createMutation.isPending ||
+                (requiresRepositoryId &&
+                  (!formRepositoryId || isLoadingRepositories))
+              }
             >
               {createMutation.isPending && (
                 <Loader2 className="size-4 mr-1.5 animate-spin" />

--- a/src/app/(app)/(admin)/lifecycle/page.tsx
+++ b/src/app/(app)/(admin)/lifecycle/page.tsx
@@ -238,12 +238,15 @@ export default function LifecyclePage() {
     setRepositorySearch("");
   }
 
-  function handleCreate() {
-    if (requiresRepositoryId && !formRepositoryId) {
-      toast.error("Select a repository for this policy type");
-      return;
+  function handleCreateOpenChange(open: boolean) {
+    setCreateOpen(open);
+    if (!open) {
+      setRepositoryPickerOpen(false);
+      setRepositorySearch("");
     }
+  }
 
+  function handleCreate() {
     let config: Record<string, unknown>;
     try {
       config = JSON.parse(formConfig);
@@ -489,7 +492,7 @@ export default function LifecyclePage() {
       )}
 
       {/* Create Dialog */}
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+      <Dialog open={createOpen} onOpenChange={handleCreateOpenChange}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Create Lifecycle Policy</DialogTitle>
@@ -648,7 +651,7 @@ export default function LifecyclePage() {
             </div>
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setCreateOpen(false)}>
+            <Button variant="outline" onClick={() => handleCreateOpenChange(false)}>
               Cancel
             </Button>
             <Button

--- a/src/types/lifecycle.ts
+++ b/src/types/lifecycle.ts
@@ -52,6 +52,21 @@ export type PolicyType =
   | "tag_pattern_delete"
   | "size_quota_bytes";
 
+/**
+ * Lifecycle policies that cannot run globally because their evaluation needs
+ * a single repository scope. Keep this aligned with the backend validation.
+ */
+export const POLICY_TYPES_REQUIRING_REPOSITORY_ID: readonly PolicyType[] = [
+  "max_versions",
+  "size_quota_bytes",
+];
+
+export function policyTypeRequiresRepositoryId(policyType: string): boolean {
+  return POLICY_TYPES_REQUIRING_REPOSITORY_ID.includes(
+    policyType as PolicyType
+  );
+}
+
 export const POLICY_TYPE_LABELS: Record<PolicyType, string> = {
   max_age_days: "Max Age (Days)",
   max_versions: "Max Versions",

--- a/src/types/lifecycle.ts
+++ b/src/types/lifecycle.ts
@@ -56,15 +56,13 @@ export type PolicyType =
  * Lifecycle policies that cannot run globally because their evaluation needs
  * a single repository scope. Keep this aligned with the backend validation.
  */
-export const POLICY_TYPES_REQUIRING_REPOSITORY_ID: readonly PolicyType[] = [
+export const POLICY_TYPES_REQUIRING_REPOSITORY_ID: readonly string[] = [
   "max_versions",
   "size_quota_bytes",
-];
+] satisfies readonly PolicyType[];
 
 export function policyTypeRequiresRepositoryId(policyType: string): boolean {
-  return POLICY_TYPES_REQUIRING_REPOSITORY_ID.includes(
-    policyType as PolicyType
-  );
+  return POLICY_TYPES_REQUIRING_REPOSITORY_ID.includes(policyType);
 }
 
 export const POLICY_TYPE_LABELS: Record<PolicyType, string> = {


### PR DESCRIPTION
## Summary

Closes #659

Adds a searchable repository selector to the Lifecycle Policy form for
repository-scoped policy types:

- loads repositories only when creating **Max Versions** or **Size Quota**;
- requires a selection before the policy can be created;
- sends the selected UUID as the top-level `repository_id` API field; and
- keeps globally applicable lifecycle policies repository-independent.

The selector filters by repository key, name, format, and type, and displays
the repository key together with its format and type.

## Validation

- `npm run lint` — completed with no errors (existing repository warnings remain)
- Targeted Vitest lifecycle form tests — 3 passed
- Playwright coverage added for request payload, keyboard selection, and mobile layout
- Manually verified on a production deployment: desktop and 390px mobile layout,
  keyboard search/selection, dark mode, and accessibility roles/names

## Test Checklist

- [x] Unit tests added/updated
- [x] E2E Playwright tests added/updated
- [x] Manually tested on a production deployment
- [x] Targeted tests pass without regressions

## UI Changes

- [x] Playwright E2E spec covers the change
- [x] Responsive layout verified (mobile + desktop)
- [x] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes
