### PR TITLE
feat(repositories): Scanning & enforcement config panel (inline scan-and-block)

### DIFF
--- a/src/app/(app)/repositories/_components/repo-settings-tab.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-settings-tab.test.tsx
@@ -55,6 +55,29 @@ vi.mock("@/hooks/use-admin-settings", () => ({
   useAdminSettings: () => mockUseAdminSettings(),
 }));
 
+// Mock auth-provider (used to repo-admin gate the Scanning & enforcement
+// section, #2954/#3003). Defaults to an admin user; tests override as needed.
+const mockUseAuth = vi.fn(() => ({ user: { is_admin: true } }));
+vi.mock("@/providers/auth-provider", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+// Mock the scan-config API (apiFetch-based client for the security endpoint).
+const mockGetScanConfig = vi.fn();
+const mockUpdateScanConfig = vi.fn();
+vi.mock("@/lib/api/scan-config", () => ({
+  __esModule: true,
+  default: {
+    get: (...args: unknown[]) => mockGetScanConfig(...args),
+    update: (...args: unknown[]) => mockUpdateScanConfig(...args),
+  },
+  scanConfigApi: {
+    get: (...args: unknown[]) => mockGetScanConfig(...args),
+    update: (...args: unknown[]) => mockUpdateScanConfig(...args),
+  },
+  SEVERITY_THRESHOLDS: ["critical", "high", "medium", "low"],
+}));
+
 // Mock lifecycle API
 const mockListPolicies = vi.fn();
 const mockDeletePolicy = vi.fn();
@@ -232,6 +255,18 @@ mockUseAdminSettings.mockReturnValue({
     },
   },
 });
