### PR TITLE
chore(deps): bump @artifact-keeper/sdk to ^1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "artifact-keeper-web",
       "version": "1.6.0",
       "dependencies": {
-        "@artifact-keeper/sdk": "^1.6.0",
+        "@artifact-keeper/sdk": "^1.7.0",
         "@hookform/resolvers": "^5.4.0",
         "@tanstack/react-query": "^5.100.9",
         "class-variance-authority": "^0.7.1",
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@artifact-keeper/sdk": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@artifact-keeper/sdk/-/sdk-1.6.0.tgz",
-      "integrity": "sha512-nCqG6/c1Dt/3CsPri/GF+Wa2/5LCrwT34c6RzSUy6vts3FB1lhiNOslmzmSnrMac8g/zByqVbYHZ8nJcb2jIvw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@artifact-keeper/sdk/-/sdk-1.7.0.tgz",
+      "integrity": "sha512-rEvZEcgaTJ9SbvsxcSmH5xu+Pnja9A57tcPYmgfY2gJCYuMPhZ0/cJHJM6JFQH3WwDCvVWFy06LlavlO9crMkg==",
       "license": "MIT",
       "dependencies": {
         "@hey-api/client-fetch": "^0.13.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "tutorial:generate-videos": "npx tsx e2e/tutorials/scripts/generate-videos.ts"
   },
   "dependencies": {
-    "@artifact-keeper/sdk": "^1.6.0",
+    "@artifact-keeper/sdk": "^1.7.0",
     "@hookform/resolvers": "^5.4.0",
     "@tanstack/react-query": "^5.100.9",
     "class-variance-authority": "^0.7.1",

--- a/src/lib/api/__tests__/promotion.test.ts
+++ b/src/lib/api/__tests__/promotion.test.ts
@@ -44,6 +44,8 @@ const SDK_REPO: SdkRepositoryResponse = {
   promotion_only: false,
   versioning_enabled: false,
   has_trusted_gpg_key: false,
+  curation_default_action: "allow",
+  curation_enabled: false,
   created_at: "2026-04-01T00:00:00Z",
   updated_at: "2026-05-01T00:00:00Z",
 };
@@ -64,6 +66,7 @@ const SDK_ARTIFACT: SdkArtifactResponse = {
   content_type: "application/java-archive",
   download_count: 0,
   analyzable: true,
+  quarantine_status: "clean",
   created_at: "2026-04-01T00:00:00Z",
   metadata: null,
 };

--- a/src/lib/api/__tests__/security.test.ts
+++ b/src/lib/api/__tests__/security.test.ts
@@ -140,6 +140,7 @@ const SDK_CONFIG: SdkScanConfigResponse = {
   scan_on_proxy: false,
   block_on_policy_violation: true,
   severity_threshold: "high",
+  proxy_scan_action: "fail_open",
   created_at: "2026-05-01T00:00:00Z",
   updated_at: "2026-05-01T00:00:00Z",
 };

--- a/src/lib/api/__tests__/sso.test.ts
+++ b/src/lib/api/__tests__/sso.test.ts
@@ -98,6 +98,8 @@ const SDK_LDAP: SdkLdapConfigResponse = {
   group_filter: "(member={dn})",
   admin_group_dn: "cn=admins,ou=groups,dc=example,dc=com",
   use_starttls: true,
+  has_ca_certificate: false,
+  insecure_skip_verify: false,
   is_enabled: true,
   priority: 10,
   created_at: "2026-04-01T00:00:00Z",

--- a/src/lib/api/repositories.ts
+++ b/src/lib/api/repositories.ts
@@ -286,7 +286,13 @@ export const repositoriesApi = {
       npm_allowed_scopes: input.npm_allowed_scopes,
       npm_allowed_name_patterns: input.npm_allowed_name_patterns,
       npm_allow_unscoped: input.npm_allow_unscoped,
-    };
+      // SDK 1.7.0 generates `curation_default_action` as a *required* field on
+      // the PATCH `UpdateRepositoryRequest` type, but this endpoint treats every
+      // field as optional (omit = leave unchanged) and the repository update
+      // dialog does not edit curation policy. Intentionally omit it from the
+      // wire so update behavior is unchanged; the cast satisfies the
+      // generated-required field without sending a spurious value.
+    } as SdkUpdateRepositoryRequest;
     const { data, error } = await updateRepository({ path: { key }, body });
     if (error) throw error;
     return adaptRepository(assertData(data, 'repositoriesApi.update'));


### PR DESCRIPTION
Closes #666

## What
Bumps the generated client dependency `@artifact-keeper/sdk` from `^1.6.0` → `^1.7.0` (npm `dist-tags.latest = 1.7.0`), refreshes the lockfile (resolves `1.7.0`), and reconciles the type drift the new SDK surfaces. Prerequisite for the rest of the 1.7.0 web catch-up. No feature behavior changes; the api-adapter external contracts stay stable so consuming pages are untouched.

## Type drift reconciled
The bump introduced **5 new tsc errors** (28 total vs the 23-error pre-existing baseline); all 5 are cleared here, leaving the baseline at exactly 23 (unchanged, no net-new errors):

| Location | New required field(s) in 1.7.0 | Fix |
|---|---|---|
| `src/lib/api/repositories.ts` (source) | `UpdateRepositoryRequest.curation_default_action` (PATCH type only; create type unaffected) | Field kept off the wire (omit = unchanged; update dialog does not edit curation policy); cast satisfies the generated-required field. Behavior unchanged. |
| `__tests__/promotion.test.ts` | `RepositoryResponse.{curation_default_action,curation_enabled}`, `ArtifactResponse.quarantine_status` | Fixture values only |
| `__tests__/security.test.ts` | `ScanConfigResponse.proxy_scan_action` | Fixture value `fail_open` (documented default) |
| `__tests__/sso.test.ts` | `LdapConfigResponse.{has_ca_certificate,insecure_skip_verify}` | Fixture values only |

## The one non-mechanical call
`curation_default_action` is generated as **required** on the PATCH `UpdateRepositoryRequest` (an OpenAPI-generation quirk — a PATCH field should be optional; `curation_enabled` on the same type is optional, and the create type never gained it). Rather than thread a new field through the web's `CreateRepositoryRequest` type and update dialog (scope creep, would change app surface), the field is intentionally omitted from the request body — matching prior update semantics — with a narrow cast. Flagged for follow-up if curation-policy editing is ever added to the repository update dialog.

## Validation
- `tsc --noEmit`: **23 → 23** (pre-existing baseline unchanged; all 5 bump-introduced errors cleared). The 23 remaining are pre-existing errors in unrelated test files (blast-radius, audit, docker-grouping), not touched here.
- `npm test` (vitest): **2924 passing** / 157 files.
- `npm run lint`: **0 errors** (36 pre-existing warnings, none in touched files).