+
+// Default scan-config: an unconfigured repository (everything off, fail-open).
+// Individual tests override with mockResolvedValueOnce.
+const defaultScanConfig = {
+  scan_enabled: false,
+  scan_on_upload: false,
+  scan_on_proxy: false,
+  block_on_policy_violation: false,
+  severity_threshold: "high",
+  proxy_scan_action: "fail_open" as const,
+};
+mockGetScanConfig.mockResolvedValue(defaultScanConfig);
 
 function createWrapper() {
   const client = new QueryClient({
@@ -1447,5 +1482,205 @@ describe("RepoSettingsTab - 1.6.0 format-specific config (#602)", () => {
       { wrapper: createWrapper() }
     );
     expect(screen.queryByText("npm Scope Policy")).toBeNull();
+  });
+});
+
+describe("RepoSettingsTab - Scanning & enforcement (#2954/#3003)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListPolicies.mockResolvedValue([]);
+    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
+    mockGetScanConfig.mockResolvedValue({
+      scan_enabled: false,
+      scan_on_upload: false,
+      scan_on_proxy: false,
+      block_on_policy_violation: false,
+      severity_threshold: "high",
+      proxy_scan_action: "fail_open",
+    });
+  });
+
+  it("hides the section entirely for non-admin users and issues no GET", () => {
+    mockUseAuth.mockReturnValue({ user: { is_admin: false } });
+    render(<RepoSettingsTab repository={baseRepo} />, {
+      wrapper: createWrapper(),
+    });
+    expect(screen.queryByText("Scanning & enforcement")).toBeNull();
+    expect(mockGetScanConfig).not.toHaveBeenCalled();
+  });
+
+  it("renders the section for admins and loads the config via GET", async () => {
+    render(<RepoSettingsTab repository={baseRepo} />, {
+      wrapper: createWrapper(),
+    });
+    expect(screen.getByText("Scanning & enforcement")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByLabelText("Enable scanning")).toBeTruthy();
+    });
+    expect(mockGetScanConfig).toHaveBeenCalledWith("maven-releases");
+  });
+
+  it("disables the dependent controls until scanning is enabled", async () => {
+    render(<RepoSettingsTab repository={baseRepo} />, {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText("Enable scanning")).toBeTruthy();
+    });
+    // Master toggle is off in the default config, so the rest are disabled.
+    expect(screen.getByLabelText("Scan on upload")).toHaveProperty(
+      "disabled",
+      true
+    );
+    expect(screen.getByLabelText("Scan on proxy download")).toHaveProperty(
+      "disabled",
+      true
+    );
+    expect(screen.getByLabelText("Block on policy violation")).toHaveProperty(
+      "disabled",
+      true
+    );
+    expect(
+      screen.getByLabelText("Fail closed on proxy downloads")
+    ).toHaveProperty("disabled", true);
+  });
+
+  it("reflects a fail_closed config and enabled toggles from the backend", async () => {
+    mockGetScanConfig.mockResolvedValue({
+      scan_enabled: true,
+      scan_on_upload: true,
+      scan_on_proxy: true,
+      block_on_policy_violation: true,
+      severity_threshold: "critical",
+      proxy_scan_action: "fail_closed",
+    });
+    render(<RepoSettingsTab repository={baseRepo} />, {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Enable scanning").getAttribute("aria-checked")
+      ).toBe("true");
+    });
+    const failClosed = screen.getByLabelText("Fail closed on proxy downloads");
+    expect(failClosed.getAttribute("aria-checked")).toBe("true");
+    expect(failClosed).toHaveProperty("disabled", false);
+    // Security-first caption is shown when fail-closed is active.
+    expect(screen.getByText(/Security first/)).toBeTruthy();
+  });
+
+  it("shows the availability-first caption when fail-open is active", async () => {
+    mockGetScanConfig.mockResolvedValue({
+      scan_enabled: true,
+      scan_on_upload: false,
+      scan_on_proxy: true,
+      block_on_policy_violation: false,
+      severity_threshold: "high",
+      proxy_scan_action: "fail_open",
+    });
+    render(<RepoSettingsTab repository={baseRepo} />, {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText("Enable scanning")).toBeTruthy();
+    });
+    expect(screen.getByText(/Availability first/)).toBeTruthy();
+  });
+
+  it("keeps Save disabled until an edit is made", async () => {
+    render(<RepoSettingsTab repository={baseRepo} />, {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText("Enable scanning")).toBeTruthy();
+    });
+    const saveBtn = screen.getByRole("button", {
+      name: /save scanning settings/i,
+    });
+    expect(saveBtn).toHaveProperty("disabled", true);
+  });
+
+  it("PUTs the full config with proxy_scan_action=fail_closed on save", async () => {
+    mockGetScanConfig.mockResolvedValue({
+      scan_enabled: true,
+      scan_on_upload: false,
+      scan_on_proxy: true,
+      block_on_policy_violation: false,
+      severity_threshold: "high",
+      proxy_scan_action: "fail_open",
+    });
+    mockUpdateScanConfig.mockResolvedValue({
+      scan_enabled: true,
+      scan_on_upload: false,
+      scan_on_proxy: true,
+      block_on_policy_violation: true,
+      severity_threshold: "high",
+      proxy_scan_action: "fail_closed",
+    });
+    const { toast } = await import("sonner");
+    const user = userEvent.setup();
+    render(<RepoSettingsTab repository={baseRepo} />, {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Fail closed on proxy downloads")
+      ).toHaveProperty("disabled", false);
+    });
+
+    // Flip to fail-closed and turn on active blocking.
+    await user.click(screen.getByLabelText("Fail closed on proxy downloads"));
+    await user.click(screen.getByLabelText("Block on policy violation"));
+
+    const saveBtn = screen.getByRole("button", {
+      name: /save scanning settings/i,
+    });
+    expect(saveBtn).toHaveProperty("disabled", false);
+    await user.click(saveBtn);
+
+    await waitFor(() => {
+      expect(mockUpdateScanConfig).toHaveBeenCalledWith(
+        "maven-releases",
+        expect.objectContaining({
+          scan_enabled: true,
+          scan_on_proxy: true,
+          block_on_policy_violation: true,
+          proxy_scan_action: "fail_closed",
+        })
+      );
+    });
+    expect(toast.success).toHaveBeenCalledWith(
+      "Scanning & enforcement settings saved"
+    );
+  });
+
+  it("toasts an error when the save fails", async () => {
+    mockGetScanConfig.mockResolvedValue({
+      scan_enabled: true,
+      scan_on_upload: false,
+      scan_on_proxy: false,
+      block_on_policy_violation: false,
+      severity_threshold: "high",
+      proxy_scan_action: "fail_open",
+    });
+    mockUpdateScanConfig.mockRejectedValue(new Error("403 Forbidden"));
+    const { toast } = await import("sonner");
+    const user = userEvent.setup();
+    render(<RepoSettingsTab repository={baseRepo} />, {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Enable scanning").getAttribute("aria-checked")
+      ).toBe("true");
+    });
+    // Toggle block-on-violation to make the form dirty.
+    await user.click(screen.getByLabelText("Block on policy violation"));
+    await user.click(
+      screen.getByRole("button", { name: /save scanning settings/i })
+    );
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Failed to save scanning settings");
+    });
   });
 });

--- a/src/app/(app)/repositories/_components/repo-settings-tab.tsx
+++ b/src/app/(app)/repositories/_components/repo-settings-tab.tsx
@@ -8,7 +8,14 @@ import { toast } from "sonner";
 import { repositoriesApi } from "@/lib/api/repositories";
 import { supportsVersioning } from "@/lib/api/versions";
 import { useAdminSettings } from "@/hooks/use-admin-settings";
+import { useAuth } from "@/providers/auth-provider";
 import lifecycleApi from "@/lib/api/lifecycle";
+import scanConfigApi, {
+  SEVERITY_THRESHOLDS,
+  type RepoScanConfig,
+  type ProxyScanAction,
+  type UpsertScanConfigRequest,
+} from "@/lib/api/scan-config";
 import { mutationErrorToast } from "@/lib/error-utils";
 import { formatBytes } from "@/lib/utils";
 import type {
@@ -526,6 +533,70 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
   const { data: adminSettings } = useAdminSettings();
   const maxUploadBytes = adminSettings?.storageSettings.max_upload_size_bytes;
 
+  // -- Scanning & enforcement (#2954 / #3003, "active blocking") --
+  // Repo-admin gated: the backend PUT is admin-only, so we only render the
+  // section (and only run the GET) for admins — mirroring how the quarantine
+  // decisions and other admin-only controls are gated on `user?.is_admin`
+  // elsewhere in the repository views.
+  const { user } = useAuth();
+  const isRepoAdmin = !!user?.is_admin;
+
+  const { data: scanConfig, isLoading: scanConfigLoading } = useQuery({
+    queryKey: ["scan-config", repository.key],
+    queryFn: () => scanConfigApi.get(repository.key),
+    enabled: isRepoAdmin,
+  });
+
+  // Override-based dirty tracking, like the general/debian/npm sections: the
+  // loaded config is the baseline, and only the operator's explicit edits are
+  // held in `scanOverrides` so a fresh load never counts as a change.
+  const [scanOverrides, setScanOverrides] = useState<Partial<RepoScanConfig>>(
+    {}
+  );
+  const scanForm: RepoScanConfig | undefined = useMemo(
+    () => (scanConfig ? { ...scanConfig, ...scanOverrides } : undefined),
+    [scanConfig, scanOverrides]
+  );
+  const scanChanged =
+    !!scanConfig &&
+    (Object.keys(scanOverrides) as (keyof RepoScanConfig)[]).some(
+      (k) => scanOverrides[k] !== undefined && scanOverrides[k] !== scanConfig[k]
+    );
+
+  const setScanField = useCallback(
+    <K extends keyof RepoScanConfig>(key: K, value: RepoScanConfig[K]) => {
+      setScanOverrides((o) => ({ ...o, [key]: value }));
+    },
+    []
+  );
+
+  const scanConfigMutation = useMutation({
+    mutationFn: (req: UpsertScanConfigRequest) =>
+      scanConfigApi.update(repository.key, req),
+    onSuccess: (updated) => {
+      // Seed the query cache with the server's echoed row and clear the local
+      // edits so the form re-baselines against what was actually persisted.
+      queryClient.setQueryData(["scan-config", repository.key], updated);
+      setScanOverrides({});
+      toast.success("Scanning & enforcement settings saved");
+    },
+    onError: mutationErrorToast("Failed to save scanning settings"),
+  });
+
+  const handleSaveScanConfig = useCallback(() => {
+    if (!scanForm) return;
+    // Send the full set — the backend upsert merges, but sending everything
+    // keeps the persisted row unambiguous and avoids a stale-field surprise.
+    scanConfigMutation.mutate({
+      scan_enabled: scanForm.scan_enabled,
+      scan_on_upload: scanForm.scan_on_upload,
+      scan_on_proxy: scanForm.scan_on_proxy,
+      block_on_policy_violation: scanForm.block_on_policy_violation,
+      severity_threshold: scanForm.severity_threshold,
+      proxy_scan_action: scanForm.proxy_scan_action,
+    });
+  }, [scanForm, scanConfigMutation]);
+
   return (
     <div className="max-w-2xl space-y-8">
       {/* -- General Settings Section -- */}
@@ -993,6 +1064,199 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
                 )}
               </div>
             </div>
+          </section>
+
+          <Separator />
+        </>
+      )}
+
+      {/* -- Scanning & Enforcement Section (#2954 / #3003, repo-admin only) -- */}
+      {isRepoAdmin && (
+        <>
+          <section aria-labelledby="settings-scan-heading">
+            <div className="mb-4">
+              <h3
+                id="settings-scan-heading"
+                className="text-base font-semibold"
+              >
+                Scanning &amp; enforcement
+              </h3>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Vulnerability scanning and inline scan-and-block for this
+                repository. When blocking is on, artifacts that violate the
+                policy are actively prevented from being downloaded rather than
+                only flagged after the fact.
+              </p>
+            </div>
+
+            {scanConfigLoading || !scanForm ? (
+              <div className="space-y-3">
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+            ) : (
+              <div className="space-y-4">
+                {/* Master toggle */}
+                <div className="flex items-center justify-between">
+                  <div className="space-y-0.5">
+                    <Label htmlFor="settings-scan-enabled">
+                      Enable scanning
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Turn vulnerability scanning on for this repository.
+                    </p>
+                  </div>
+                  <Switch
+                    id="settings-scan-enabled"
+                    checked={scanForm.scan_enabled}
+                    onCheckedChange={(v) => setScanField("scan_enabled", v)}
+                  />
+                </div>
+
+                {/* Scan on upload */}
+                <div className="flex items-center justify-between">
+                  <div className="space-y-0.5">
+                    <Label htmlFor="settings-scan-on-upload">
+                      Scan on upload
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Scan artifacts as they are published to this repository.
+                    </p>
+                  </div>
+                  <Switch
+                    id="settings-scan-on-upload"
+                    checked={scanForm.scan_on_upload}
+                    disabled={!scanForm.scan_enabled}
+                    onCheckedChange={(v) => setScanField("scan_on_upload", v)}
+                  />
+                </div>
+
+                {/* Scan on proxy */}
+                <div className="flex items-center justify-between">
+                  <div className="space-y-0.5">
+                    <Label htmlFor="settings-scan-on-proxy">
+                      Scan on proxy download
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Scan upstream artifacts inline as they are proxied
+                      through this repository.
+                    </p>
+                  </div>
+                  <Switch
+                    id="settings-scan-on-proxy"
+                    checked={scanForm.scan_on_proxy}
+                    disabled={!scanForm.scan_enabled}
+                    onCheckedChange={(v) => setScanField("scan_on_proxy", v)}
+                  />
+                </div>
+
+                {/* Block on policy violation */}
+                <div className="flex items-center justify-between">
+                  <div className="space-y-0.5">
+                    <Label htmlFor="settings-scan-block">
+                      Block on policy violation
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Actively block downloads of artifacts that violate the
+                      severity policy, instead of only recording a finding.
+                    </p>
+                  </div>
+                  <Switch
+                    id="settings-scan-block"
+                    checked={scanForm.block_on_policy_violation}
+                    disabled={!scanForm.scan_enabled}
+                    onCheckedChange={(v) =>
+                      setScanField("block_on_policy_violation", v)
+                    }
+                  />
+                </div>
+
+                {/* Severity threshold */}
+                <div className="space-y-2">
+                  <Label htmlFor="settings-scan-severity">
+                    Severity threshold
+                  </Label>
+                  <Select
+                    value={scanForm.severity_threshold}
+                    onValueChange={(v) =>
+                      setScanField("severity_threshold", v)
+                    }
+                    disabled={!scanForm.scan_enabled}
+                  >
+                    <SelectTrigger
+                      id="settings-scan-severity"
+                      className="w-40"
+                      aria-label="Severity threshold"
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {SEVERITY_THRESHOLDS.map((level) => (
+                        <SelectItem key={level} value={level}>
+                          {level.charAt(0).toUpperCase() + level.slice(1)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground">
+                    Findings at or above this severity count as a policy
+                    violation.
+                  </p>
+                </div>
+
+                {/* Proxy scan action: fail-open vs fail-closed */}
+                <div className="rounded-md border p-3 space-y-2">
+                  <div className="flex items-center justify-between">
+                    <div className="space-y-0.5">
+                      <Label htmlFor="settings-scan-fail-closed">
+                        Fail closed on proxy downloads
+                      </Label>
+                      <p className="text-xs text-muted-foreground">
+                        {scanForm.proxy_scan_action === "fail_closed"
+                          ? "Fail closed: if the scanner is unavailable or an inline scan can't confirm the artifact is clean, the download is blocked. Security first — a proxy outage can interrupt availability."
+                          : "Fail open: if the scanner is unavailable or an inline scan can't confirm the artifact is clean, the download is served anyway. Availability first — an unscanned artifact can slip through."}
+                      </p>
+                    </div>
+                    <Switch
+                      id="settings-scan-fail-closed"
+                      checked={scanForm.proxy_scan_action === "fail_closed"}
+                      disabled={
+                        !scanForm.scan_enabled || !scanForm.scan_on_proxy
+                      }
+                      onCheckedChange={(v) =>
+                        setScanField(
+                          "proxy_scan_action",
+                          (v ? "fail_closed" : "fail_open") as ProxyScanAction
+                        )
+                      }
+                    />
+                  </div>
+                  {(!scanForm.scan_enabled || !scanForm.scan_on_proxy) && (
+                    <p className="text-xs text-muted-foreground">
+                      Enable scanning and &ldquo;Scan on proxy download&rdquo;
+                      to choose the fail-open / fail-closed behavior.
+                    </p>
+                  )}
+                </div>
+
+                <div className="flex justify-end">
+                  <Button
+                    onClick={handleSaveScanConfig}
+                    disabled={scanConfigMutation.isPending || !scanChanged}
+                  >
+                    {scanConfigMutation.isPending ? (
+                      <>
+                        <Loader2 className="size-4 animate-spin" />
+                        Saving...
+                      </>
+                    ) : (
+                      "Save Scanning Settings"
+                    )}
+                  </Button>
+                </div>
+              </div>
+            )}
           </section>
 
           <Separator />

--- a/src/lib/api/__tests__/scan-config.test.ts
+++ b/src/lib/api/__tests__/scan-config.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/sdk-client", () => ({}));
+
+const mockApiFetch = vi.fn();
+
+vi.mock("@/lib/api/fetch", () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}));
+
+const fullConfig = {
+  id: "cfg-1",
+  repository_id: "repo-1",
+  scan_enabled: true,
+  scan_on_upload: true,
+  scan_on_proxy: true,
+  block_on_policy_violation: true,
+  severity_threshold: "critical",
+  proxy_scan_action: "fail_closed",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-02T00:00:00Z",
+};
+
+describe("scanConfigApi.get", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("parses a wrapped { config } response including proxy_scan_action", async () => {
+    mockApiFetch.mockResolvedValue({ config: fullConfig, score: null });
+    const mod = await import("../scan-config");
+    const cfg = await mod.scanConfigApi.get("maven-releases");
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      "/api/v1/repositories/maven-releases/security",
+      { method: "GET" },
+    );
+    expect(cfg.scan_enabled).toBe(true);
+    expect(cfg.scan_on_proxy).toBe(true);
+    expect(cfg.block_on_policy_violation).toBe(true);
+    expect(cfg.severity_threshold).toBe("critical");
+    expect(cfg.proxy_scan_action).toBe("fail_closed");
+  });
+
+  it("returns documented defaults when config is null (unconfigured repo)", async () => {
+    mockApiFetch.mockResolvedValue({ config: null, score: null });
+    const mod = await import("../scan-config");
+    const cfg = await mod.scanConfigApi.get("npm-proxy");
+    expect(cfg).toEqual(mod.DEFAULT_SCAN_CONFIG);
+    expect(cfg.proxy_scan_action).toBe("fail_open");
+  });
+
+  it("defaults proxy_scan_action to fail_open when the field is absent (SDK-skew safety)", async () => {
+    const withoutAction: Partial<typeof fullConfig> = { ...fullConfig };
+    delete withoutAction.proxy_scan_action;
+    mockApiFetch.mockResolvedValue({ config: withoutAction, score: null });
+    const mod = await import("../scan-config");
+    const cfg = await mod.scanConfigApi.get("maven-releases");
+    expect(cfg.proxy_scan_action).toBe("fail_open");
+    // Other fields still parse through.
+    expect(cfg.scan_enabled).toBe(true);
+  });
+
+  it("falls back to fail_open for an unrecognized proxy_scan_action value", async () => {
+    mockApiFetch.mockResolvedValue({
+      config: { ...fullConfig, proxy_scan_action: "explode" },
+      score: null,
+    });
+    const mod = await import("../scan-config");
+    const cfg = await mod.scanConfigApi.get("maven-releases");
+    expect(cfg.proxy_scan_action).toBe("fail_open");
+  });
+
+  it("accepts a bare config object (no wrapper)", async () => {
+    mockApiFetch.mockResolvedValue(fullConfig);
+    const mod = await import("../scan-config");
+    const cfg = await mod.scanConfigApi.get("maven-releases");
+    expect(cfg.scan_on_upload).toBe(true);
+    expect(cfg.proxy_scan_action).toBe("fail_closed");
+  });
+
+  it("throws when the response is not an object", async () => {
+    mockApiFetch.mockResolvedValue("nope");
+    const mod = await import("../scan-config");
+    await expect(mod.scanConfigApi.get("x")).rejects.toThrow(
+      /did not match the expected shape/,
+    );
+  });
+
+  it("URL-encodes the repository key", async () => {
+    mockApiFetch.mockResolvedValue({ config: null });
+    const mod = await import("../scan-config");
+    await mod.scanConfigApi.get("group/with space");
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      "/api/v1/repositories/group%2Fwith%20space/security",
+      { method: "GET" },
+    );
+  });
+});
+
+describe("scanConfigApi.update", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("PUTs the patch and parses the echoed config", async () => {
+    mockApiFetch.mockResolvedValue(fullConfig);
+    const mod = await import("../scan-config");
+    const cfg = await mod.scanConfigApi.update("maven-releases", {
+      scan_enabled: true,
+      scan_on_proxy: true,
+      proxy_scan_action: "fail_closed",
+    });
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      "/api/v1/repositories/maven-releases/security",
+      {
+        method: "PUT",
+        body: JSON.stringify({
+          scan_enabled: true,
+          scan_on_proxy: true,
+          proxy_scan_action: "fail_closed",
+        }),
+      },
+    );
+    expect(cfg.proxy_scan_action).toBe("fail_closed");
+    expect(cfg.scan_enabled).toBe(true);
+  });
+
+  it("supports a partial patch (single field)", async () => {
+    mockApiFetch.mockResolvedValue({ ...fullConfig, scan_enabled: false });
+    const mod = await import("../scan-config");
+    await mod.scanConfigApi.update("maven-releases", { scan_enabled: false });
+    const [, init] = mockApiFetch.mock.calls[0];
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      scan_enabled: false,
+    });
+  });
+
+  it("throws when the PUT response is malformed", async () => {
+    mockApiFetch.mockResolvedValue(42);
+    const mod = await import("../scan-config");
+    await expect(
+      mod.scanConfigApi.update("x", { scan_enabled: true }),
+    ).rejects.toThrow(/did not match the expected shape/);
+  });
+});

--- a/src/lib/api/scan-config.ts
+++ b/src/lib/api/scan-config.ts
@@ -1,0 +1,171 @@
+import { z } from "zod";
+import { apiFetch } from "@/lib/api/fetch";
+
+/**
+ * Repository-scoped scanning & enforcement configuration
+ * (backend #2954 / #3003, "inline scan-and-block").
+ *
+ * The generated SDK models this endpoint too, but the SDK's
+ * `UpsertScanConfigRequest`/`ScanConfigResponse` do not yet carry the
+ * `proxy_scan_action` field — the knob that decides, when an inline proxy
+ * download is scanned and the scanner is unavailable or the artifact fails
+ * policy, whether the request *fails open* (serve anyway, availability first)
+ * or *fails closed* (block, security first). Bumping the SDK is owned by a
+ * separate worker, so this module deliberately talks to the backend through
+ * the shared `apiFetch` wrapper and validates responses with zod at the trust
+ * boundary. That keeps the "active blocking" UI shippable independently of the
+ * SDK release cadence.
+ *
+ * Endpoints (repo-admin guarded on the backend):
+ *   GET /api/v1/repositories/{key}/security  -> RepoSecurityResponse
+ *   PUT /api/v1/repositories/{key}/security  -> ScanConfigResponse
+ *
+ * The GET wraps the config in `{ config, score }`; `config` is `null` until a
+ * row exists, in which case we surface the documented defaults so the form has
+ * something coherent to render.
+ */
+
+/**
+ * What the proxy does when an inline download is scanned and the scan can't
+ * confirm the artifact is clean (scanner error/timeout, or a policy violation
+ * with blocking on).
+ *
+ * - `fail_open`  — serve the artifact anyway. Availability first. (default)
+ * - `fail_closed`— block the download. Security first ("active blocking").
+ */
+export type ProxyScanAction = "fail_open" | "fail_closed";
+
+export type SeverityThreshold = "critical" | "high" | "medium" | "low";
+
+export const SEVERITY_THRESHOLDS: readonly SeverityThreshold[] = [
+  "critical",
+  "high",
+  "medium",
+  "low",
+] as const;
+
+/** Documented backend defaults for a repository with no scan-config row yet. */
+export const DEFAULT_SCAN_CONFIG: RepoScanConfig = {
+  scan_enabled: false,
+  scan_on_upload: false,
+  scan_on_proxy: false,
+  block_on_policy_violation: false,
+  severity_threshold: "high",
+  proxy_scan_action: "fail_open",
+};
+
+export interface RepoScanConfig {
+  scan_enabled: boolean;
+  scan_on_upload: boolean;
+  scan_on_proxy: boolean;
+  block_on_policy_violation: boolean;
+  severity_threshold: string;
+  proxy_scan_action: ProxyScanAction;
+}
+
+/**
+ * Upsert patch. Every field is optional: the backend upsert is a
+ * read-modify-write that merges the patch over the existing row (#1374), so an
+ * omitted field keeps its stored value instead of being reset to a default.
+ */
+export interface UpsertScanConfigRequest {
+  scan_enabled?: boolean;
+  scan_on_upload?: boolean;
+  scan_on_proxy?: boolean;
+  block_on_policy_violation?: boolean;
+  severity_threshold?: string;
+  proxy_scan_action?: ProxyScanAction;
+}
+
+const ProxyScanActionSchema = z.enum(["fail_open", "fail_closed"]);
+
+// `.catch("fail_open")` keeps the UI resilient if a backend build predates the
+// field or returns an unknown value: we fall back to the safe availability-
+// first default rather than throwing at the trust boundary.
+const ProxyScanActionLoose = ProxyScanActionSchema.catch("fail_open");
+
+const ScanConfigSchema = z
+  .object({
+    scan_enabled: z.boolean().catch(false),
+    scan_on_upload: z.boolean().catch(false),
+    scan_on_proxy: z.boolean().catch(false),
+    block_on_policy_violation: z.boolean().catch(false),
+    severity_threshold: z.string().catch("high"),
+    proxy_scan_action: ProxyScanActionLoose.optional(),
+  })
+  .passthrough();
+
+// The GET returns `{ config: ScanConfigResponse | null, score: ... | null }`.
+// Accept the wrapped shape and, defensively, a bare config object too.
+const RepoSecuritySchema = z.union([
+  z
+    .object({ config: ScanConfigSchema.nullable().optional() })
+    .passthrough(),
+  ScanConfigSchema,
+]);
+
+function normalize(raw: z.infer<typeof ScanConfigSchema>): RepoScanConfig {
+  return {
+    scan_enabled: raw.scan_enabled,
+    scan_on_upload: raw.scan_on_upload,
+    scan_on_proxy: raw.scan_on_proxy,
+    block_on_policy_violation: raw.block_on_policy_violation,
+    severity_threshold: raw.severity_threshold,
+    proxy_scan_action: raw.proxy_scan_action ?? "fail_open",
+  };
+}
+
+/** Parse a GET response into a normalized config, applying defaults when the
+ *  repository has no config row yet. Exported for unit testing. */
+export function parseRepoSecurity(data: unknown): RepoScanConfig {
+  const parsed = RepoSecuritySchema.safeParse(data);
+  if (!parsed.success) {
+    throw new Error(
+      "Repository security response did not match the expected shape",
+    );
+  }
+  const value = parsed.data;
+  // Bare config object (no wrapper).
+  if ("scan_enabled" in value) {
+    return normalize(value as z.infer<typeof ScanConfigSchema>);
+  }
+  // Wrapped: `config` may be null/absent for an unconfigured repository.
+  if (!value.config) {
+    return { ...DEFAULT_SCAN_CONFIG };
+  }
+  return normalize(value.config);
+}
+
+/** Parse a PUT response (a bare ScanConfigResponse). Exported for testing. */
+export function parseScanConfig(data: unknown): RepoScanConfig {
+  const parsed = ScanConfigSchema.safeParse(data);
+  if (!parsed.success) {
+    throw new Error("Scan config response did not match the expected shape");
+  }
+  return normalize(parsed.data);
+}
+
+export const scanConfigApi = {
+  /** Load the current scanning & enforcement config for a repository. */
+  get: async (repoKey: string): Promise<RepoScanConfig> => {
+    const data = await apiFetch<unknown>(
+      `/api/v1/repositories/${encodeURIComponent(repoKey)}/security`,
+      { method: "GET" },
+    );
+    return parseRepoSecurity(data);
+  },
+
+  /** Save (upsert) the scanning & enforcement config for a repository. */
+  update: async (
+    repoKey: string,
+    req: UpsertScanConfigRequest,
+  ): Promise<RepoScanConfig> => {
+    const data = await apiFetch<unknown>(
+      `/api/v1/repositories/${encodeURIComponent(repoKey)}/security`,
+      { method: "PUT", body: JSON.stringify(req) },
+    );
+    return parseScanConfig(data);
+  },
+};
+
+export default scanConfigApi;


### PR DESCRIPTION
Closes #680

## What

Adds a **Scanning & enforcement** section to the repository settings tab so admins can configure vulnerability scanning and inline scan-and-block from the UI. Previously there was no way to turn on active blocking or pick the fail-open/fail-closed proxy behavior without calling the API directly — this closes that gap (the primary ask from a customer evaluation).

### The panel
Loads current config via `GET /api/v1/repositories/{key}/security` and saves via `PUT /api/v1/repositories/{key}/security`:

- **Toggles** — `scan_enabled`, `scan_on_upload`, `scan_on_proxy`, `block_on_policy_violation`
- **Severity threshold** select (critical / high / medium / low)
- **Fail-open vs fail-closed** toggle for `proxy_scan_action`, with a caption spelling out the availability-vs-security tradeoff (fail-closed blocks a proxy download when an inline scan can't confirm the artifact is clean; fail-open serves it anyway)

Dependent controls are disabled until scanning is enabled, and the fail-open/closed toggle is disabled until "Scan on proxy download" is on. The section is **repo-admin gated** (hidden for non-admins), matching the `user?.is_admin` gating used elsewhere in the repository views; the backend PUT is admin-only.

### API client
New `src/lib/api/scan-config.ts` talks to the security endpoint through the shared `apiFetch` wrapper with zod validation at the trust boundary, **not** the generated SDK. The SDK's scan-config types don't yet carry `proxy_scan_action` (a separate worker owns the SDK bump), so this keeps the active-blocking UI shippable on its own cadence. The zod boundary defaults an absent/unknown `proxy_scan_action` to `fail_open`, so the panel is safe against SDK/backend skew.

## Tests
- Unit tests for the api client (wrapped/bare/null responses, proxy_scan_action skew + fallback, URL encoding, PUT partial patch, malformed-response handling).
- Component tests for the new section: non-admin hides it (no GET), admin loads it, dependent controls gated on the master toggle, fail-open/closed captions, Save disabled-until-dirty, save PUTs the full config with `proxy_scan_action=fail_closed`, and error toast on failure.

## Validation
- `npx vitest run` — 158 files / 2942 tests green (includes the new + existing settings-tab suites).
- `npm run build` — compiles clean (product type-check passes).
- `npx eslint` — clean on changed files.

Adds a component-visible UI change; the E2E matrix runs in CI.