### PR TITLE
feat(curation): Rules editor for publisher-trust and popularity (typo-squat) gates

### DIFF
--- a/src/app/(app)/(admin)/curation/_components/curation-rules-manager.test.tsx
+++ b/src/app/(app)/(admin)/curation/_components/curation-rules-manager.test.tsx
@@ -1,0 +1,656 @@
+// @vitest-environment jsdom
+import React from "react";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup, within, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+  Element.prototype.scrollIntoView = vi.fn();
+  Element.prototype.hasPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+});
+
+interface MutationConfig {
+  mutationFn: (...a: unknown[]) => unknown;
+  onSuccess?: (...a: unknown[]) => void;
+  onError?: (...a: unknown[]) => void;
+}
+const mutationConfigs: MutationConfig[] = [];
+const mutateFns: Array<ReturnType<typeof vi.fn>> = [];
+const mockInvalidate = vi.fn();
+let rulesResponse: {
+  data: unknown;
+  isLoading?: boolean;
+  isError?: boolean;
+  error?: unknown;
+} = { data: [], isLoading: false };
+let reposData: unknown = { items: [] };
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (opts: {
+    queryKey: unknown[];
+    queryFn: () => unknown;
+    enabled?: boolean;
+  }) => {
+    const key = (opts.queryKey as string[])[0];
+    if (key === "repositories-all") return { data: reposData };
+    if (opts.enabled !== false) {
+      try {
+        opts.queryFn();
+      } catch {
+        /* ignore */
+      }
+    }
+    return { refetch: vi.fn(), isFetching: false, ...rulesResponse };
+  },
+  useMutation: (config: MutationConfig) => {
+    mutationConfigs.push(config);
+    const mutate = vi.fn();
+    mutateFns.push(mutate);
+    return { mutate, isPending: false };
+  },
+  useQueryClient: () => ({ invalidateQueries: mockInvalidate }),
+}));
+
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...a: unknown[]) => mockToastSuccess(...a),
+    error: vi.fn(),
+  },
+}));
+
+const api = { list: vi.fn(), get: vi.fn(), create: vi.fn(), update: vi.fn(), remove: vi.fn() };
+vi.mock("@/lib/api/curation-rules", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/api/curation-rules")
+  >("@/lib/api/curation-rules");
+  return {
+    ...actual,
+    default: {
+      list: (...a: unknown[]) => api.list(...a),
+      get: (...a: unknown[]) => api.get(...a),
+      create: (...a: unknown[]) => api.create(...a),
+      update: (...a: unknown[]) => api.update(...a),
+      remove: (...a: unknown[]) => api.remove(...a),
+    },
+  };
+});
+vi.mock("@/lib/api/repositories", () => ({
+  repositoriesApi: { list: vi.fn() },
+}));
+
+// Native <select> stub for jsdom (project convention in this admin dir).
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value?: string;
+    onValueChange?: (v: string) => void;
+    children: React.ReactNode;
+  }) => {
+    const items: Array<{ value: string; label: string }> = [];
+    let ariaLabel = "";
+    React.Children.forEach(children, (c) => {
+      if (!React.isValidElement(c)) return;
+      const el = c as React.ReactElement<{
+        "aria-label"?: string;
+        children?: React.ReactNode;
+      }>;
+      if (el.props["aria-label"]) ariaLabel = el.props["aria-label"];
+      React.Children.forEach(el.props.children, (s) => {
+        if (
+          React.isValidElement(s) &&
+          (s.props as Record<string, unknown>).value
+        ) {
+          const p = s.props as { value: string; children: React.ReactNode };
+          items.push({ value: p.value, label: String(p.children) });
+        }
+      });
+    });
+    return (
+      <select
+        aria-label={ariaLabel || undefined}
+        value={value}
+        onChange={(e) => onValueChange?.(e.target.value)}
+      >
+        <option value="" />
+        {items.map((i) => (
+          <option key={i.value} value={i.value}>
+            {i.label}
+          </option>
+        ))}
+      </select>
+    );
+  },
+  SelectTrigger: ({ children, ...p }: { children: React.ReactNode }) => (
+    <span {...p}>{children}</span>
+  ),
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  SelectItem: ({
+    value,
+    children,
+  }: {
+    value: string;
+    children: React.ReactNode;
+  }) => <option value={value}>{children}</option>,
+}));
+
+vi.mock("@/components/ui/switch", () => ({
+  Switch: ({
+    checked,
+    onCheckedChange,
+    id,
+  }: {
+    checked?: boolean;
+    onCheckedChange?: (v: boolean) => void;
+    id?: string;
+  }) => (
+    <input
+      type="checkbox"
+      role="switch"
+      id={id}
+      checked={!!checked}
+      onChange={(e) => onCheckedChange?.(e.target.checked)}
+    />
+  ),
+}));
+
+import { CurationRulesManager, toRequest } from "./curation-rules-manager";
+
+const PATTERN_RULE = {
+  id: "r1",
+  staging_repo_id: "repo1",
+  package_pattern: "left-*",
+  version_constraint: "*",
+  architecture: "*",
+  action: "block",
+  priority: 50,
+  reason: "known-bad",
+  rule_type: "pattern",
+  config: {},
+  scope: "repository",
+  enabled: true,
+};
+const POP_RULE = {
+  id: "r2",
+  staging_repo_id: null,
+  package_pattern: "*",
+  version_constraint: "*",
+  architecture: "*",
+  action: "flag",
+  priority: 100,
+  reason: null,
+  rule_type: "popularity",
+  config: {
+    min_downloads: 500,
+    typosquat_check: true,
+    homoglyph_check: true,
+    affix_check: true,
+    affix_max_downloads: 2000,
+    max_distance: 1,
+    action: "block",
+  },
+  scope: "global",
+  enabled: false,
+};
+const REPOS = {
+  items: [{ id: "repo1", key: "staging-npm", repo_type: "staging" }],
+};
+
+const saveMutate = () => mutateFns[mutateFns.length - 2];
+const deleteMutate = () => mutateFns[mutateFns.length - 1];
+
+beforeEach(() => {
+  mutationConfigs.length = 0;
+  mutateFns.length = 0;
+  vi.clearAllMocks();
+  rulesResponse = { data: [], isLoading: false };
+  reposData = { items: [] };
+});
+afterEach(() => cleanup());
+
+describe("CurationRulesManager", () => {
+  it("shows the empty state", () => {
+    render(<CurationRulesManager />);
+    expect(screen.getByText(/No curation rules yet/i)).toBeInTheDocument();
+  });
+
+  it("shows a skeleton while loading", () => {
+    rulesResponse = { data: undefined, isLoading: true };
+    render(<CurationRulesManager />);
+    expect(screen.queryByText(/No curation rules yet/i)).not.toBeInTheDocument();
+  });
+
+  it("shows an error state with retry", () => {
+    rulesResponse = {
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error("x"),
+    };
+    render(<CurationRulesManager />);
+    expect(
+      screen.getByText(/Couldn't load curation rules/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("lists rules across engine types with resolved scope + action", () => {
+    rulesResponse = { data: [PATTERN_RULE, POP_RULE], isLoading: false };
+    reposData = REPOS;
+    render(<CurationRulesManager />);
+    // "Pattern" appears as both a column header and the pattern rule's type.
+    expect(screen.getAllByText("Pattern").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText("Popularity")).toBeInTheDocument();
+    expect(screen.getByText("left-*")).toBeInTheDocument();
+    // repository-scoped rule resolves its repo key
+    expect(screen.getByText("staging-npm")).toBeInTheDocument();
+    // global-scoped rule shows "global"
+    expect(screen.getByText("global")).toBeInTheDocument();
+    // block action + disabled badge
+    expect(screen.getByText("block")).toBeInTheDocument();
+    expect(screen.getByText("disabled")).toBeInTheDocument();
+  });
+
+  it("creates a default pattern rule", async () => {
+    const user = userEvent.setup();
+    reposData = REPOS;
+    render(<CurationRulesManager />);
+    await user.click(screen.getByRole("button", { name: /new rule/i }));
+    await user.click(screen.getByRole("button", { name: /^Create$/i }));
+    expect(saveMutate()).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: null,
+        form: expect.objectContaining({ rule_type: "pattern" }),
+      }),
+    );
+  });
+
+  it("switches the config sub-form to publisher-trust and requires publishers", async () => {
+    const user = userEvent.setup();
+    render(<CurationRulesManager />);
+    await user.click(screen.getByRole("button", { name: /new rule/i }));
+    await user.selectOptions(
+      screen.getByLabelText("Rule type"),
+      "publisher_trust",
+    );
+    // sub-form is revealed
+    const publishers = screen.getByLabelText(/Trusted publishers/i);
+    expect(publishers).toBeInTheDocument();
+    // Create is disabled until a publisher is entered
+    const create = screen.getByRole("button", { name: /^Create$/i });
+    expect(create).toBeDisabled();
+    await user.type(publishers, "github.com/acme");
+    expect(create).toBeEnabled();
+    await user.click(create);
+    expect(saveMutate()).toHaveBeenCalledWith(
+      expect.objectContaining({
+        form: expect.objectContaining({
+          rule_type: "publisher_trust",
+          trusted_publishers: "github.com/acme",
+        }),
+      }),
+    );
+  });
+
+  it("reveals homoglyph/affix fields only when the typo-squat toggle is on", async () => {
+    const user = userEvent.setup();
+    render(<CurationRulesManager />);
+    await user.click(screen.getByRole("button", { name: /new rule/i }));
+    await user.selectOptions(screen.getByLabelText("Rule type"), "popularity");
+    // min_downloads is always visible for popularity
+    expect(screen.getByLabelText(/Min downloads/i)).toBeInTheDocument();
+    // typosquat defaults on -> nested checks visible
+    expect(screen.getByLabelText(/Homoglyph check/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Max edit distance/i)).toBeInTheDocument();
+    // toggle typosquat off -> nested checks hidden
+    await user.click(screen.getByLabelText(/Typo-squat check/i));
+    expect(screen.queryByLabelText(/Homoglyph check/i)).not.toBeInTheDocument();
+    // affix_max_downloads only appears once affix check is on
+    await user.click(screen.getByLabelText(/Typo-squat check/i)); // back on
+    expect(
+      screen.queryByLabelText(/Affix max downloads/i),
+    ).not.toBeInTheDocument();
+    await user.click(screen.getByLabelText(/^Affix check/i));
+    expect(screen.getByLabelText(/Affix max downloads/i)).toBeInTheDocument();
+  });
+
+  it("round-trips an existing popularity rule into the edit form", async () => {
+    const user = userEvent.setup();
+    rulesResponse = { data: [POP_RULE], isLoading: false };
+    render(<CurationRulesManager />);
+    await user.click(
+      screen.getByRole("button", { name: /Edit popularity rule/i }),
+    );
+    expect((screen.getByLabelText(/Min downloads/i) as HTMLInputElement).value).toBe(
+      "500",
+    );
+    expect(
+      (screen.getByLabelText(/Max edit distance/i) as HTMLInputElement).value,
+    ).toBe("1");
+    expect(
+      (screen.getByLabelText(/Affix max downloads/i) as HTMLInputElement).value,
+    ).toBe("2000");
+    await user.click(screen.getByRole("button", { name: /^Save$/i }));
+    expect(saveMutate()).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "r2" }),
+    );
+  });
+
+  it("deletes via confirm", async () => {
+    const user = userEvent.setup();
+    rulesResponse = { data: [PATTERN_RULE], isLoading: false };
+    reposData = REPOS;
+    render(<CurationRulesManager />);
+    await user.click(
+      screen.getByRole("button", { name: /Delete pattern rule/i }),
+    );
+    const dialog = await screen.findByRole("alertdialog");
+    await user.click(within(dialog).getByRole("button", { name: /^Delete$/i }));
+    expect(deleteMutate()).toHaveBeenCalledWith("r1");
+  });
+
+  it("resolves an unknown repo id to the raw id in the scope badge", () => {
+    rulesResponse = {
+      data: [{ ...PATTERN_RULE, staging_repo_id: "ghost-repo" }],
+      isLoading: false,
+    };
+    reposData = REPOS; // does not contain ghost-repo
+    render(<CurationRulesManager />);
+    expect(screen.getByText("ghost-repo")).toBeInTheDocument();
+  });
+
+  it("captures every common + popularity field on create", async () => {
+    const user = userEvent.setup();
+    render(<CurationRulesManager />);
+    await user.click(screen.getByRole("button", { name: /new rule/i }));
+    await user.selectOptions(screen.getByLabelText("Rule type"), "popularity");
+    await user.selectOptions(screen.getByLabelText("Scope"), "global");
+
+    const pattern = screen.getByLabelText("Package pattern");
+    await user.clear(pattern);
+    await user.type(pattern, "ex-*");
+    const version = screen.getByLabelText("Version");
+    await user.clear(version);
+    await user.type(version, ">=1.0.0");
+    const arch = screen.getByLabelText("Architecture");
+    await user.clear(arch);
+    await user.type(arch, "x86_64");
+    await user.selectOptions(screen.getByLabelText("Action"), "block");
+    // Number inputs carry a default and revert on clear, so drive them with a
+    // single deterministic change event rather than clear+type.
+    fireEvent.change(screen.getByLabelText("Priority"), {
+      target: { value: "5" },
+    });
+
+    fireEvent.change(screen.getByLabelText(/Min downloads/i), {
+      target: { value: "300" },
+    });
+    await user.selectOptions(screen.getByLabelText(/Flagged action/i), "block");
+    fireEvent.change(screen.getByLabelText(/Max edit distance/i), {
+      target: { value: "1" },
+    });
+    await user.click(screen.getByLabelText(/Homoglyph check/i));
+    await user.click(screen.getByLabelText(/^Affix check/i));
+    fireEvent.change(screen.getByLabelText(/Affix max downloads/i), {
+      target: { value: "250" },
+    });
+    await user.type(screen.getByLabelText(/Popular packages/i), "react, vue");
+
+    await user.type(screen.getByLabelText("Reason"), "squat guard");
+    await user.click(screen.getByLabelText("Enabled")); // true -> false
+
+    await user.click(screen.getByRole("button", { name: /^Create$/i }));
+    const arg = saveMutate().mock.calls[0][0] as { form: Record<string, unknown> };
+    expect(arg.form).toMatchObject({
+      rule_type: "popularity",
+      scope: "global",
+      package_pattern: "ex-*",
+      version_constraint: ">=1.0.0",
+      architecture: "x86_64",
+      action: "block",
+      priority: 5,
+      min_downloads: 300,
+      pop_action: "block",
+      max_distance: 1,
+      homoglyph_check: true,
+      affix_check: true,
+      affix_max_downloads: 250,
+      popular_packages: "react, vue",
+      reason: "squat guard",
+      enabled: false,
+    });
+  });
+
+  it("captures publisher-trust match + untrusted action on create", async () => {
+    const user = userEvent.setup();
+    render(<CurationRulesManager />);
+    await user.click(screen.getByRole("button", { name: /new rule/i }));
+    await user.selectOptions(
+      screen.getByLabelText("Rule type"),
+      "publisher_trust",
+    );
+    await user.type(screen.getByLabelText(/Trusted publishers/i), "acme");
+    await user.selectOptions(screen.getByLabelText("Match"), "signature");
+    await user.selectOptions(
+      screen.getByLabelText("Untrusted action"),
+      "block",
+    );
+    await user.click(screen.getByRole("button", { name: /^Create$/i }));
+    const arg = saveMutate().mock.calls[0][0] as { form: Record<string, unknown> };
+    expect(arg.form).toMatchObject({
+      rule_type: "publisher_trust",
+      trusted_publishers: "acme",
+      pt_match: "signature",
+      pt_action: "block",
+    });
+  });
+
+  it("round-trips a publisher-trust rule into the edit form", async () => {
+    const user = userEvent.setup();
+    rulesResponse = {
+      data: [
+        {
+          ...PATTERN_RULE,
+          id: "pt1",
+          rule_type: "publisher_trust",
+          config: {
+            trusted_publishers: ["p1", "p2"],
+            match: "namespace",
+            action: "audit",
+          },
+        },
+      ],
+      isLoading: false,
+    };
+    reposData = REPOS;
+    render(<CurationRulesManager />);
+    await user.click(
+      screen.getByRole("button", { name: /Edit publisher_trust rule/i }),
+    );
+    expect(
+      (screen.getByLabelText(/Trusted publishers/i) as HTMLTextAreaElement)
+        .value,
+    ).toBe("p1, p2");
+    expect((screen.getByLabelText("Untrusted action") as HTMLSelectElement).value).toBe(
+      "audit",
+    );
+  });
+
+  it("cancel closes the dialog without saving", async () => {
+    const user = userEvent.setup();
+    render(<CurationRulesManager />);
+    await user.click(screen.getByRole("button", { name: /new rule/i }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /^Cancel$/i }));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(saveMutate()).not.toHaveBeenCalled();
+  });
+
+  it("mutation callbacks invalidate, toast, and reset (create/update/delete)", () => {
+    render(<CurationRulesManager />);
+    const [save, del] = mutationConfigs;
+    save.onSuccess?.(undefined, { id: null });
+    save.onSuccess?.(undefined, { id: "r1" });
+    del.onSuccess?.();
+    expect(mockInvalidate).toHaveBeenCalledTimes(3);
+    expect(mockToastSuccess).toHaveBeenCalledWith("Rule created");
+    expect(mockToastSuccess).toHaveBeenCalledWith("Rule updated");
+    expect(mockToastSuccess).toHaveBeenCalledWith("Rule deleted");
+  });
+
+  it("save mutationFn dispatches create vs update against the api", () => {
+    render(<CurationRulesManager />);
+    const [save] = mutationConfigs;
+    const baseForm = {
+      rule_type: "popularity",
+      scope: "global",
+      staging_repo_id: "",
+      package_pattern: "*",
+      version_constraint: "*",
+      architecture: "*",
+      action: "flag",
+      priority: 100,
+      reason: "",
+      enabled: true,
+      trusted_publishers: "",
+      pt_match: "attestation",
+      pt_action: "flag",
+      min_downloads: 1000,
+      max_distance: 2,
+      typosquat_check: true,
+      homoglyph_check: false,
+      affix_check: false,
+      affix_max_downloads: 1000,
+      pop_action: "block",
+      popular_packages: "react, lodash",
+    };
+    save.mutationFn({ id: null, form: baseForm });
+    expect(api.create).toHaveBeenCalledTimes(1);
+    const createReq = api.create.mock.calls[0][0];
+    expect(createReq.rule_type).toBe("popularity");
+    expect(createReq.staging_repo_id).toBeNull();
+    expect(createReq.config).toMatchObject({
+      typosquat_check: true,
+      action: "block",
+      min_downloads: 1000,
+      max_distance: 2,
+      popular_packages: ["react", "lodash"],
+    });
+    save.mutationFn({ id: "r9", form: baseForm });
+    expect(api.update).toHaveBeenCalledWith("r9", expect.any(Object));
+  });
+});
+
+describe("toRequest config building", () => {
+  const base = {
+    rule_type: "pattern" as const,
+    scope: "repository" as const,
+    staging_repo_id: "repo1",
+    package_pattern: "  left-* ",
+    version_constraint: "",
+    architecture: "*",
+    action: "block",
+    priority: 10,
+    reason: "  bad  ",
+    enabled: true,
+    trusted_publishers: "",
+    pt_match: "attestation",
+    pt_action: "flag",
+    min_downloads: undefined,
+    max_distance: 2,
+    typosquat_check: true,
+    homoglyph_check: false,
+    affix_check: false,
+    affix_max_downloads: 1000,
+    pop_action: "flag",
+    popular_packages: "",
+  };
+
+  it("trims patterns, defaults blanks to *, trims reason, empty config for pattern", () => {
+    const req = toRequest(base);
+    expect(req.package_pattern).toBe("left-*");
+    expect(req.version_constraint).toBe("*");
+    expect(req.reason).toBe("bad");
+    expect(req.config).toEqual({});
+    expect(req.staging_repo_id).toBe("repo1");
+  });
+
+  it("nulls staging_repo_id when scope is global", () => {
+    const req = toRequest({ ...base, scope: "global" });
+    expect(req.staging_repo_id).toBeNull();
+  });
+
+  it("builds publisher_trust config with a parsed publisher list", () => {
+    const req = toRequest({
+      ...base,
+      rule_type: "publisher_trust",
+      trusted_publishers: "a, b\n b \nc",
+      pt_match: "signature",
+      pt_action: "block",
+    });
+    expect(req.config).toEqual({
+      trusted_publishers: ["a", "b", "c"],
+      match: "signature",
+      action: "block",
+    });
+  });
+
+  it("omits affix/homoglyph/distance from popularity config when typosquat is off", () => {
+    const req = toRequest({
+      ...base,
+      rule_type: "popularity",
+      typosquat_check: false,
+      pop_action: "flag",
+      min_downloads: 250,
+    });
+    expect(req.config).toEqual({
+      typosquat_check: false,
+      action: "flag",
+      min_downloads: 250,
+    });
+  });
+
+  it("includes affix_max_downloads only when affix_check is on", () => {
+    const withAffix = toRequest({
+      ...base,
+      rule_type: "popularity",
+      typosquat_check: true,
+      affix_check: true,
+      affix_max_downloads: 3000,
+    });
+    expect(withAffix.config).toMatchObject({
+      max_distance: 2,
+      homoglyph_check: false,
+      affix_check: true,
+      affix_max_downloads: 3000,
+    });
+    const withoutAffix = toRequest({
+      ...base,
+      rule_type: "popularity",
+      typosquat_check: true,
+      affix_check: false,
+    });
+    expect(withoutAffix.config).not.toHaveProperty("affix_max_downloads");
+  });
+});

--- a/src/app/(app)/(admin)/curation/_components/curation-rules-manager.tsx
+++ b/src/app/(app)/(admin)/curation/_components/curation-rules-manager.tsx
@@ -1,0 +1,886 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  Plus,
+  Trash2,
+  Pencil,
+  AlertCircle,
+  RotateCcw,
+  Loader2,
+  ShieldCheck,
+  TrendingDown,
+  Filter,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import curationRulesApi, {
+  type CurationRule,
+  type CreateRuleRequest,
+  type RuleType,
+  RULE_ACTIONS,
+  RULE_TYPES,
+  PUBLISHER_MATCHES,
+  parseList,
+  clampDistance,
+} from "@/lib/api/curation-rules";
+import { repositoriesApi } from "@/lib/api/repositories";
+import { mutationErrorToast, toUserMessage } from "@/lib/error-utils";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ConfirmDialog } from "@/components/common/confirm-dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+
+const QUERY_KEY = ["curation-rules"];
+
+const RULE_TYPE_LABELS: Record<RuleType, string> = {
+  pattern: "Pattern",
+  publisher_trust: "Publisher trust",
+  popularity: "Popularity",
+};
+
+const RULE_TYPE_ICONS: Record<RuleType, typeof Filter> = {
+  pattern: Filter,
+  publisher_trust: ShieldCheck,
+  popularity: TrendingDown,
+};
+
+// ---------------------------------------------------------------------------
+// Form state — one flat object covering every engine's fields. `toRequest`
+// projects only the fields relevant to the selected `rule_type` into `config`.
+// ---------------------------------------------------------------------------
+
+interface RuleFormState {
+  rule_type: RuleType;
+  scope: "repository" | "global";
+  staging_repo_id: string; // "" => omitted
+  package_pattern: string;
+  version_constraint: string;
+  architecture: string;
+  action: string;
+  priority: number;
+  reason: string;
+  enabled: boolean;
+  // publisher_trust
+  trusted_publishers: string; // comma/newline separated
+  pt_match: string;
+  pt_action: string;
+  // popularity
+  min_downloads: number | undefined;
+  max_distance: number;
+  typosquat_check: boolean;
+  homoglyph_check: boolean;
+  affix_check: boolean;
+  affix_max_downloads: number | undefined;
+  pop_action: string;
+  popular_packages: string; // comma/newline separated
+}
+
+const emptyForm: RuleFormState = {
+  rule_type: "pattern",
+  scope: "repository",
+  staging_repo_id: "",
+  package_pattern: "*",
+  version_constraint: "*",
+  architecture: "*",
+  action: "flag",
+  priority: 100,
+  reason: "",
+  enabled: true,
+  trusted_publishers: "",
+  pt_match: "attestation",
+  pt_action: "flag",
+  min_downloads: undefined,
+  max_distance: 2,
+  typosquat_check: true,
+  homoglyph_check: false,
+  affix_check: false,
+  affix_max_downloads: 1000,
+  pop_action: "flag",
+  popular_packages: "",
+};
+
+function buildConfig(f: RuleFormState): Record<string, unknown> {
+  if (f.rule_type === "publisher_trust") {
+    return {
+      trusted_publishers: parseList(f.trusted_publishers),
+      match: f.pt_match,
+      action: f.pt_action,
+    };
+  }
+  if (f.rule_type === "popularity") {
+    const config: Record<string, unknown> = {
+      typosquat_check: f.typosquat_check,
+      action: f.pop_action,
+    };
+    if (f.min_downloads != null) config.min_downloads = f.min_downloads;
+    if (f.typosquat_check) {
+      config.max_distance = clampDistance(f.max_distance);
+      config.homoglyph_check = f.homoglyph_check;
+      config.affix_check = f.affix_check;
+      if (f.affix_check) {
+        config.affix_max_downloads = f.affix_max_downloads ?? 1000;
+      }
+    }
+    const popular = parseList(f.popular_packages);
+    if (popular.length > 0) config.popular_packages = popular;
+    return config;
+  }
+  // pattern: no engine-specific config
+  return {};
+}
+
+export function toRequest(f: RuleFormState): CreateRuleRequest {
+  return {
+    rule_type: f.rule_type,
+    scope: f.scope,
+    staging_repo_id:
+      f.scope === "global" || f.staging_repo_id === ""
+        ? null
+        : f.staging_repo_id,
+    package_pattern: f.package_pattern.trim() || "*",
+    version_constraint: f.version_constraint.trim() || "*",
+    architecture: f.architecture.trim() || "*",
+    action: f.action,
+    priority: f.priority,
+    reason: f.reason.trim(),
+    enabled: f.enabled,
+    config: buildConfig(f),
+  };
+}
+
+function formFromRule(r: CurationRule): RuleFormState {
+  const c = r.config ?? {};
+  const asList = (v: unknown): string =>
+    Array.isArray(v) ? (v as unknown[]).map(String).join(", ") : "";
+  const asNum = (v: unknown): number | undefined =>
+    typeof v === "number" ? v : undefined;
+  const asBool = (v: unknown, dflt: boolean): boolean =>
+    typeof v === "boolean" ? v : dflt;
+  return {
+    rule_type: r.rule_type,
+    scope: r.scope,
+    staging_repo_id: r.staging_repo_id ?? "",
+    package_pattern: r.package_pattern,
+    version_constraint: r.version_constraint,
+    architecture: r.architecture,
+    action: r.action,
+    priority: r.priority,
+    reason: r.reason ?? "",
+    enabled: r.enabled,
+    trusted_publishers: asList(c.trusted_publishers),
+    pt_match: typeof c.match === "string" ? c.match : "attestation",
+    pt_action:
+      r.rule_type === "publisher_trust" && typeof c.action === "string"
+        ? c.action
+        : "flag",
+    min_downloads: asNum(c.min_downloads),
+    max_distance: clampDistance(asNum(c.max_distance)),
+    typosquat_check: asBool(c.typosquat_check, true),
+    homoglyph_check: asBool(c.homoglyph_check, false),
+    affix_check: asBool(c.affix_check, false),
+    affix_max_downloads: asNum(c.affix_max_downloads) ?? 1000,
+    pop_action:
+      r.rule_type === "popularity" && typeof c.action === "string"
+        ? c.action
+        : "flag",
+    popular_packages: asList(c.popular_packages),
+  };
+}
+
+function numField(v: string): number | undefined {
+  const n = Number.parseInt(v, 10);
+  return Number.isNaN(n) ? undefined : n;
+}
+
+export function CurationRulesManager() {
+  const queryClient = useQueryClient();
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<CurationRule | null>(null);
+  const [form, setForm] = useState<RuleFormState>(emptyForm);
+  const [deleteTarget, setDeleteTarget] = useState<CurationRule | null>(null);
+
+  const { data: rules, isLoading, isError, error, refetch, isFetching } =
+    useQuery({
+      queryKey: QUERY_KEY,
+      queryFn: () => curationRulesApi.list(),
+    });
+
+  const { data: repos } = useQuery({
+    queryKey: ["repositories-all"],
+    queryFn: () => repositoriesApi.list({ per_page: 1000 }),
+  });
+  const stagingRepos = useMemo(
+    () => (repos?.items ?? []).filter((r) => r.repo_type === "staging"),
+    [repos?.items],
+  );
+  const repoKey = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const r of repos?.items ?? []) map.set(r.id, r.key);
+    return (id: string | null | undefined) => (id ? map.get(id) ?? id : null);
+  }, [repos?.items]);
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+
+  const saveMutation = useMutation({
+    mutationFn: (vars: { id: string | null; form: RuleFormState }) => {
+      const req = toRequest(vars.form);
+      return vars.id
+        ? curationRulesApi.update(vars.id, req)
+        : curationRulesApi.create(req);
+    },
+    onSuccess: (_r, vars) => {
+      invalidate();
+      setDialogOpen(false);
+      setEditing(null);
+      setForm(emptyForm);
+      toast.success(vars.id ? "Rule updated" : "Rule created");
+    },
+    onError: mutationErrorToast("Failed to save rule"),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => curationRulesApi.remove(id),
+    onSuccess: () => {
+      invalidate();
+      setDeleteTarget(null);
+      toast.success("Rule deleted");
+    },
+    onError: mutationErrorToast("Failed to delete rule"),
+  });
+
+  function openCreate() {
+    setEditing(null);
+    setForm(emptyForm);
+    setDialogOpen(true);
+  }
+  function openEdit(r: CurationRule) {
+    setEditing(r);
+    setForm(formFromRule(r));
+    setDialogOpen(true);
+  }
+
+  const canSave =
+    !saveMutation.isPending &&
+    (form.rule_type !== "publisher_trust" ||
+      parseList(form.trusted_publishers).length > 0);
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSave) return;
+    saveMutation.mutate({ id: editing?.id ?? null, form });
+  }
+
+  const rows = rules ?? [];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          Standing policy the curation queue is evaluated against: pattern,
+          publisher-trust, and popularity (typo-squat) gates.
+        </p>
+        <Button onClick={openCreate}>
+          <Plus className="size-4" />
+          New Rule
+        </Button>
+      </div>
+
+      {isLoading && (
+        <div className="space-y-2" role="status" aria-busy="true">
+          <Skeleton className="h-12 w-full" />
+          <Skeleton className="h-12 w-full" />
+        </div>
+      )}
+
+      {!isLoading && isError && (
+        <div
+          className="flex flex-col items-center justify-center py-12 text-center"
+          role="alert"
+        >
+          <AlertCircle className="size-8 mb-2 text-destructive opacity-80" />
+          <p className="text-sm font-medium">Couldn&apos;t load curation rules</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {toUserMessage(error, "Unknown error")}
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-4"
+            onClick={() => refetch()}
+            disabled={isFetching}
+          >
+            <RotateCcw className={`size-4 ${isFetching ? "animate-spin" : ""}`} />
+            Retry
+          </Button>
+        </div>
+      )}
+
+      {!isLoading && !isError && rows.length === 0 && (
+        <div className="flex flex-col items-center justify-center rounded-md border border-dashed py-12 text-center text-muted-foreground">
+          <ShieldCheck className="size-8 mb-2 opacity-50" />
+          <p className="text-sm">No curation rules yet.</p>
+          <p className="text-xs">
+            Create one to gate proxied packages by pattern, publisher trust, or
+            popularity.
+          </p>
+        </div>
+      )}
+
+      {!isLoading && !isError && rows.length > 0 && (
+        <div className="overflow-hidden rounded-md border">
+          <table className="w-full text-sm">
+            <thead className="border-b bg-muted/50 text-left">
+              <tr>
+                <th className="px-3 py-2 font-medium">Type</th>
+                <th className="px-3 py-2 font-medium">Pattern</th>
+                <th className="px-3 py-2 font-medium">Scope</th>
+                <th className="px-3 py-2 font-medium">Action</th>
+                <th className="px-3 py-2 font-medium">Priority</th>
+                <th className="px-3 py-2 font-medium">Enabled</th>
+                <th className="px-3 py-2" />
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {rows.map((r) => {
+                const Icon = RULE_TYPE_ICONS[r.rule_type];
+                return (
+                  <tr key={r.id}>
+                    <td className="px-3 py-2">
+                      <span className="flex items-center gap-1.5">
+                        <Icon className="size-4 text-muted-foreground" />
+                        {RULE_TYPE_LABELS[r.rule_type]}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 font-mono text-xs">
+                      {r.package_pattern}
+                    </td>
+                    <td className="px-3 py-2">
+                      <Badge variant="outline" className="capitalize">
+                        {r.scope === "global"
+                          ? "global"
+                          : repoKey(r.staging_repo_id) ?? "repository"}
+                      </Badge>
+                    </td>
+                    <td className="px-3 py-2">
+                      <Badge
+                        variant={
+                          r.action === "block" ? "destructive" : "secondary"
+                        }
+                        className="capitalize"
+                      >
+                        {r.action}
+                      </Badge>
+                    </td>
+                    <td className="px-3 py-2 tabular-nums">{r.priority}</td>
+                    <td className="px-3 py-2">
+                      {r.enabled ? (
+                        <Badge variant="secondary">enabled</Badge>
+                      ) : (
+                        <Badge variant="outline">disabled</Badge>
+                      )}
+                    </td>
+                    <td className="px-3 py-2">
+                      <div className="flex justify-end gap-1">
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          aria-label={`Edit ${r.rule_type} rule ${r.package_pattern}`}
+                          onClick={() => openEdit(r)}
+                        >
+                          <Pencil className="size-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          aria-label={`Delete ${r.rule_type} rule ${r.package_pattern}`}
+                          onClick={() => setDeleteTarget(r)}
+                        >
+                          <Trash2 className="size-4 text-destructive" />
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Create / edit dialog */}
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+          <form onSubmit={submit}>
+            <DialogHeader>
+              <DialogTitle>
+                {editing ? "Edit curation rule" : "New curation rule"}
+              </DialogTitle>
+              <DialogDescription>
+                Rules are evaluated in priority order over packages entering the
+                curation queue.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-4 py-4">
+              {/* Rule type */}
+              <div className="space-y-1.5">
+                <Label htmlFor="cr-type">Rule type</Label>
+                <Select
+                  value={form.rule_type}
+                  onValueChange={(v) =>
+                    setForm((f) => ({ ...f, rule_type: v as RuleType }))
+                  }
+                >
+                  <SelectTrigger id="cr-type" aria-label="Rule type">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {RULE_TYPES.map((t) => (
+                      <SelectItem key={t} value={t}>
+                        {RULE_TYPE_LABELS[t]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Common: scope + repo */}
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <Label htmlFor="cr-scope">Scope</Label>
+                  <Select
+                    value={form.scope}
+                    onValueChange={(v) =>
+                      setForm((f) => ({
+                        ...f,
+                        scope: v as "repository" | "global",
+                      }))
+                    }
+                  >
+                    <SelectTrigger id="cr-scope" aria-label="Scope">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="repository">Repository</SelectItem>
+                      <SelectItem value="global">Global</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="cr-repo">Staging repository</Label>
+                  <Select
+                    value={form.staging_repo_id}
+                    onValueChange={(v) =>
+                      setForm((f) => ({ ...f, staging_repo_id: v }))
+                    }
+                  >
+                    <SelectTrigger
+                      id="cr-repo"
+                      aria-label="Staging repository"
+                      disabled={form.scope === "global"}
+                    >
+                      <SelectValue placeholder="Select a repository" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {stagingRepos.map((r) => (
+                        <SelectItem key={r.id} value={r.id}>
+                          {r.key}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              {/* Common: pattern / version / arch */}
+              <div className="grid grid-cols-3 gap-3">
+                <div className="space-y-1.5">
+                  <Label htmlFor="cr-pattern">Package pattern</Label>
+                  <Input
+                    id="cr-pattern"
+                    value={form.package_pattern}
+                    onChange={(e) =>
+                      setForm((f) => ({ ...f, package_pattern: e.target.value }))
+                    }
+                    placeholder="*"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="cr-version">Version</Label>
+                  <Input
+                    id="cr-version"
+                    value={form.version_constraint}
+                    onChange={(e) =>
+                      setForm((f) => ({
+                        ...f,
+                        version_constraint: e.target.value,
+                      }))
+                    }
+                    placeholder="*"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="cr-arch">Architecture</Label>
+                  <Input
+                    id="cr-arch"
+                    value={form.architecture}
+                    onChange={(e) =>
+                      setForm((f) => ({ ...f, architecture: e.target.value }))
+                    }
+                    placeholder="*"
+                  />
+                </div>
+              </div>
+
+              {/* Common: action + priority */}
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <Label htmlFor="cr-action">Action</Label>
+                  <Select
+                    value={form.action}
+                    onValueChange={(v) =>
+                      setForm((f) => ({ ...f, action: v }))
+                    }
+                  >
+                    <SelectTrigger id="cr-action" aria-label="Action">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {RULE_ACTIONS.map((a) => (
+                        <SelectItem key={a} value={a} className="capitalize">
+                          {a}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="cr-priority">Priority</Label>
+                  <Input
+                    id="cr-priority"
+                    type="number"
+                    min={0}
+                    value={form.priority}
+                    onChange={(e) =>
+                      setForm((f) => ({
+                        ...f,
+                        priority: numField(e.target.value) ?? 100,
+                      }))
+                    }
+                  />
+                </div>
+              </div>
+
+              {/* Engine-specific config sub-form */}
+              {form.rule_type === "publisher_trust" && (
+                <div className="space-y-4 rounded-md border p-3">
+                  <p className="text-xs font-medium text-muted-foreground">
+                    Publisher-trust configuration
+                  </p>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="cr-pt-publishers">
+                      Trusted publishers (one per line or comma-separated)
+                    </Label>
+                    <Textarea
+                      id="cr-pt-publishers"
+                      value={form.trusted_publishers}
+                      onChange={(e) =>
+                        setForm((f) => ({
+                          ...f,
+                          trusted_publishers: e.target.value,
+                        }))
+                      }
+                      placeholder={"github.com/acme\nnpmjs.com/@acme"}
+                      rows={3}
+                    />
+                  </div>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1.5">
+                      <Label htmlFor="cr-pt-match">Match</Label>
+                      <Select
+                        value={form.pt_match}
+                        onValueChange={(v) =>
+                          setForm((f) => ({ ...f, pt_match: v }))
+                        }
+                      >
+                        <SelectTrigger id="cr-pt-match" aria-label="Match">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {PUBLISHER_MATCHES.map((m) => (
+                            <SelectItem
+                              key={m}
+                              value={m}
+                              className="capitalize"
+                            >
+                              {m}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="cr-pt-action">Untrusted action</Label>
+                      <Select
+                        value={form.pt_action}
+                        onValueChange={(v) =>
+                          setForm((f) => ({ ...f, pt_action: v }))
+                        }
+                      >
+                        <SelectTrigger
+                          id="cr-pt-action"
+                          aria-label="Untrusted action"
+                        >
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {(["flag", "block", "allow", "audit"] as const).map(
+                            (a) => (
+                              <SelectItem
+                                key={a}
+                                value={a}
+                                className="capitalize"
+                              >
+                                {a}
+                              </SelectItem>
+                            ),
+                          )}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {form.rule_type === "popularity" && (
+                <div className="space-y-4 rounded-md border p-3">
+                  <p className="text-xs font-medium text-muted-foreground">
+                    Popularity configuration
+                  </p>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1.5">
+                      <Label htmlFor="cr-pop-min">Min downloads</Label>
+                      <Input
+                        id="cr-pop-min"
+                        type="number"
+                        min={0}
+                        value={form.min_downloads ?? ""}
+                        onChange={(e) =>
+                          setForm((f) => ({
+                            ...f,
+                            min_downloads: numField(e.target.value),
+                          }))
+                        }
+                        placeholder="e.g. 1000"
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="cr-pop-action">Flagged action</Label>
+                      <Select
+                        value={form.pop_action}
+                        onValueChange={(v) =>
+                          setForm((f) => ({ ...f, pop_action: v }))
+                        }
+                      >
+                        <SelectTrigger
+                          id="cr-pop-action"
+                          aria-label="Flagged action"
+                        >
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {(["flag", "block"] as const).map((a) => (
+                            <SelectItem
+                              key={a}
+                              value={a}
+                              className="capitalize"
+                            >
+                              {a}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+
+                  <div className="flex items-center justify-between rounded-md border p-3">
+                    <Label htmlFor="cr-pop-typo">Typo-squat check</Label>
+                    <Switch
+                      id="cr-pop-typo"
+                      checked={form.typosquat_check}
+                      onCheckedChange={(v) =>
+                        setForm((f) => ({ ...f, typosquat_check: v }))
+                      }
+                    />
+                  </div>
+
+                  {form.typosquat_check && (
+                    <div className="space-y-4 border-l-2 pl-3">
+                      <div className="space-y-1.5">
+                        <Label htmlFor="cr-pop-distance">
+                          Max edit distance (1–2)
+                        </Label>
+                        <Input
+                          id="cr-pop-distance"
+                          type="number"
+                          min={1}
+                          max={2}
+                          value={form.max_distance}
+                          onChange={(e) =>
+                            setForm((f) => ({
+                              ...f,
+                              max_distance: clampDistance(
+                                numField(e.target.value),
+                              ),
+                            }))
+                          }
+                        />
+                      </div>
+                      <div className="flex items-center justify-between rounded-md border p-3">
+                        <Label htmlFor="cr-pop-homoglyph">
+                          Homoglyph check
+                        </Label>
+                        <Switch
+                          id="cr-pop-homoglyph"
+                          checked={form.homoglyph_check}
+                          onCheckedChange={(v) =>
+                            setForm((f) => ({ ...f, homoglyph_check: v }))
+                          }
+                        />
+                      </div>
+                      <div className="flex items-center justify-between rounded-md border p-3">
+                        <Label htmlFor="cr-pop-affix">Affix check</Label>
+                        <Switch
+                          id="cr-pop-affix"
+                          checked={form.affix_check}
+                          onCheckedChange={(v) =>
+                            setForm((f) => ({ ...f, affix_check: v }))
+                          }
+                        />
+                      </div>
+                      {form.affix_check && (
+                        <div className="space-y-1.5">
+                          <Label htmlFor="cr-pop-affix-max">
+                            Affix max downloads
+                          </Label>
+                          <Input
+                            id="cr-pop-affix-max"
+                            type="number"
+                            min={0}
+                            value={form.affix_max_downloads ?? ""}
+                            onChange={(e) =>
+                              setForm((f) => ({
+                                ...f,
+                                affix_max_downloads: numField(e.target.value),
+                              }))
+                            }
+                          />
+                        </div>
+                      )}
+                    </div>
+                  )}
+
+                  <div className="space-y-1.5">
+                    <Label htmlFor="cr-pop-packages">
+                      Popular packages (optional; one per line or comma-separated)
+                    </Label>
+                    <Textarea
+                      id="cr-pop-packages"
+                      value={form.popular_packages}
+                      onChange={(e) =>
+                        setForm((f) => ({
+                          ...f,
+                          popular_packages: e.target.value,
+                        }))
+                      }
+                      placeholder={"react\nlodash\nexpress"}
+                      rows={2}
+                    />
+                  </div>
+                </div>
+              )}
+
+              {/* Common: reason + enabled */}
+              <div className="space-y-1.5">
+                <Label htmlFor="cr-reason">Reason</Label>
+                <Input
+                  id="cr-reason"
+                  value={form.reason}
+                  onChange={(e) =>
+                    setForm((f) => ({ ...f, reason: e.target.value }))
+                  }
+                  placeholder="Why this rule exists (recorded on matches)"
+                />
+              </div>
+              <div className="flex items-center justify-between rounded-md border p-3">
+                <Label htmlFor="cr-enabled">Enabled</Label>
+                <Switch
+                  id="cr-enabled"
+                  checked={form.enabled}
+                  onCheckedChange={(v) =>
+                    setForm((f) => ({ ...f, enabled: v }))
+                  }
+                />
+              </div>
+            </div>
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => setDialogOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={!canSave}>
+                {saveMutation.isPending ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : null}
+                {editing ? "Save" : "Create"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        onOpenChange={(o) => !o && setDeleteTarget(null)}
+        title="Delete curation rule?"
+        description={`This ${
+          deleteTarget?.rule_type ?? ""
+        } rule will be permanently deleted. The curation queue stops applying it.`}
+        confirmText="Delete"
+        danger
+        loading={deleteMutation.isPending}
+        onConfirm={() => deleteTarget && deleteMutation.mutate(deleteTarget.id)}
+      />
+    </div>
+  );
+}
+
+export default CurationRulesManager;

--- a/src/app/(app)/(admin)/curation/page.tsx
+++ b/src/app/(app)/(admin)/curation/page.tsx
@@ -37,6 +37,13 @@ import {
   DialogDescription,
   DialogFooter,
 } from "@/components/ui/dialog";
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+} from "@/components/ui/tabs";
+import { CurationRulesManager } from "./_components/curation-rules-manager";
 
 const STATUSES = ["pending", "approved", "blocked"] as const;
 
@@ -148,11 +155,19 @@ export default function CurationPage() {
         <div>
           <h1 className="text-xl font-semibold">Package Curation</h1>
           <p className="text-sm text-muted-foreground">
-            Review and approve or block packages staged from upstream repositories.
+            Review packages staged from upstream repositories and author the
+            rules that gate them.
           </p>
         </div>
       </div>
 
+      <Tabs defaultValue="queue" className="space-y-6">
+        <TabsList>
+          <TabsTrigger value="queue">Review Queue</TabsTrigger>
+          <TabsTrigger value="rules">Rules</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="queue" className="space-y-6">
       <div className="flex flex-wrap items-center gap-3">
         <Select value={repoId} onValueChange={(v) => { setRepoId(v); setSelected(new Set()); }}>
           <SelectTrigger className="w-64" aria-label="Staging repository">
@@ -327,6 +342,12 @@ export default function CurationPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+        </TabsContent>
+
+        <TabsContent value="rules">
+          <CurationRulesManager />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/src/lib/api/__tests__/curation-rules.test.ts
+++ b/src/lib/api/__tests__/curation-rules.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/sdk-client", () => ({}));
+
+const mockApiFetch = vi.fn();
+
+vi.mock("@/lib/api/fetch", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api/fetch")>(
+    "@/lib/api/fetch",
+  );
+  return {
+    ...actual,
+    apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+  };
+});
+
+describe("curationRulesApi", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("parses an array list response and defaults missing fields", async () => {
+    mockApiFetch.mockResolvedValue([
+      {
+        id: "1",
+        rule_type: "pattern",
+        action: "block",
+        scope: "repository",
+        package_pattern: "left-*",
+        priority: 50,
+      },
+      // sparse row: defaults kick in
+      { id: "2", action: "flag" },
+    ]);
+    const mod = await import("../curation-rules");
+    const rows = await mod.curationRulesApi.list();
+    expect(mockApiFetch).toHaveBeenCalledWith("/api/v1/curation/rules", {
+      method: "GET",
+    });
+    expect(rows).toHaveLength(2);
+    expect(rows[0].package_pattern).toBe("left-*");
+    // sparse defaults
+    expect(rows[1].rule_type).toBe("pattern");
+    expect(rows[1].scope).toBe("repository");
+    expect(rows[1].package_pattern).toBe("*");
+    expect(rows[1].version_constraint).toBe("*");
+    expect(rows[1].architecture).toBe("*");
+    expect(rows[1].priority).toBe(100);
+    expect(rows[1].enabled).toBe(true);
+  });
+
+  it("parses an object-wrapped list response", async () => {
+    mockApiFetch.mockResolvedValue({
+      rules: [{ id: "9", rule_type: "popularity", action: "flag" }],
+    });
+    const mod = await import("../curation-rules");
+    const rows = await mod.curationRulesApi.list();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].rule_type).toBe("popularity");
+  });
+
+  it("narrows an unknown rule_type / scope to safe fallbacks", async () => {
+    mockApiFetch.mockResolvedValue([
+      { id: "1", rule_type: "quantum", scope: "galaxy", action: "flag" },
+    ]);
+    const mod = await import("../curation-rules");
+    const rows = await mod.curationRulesApi.list();
+    expect(rows[0].rule_type).toBe("pattern");
+    expect(rows[0].scope).toBe("repository");
+  });
+
+  it("keeps engine config on the row", async () => {
+    mockApiFetch.mockResolvedValue([
+      {
+        id: "1",
+        rule_type: "publisher_trust",
+        action: "block",
+        config: {
+          trusted_publishers: ["github.com/acme"],
+          match: "attestation",
+          action: "block",
+        },
+      },
+    ]);
+    const mod = await import("../curation-rules");
+    const rows = await mod.curationRulesApi.list();
+    expect(rows[0].config.trusted_publishers).toEqual(["github.com/acme"]);
+  });
+
+  it("throws on a malformed list response", async () => {
+    mockApiFetch.mockResolvedValue({ nope: true });
+    const mod = await import("../curation-rules");
+    await expect(mod.curationRulesApi.list()).rejects.toThrow(
+      /did not match the expected shape/i,
+    );
+  });
+
+  it("POSTs the create body and parses the echoed row", async () => {
+    mockApiFetch.mockResolvedValue({
+      id: "new",
+      rule_type: "popularity",
+      action: "flag",
+      scope: "global",
+    });
+    const mod = await import("../curation-rules");
+    const created = await mod.curationRulesApi.create({
+      rule_type: "popularity",
+      action: "flag",
+      scope: "global",
+      config: { typosquat_check: true },
+    });
+    expect(created.id).toBe("new");
+    const [path, init] = mockApiFetch.mock.calls[0];
+    expect(path).toBe("/api/v1/curation/rules");
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body);
+    expect(body.rule_type).toBe("popularity");
+    expect(body.config.typosquat_check).toBe(true);
+  });
+
+  it("PUTs the update body to the id-scoped path", async () => {
+    mockApiFetch.mockResolvedValue({ id: "r1", action: "block" });
+    const mod = await import("../curation-rules");
+    await mod.curationRulesApi.update("r1", { action: "block" });
+    const [path, init] = mockApiFetch.mock.calls[0];
+    expect(path).toBe("/api/v1/curation/rules/r1");
+    expect(init.method).toBe("PUT");
+    expect(JSON.parse(init.body).action).toBe("block");
+  });
+
+  it("url-encodes the id on delete", async () => {
+    mockApiFetch.mockResolvedValue(undefined);
+    const mod = await import("../curation-rules");
+    await mod.curationRulesApi.remove("a/b id");
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      "/api/v1/curation/rules/a%2Fb%20id",
+      { method: "DELETE" },
+    );
+  });
+
+  describe("parseList", () => {
+    it("splits on commas and newlines, trims, and de-dupes", async () => {
+      const { parseList } = await import("../curation-rules");
+      expect(parseList("react, lodash\nreact\n  express  ")).toEqual([
+        "react",
+        "lodash",
+        "express",
+      ]);
+      expect(parseList("   ")).toEqual([]);
+    });
+  });
+
+  describe("clampDistance", () => {
+    it("clamps to the 1–2 range and defaults undefined to 2", async () => {
+      const { clampDistance } = await import("../curation-rules");
+      expect(clampDistance(undefined)).toBe(2);
+      expect(clampDistance(0)).toBe(1);
+      expect(clampDistance(1)).toBe(1);
+      expect(clampDistance(2)).toBe(2);
+      expect(clampDistance(9)).toBe(2);
+      expect(clampDistance(Number.NaN)).toBe(2);
+    });
+  });
+});

--- a/src/lib/api/curation-rules.ts
+++ b/src/lib/api/curation-rules.ts
@@ -1,0 +1,287 @@
+import { z } from "zod";
+import { apiFetch } from "@/lib/api/fetch";
+import { narrowEnum } from "@/lib/api/fetch";
+
+/**
+ * Admin client for curation **rules** (v1.7.0, backend admin-guarded router).
+ *
+ * Where the curation *queue* (`@/lib/api/curation`) approves or blocks
+ * individual packages after the fact, curation *rules* are the standing policy
+ * the queue is evaluated against: pattern matches, publisher-trust gates, and
+ * popularity / typo-squat heuristics. 1.7.0 added two new engine types
+ * (`publisher_trust`, `popularity`) that a customer evaluation asked for and
+ * that had no UI to author them.
+ *
+ * The rules endpoints are NOT in the generated SDK (a separate change is
+ * bumping the SDK), so this module deliberately talks to the REST surface
+ * through the shared `apiFetch` wrapper and validates responses with zod at the
+ * trust boundary — the same pattern as `rate-limits`, `downloads`, and `audit`.
+ * Keeping it SDK-free is intentional so it can't collide with the SDK bump.
+ *
+ * Endpoints (all under the admin-guarded curation router):
+ *   GET    /api/v1/curation/rules        -> CurationRule[]
+ *   POST   /api/v1/curation/rules        -> CurationRule
+ *   GET    /api/v1/curation/rules/{id}   -> CurationRule
+ *   PUT    /api/v1/curation/rules/{id}   -> CurationRule
+ *   DELETE /api/v1/curation/rules/{id}
+ */
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+/** Which matching engine the rule drives. */
+export type RuleType = "pattern" | "publisher_trust" | "popularity";
+export const RULE_TYPES: readonly RuleType[] = [
+  "pattern",
+  "publisher_trust",
+  "popularity",
+] as const;
+const RULE_TYPE_SET = new Set<RuleType>(RULE_TYPES);
+
+/** Whether the rule applies to one staging repo or every repo. */
+export type RuleScope = "repository" | "global";
+export const RULE_SCOPES: readonly RuleScope[] = ["repository", "global"] as const;
+const RULE_SCOPE_SET = new Set<RuleScope>(RULE_SCOPES);
+
+/**
+ * Top-level rule action (the decision applied when the rule matches). Different
+ * engines support different subsets, but the backend models one string column,
+ * so the web keeps a single union and lets each sub-form present the relevant
+ * options.
+ */
+export type RuleAction = "allow" | "block" | "flag" | "audit";
+export const RULE_ACTIONS: readonly RuleAction[] = [
+  "allow",
+  "block",
+  "flag",
+  "audit",
+] as const;
+
+/** publisher_trust `match` strategy. */
+export type PublisherMatch = "attestation" | "signature" | "namespace";
+export const PUBLISHER_MATCHES: readonly PublisherMatch[] = [
+  "attestation",
+  "signature",
+  "namespace",
+] as const;
+
+// ---------------------------------------------------------------------------
+// Config shapes (engine-specific `config` JSON)
+// ---------------------------------------------------------------------------
+
+/** `publisher_trust` engine config. */
+export interface PublisherTrustConfig {
+  /** Publishers whose artifacts are trusted (required, non-empty). */
+  trusted_publishers: string[];
+  /** How trust is proven; backend default `attestation`. */
+  match: string;
+  /** Decision for artifacts from an untrusted publisher. */
+  action: "flag" | "block" | "allow" | "audit";
+}
+
+/** `popularity` engine config (typo-squat / low-reputation heuristics). */
+export interface PopularityConfig {
+  /** Minimum download count for a package to be considered established. */
+  min_downloads?: number;
+  /** Max edit distance to a popular package that still counts as a squat (1–2). */
+  max_distance?: number;
+  /** Enable the typo-squat distance check. */
+  typosquat_check?: boolean;
+  /** Enable the homoglyph (look-alike character) check. */
+  homoglyph_check?: boolean;
+  /** Enable the affix (prefix/suffix padding) check. */
+  affix_check?: boolean;
+  /** Affix check ignores packages above this download count; backend default 1000. */
+  affix_max_downloads?: number;
+  /** Decision for a package flagged by any enabled heuristic. */
+  action?: "flag" | "block";
+  /** Optional explicit list of popular packages to compare against. */
+  popular_packages?: string[];
+}
+
+export type RuleConfig =
+  | PublisherTrustConfig
+  | PopularityConfig
+  | Record<string, unknown>;
+
+// ---------------------------------------------------------------------------
+// Rule + request types
+// ---------------------------------------------------------------------------
+
+/** A stored curation rule. */
+export interface CurationRule {
+  id: string;
+  /** Repo the rule is scoped to; null / undefined for global rules. */
+  staging_repo_id?: string | null;
+  /** Glob over package names (default `*`). */
+  package_pattern: string;
+  /** Version constraint / glob (default `*`). */
+  version_constraint: string;
+  /** Architecture glob (default `*`). */
+  architecture: string;
+  action: string;
+  /** Lower runs first; backend default 100. */
+  priority: number;
+  reason?: string | null;
+  rule_type: RuleType;
+  config: Record<string, unknown>;
+  scope: RuleScope;
+  /** Whether the rule is active. Absent responses are treated as enabled. */
+  enabled: boolean;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+/** Create body. Mirrors the backend `CreateRuleRequest`. */
+export interface CreateRuleRequest {
+  staging_repo_id?: string | null;
+  package_pattern?: string;
+  version_constraint?: string;
+  architecture?: string;
+  action: string;
+  priority?: number;
+  reason?: string;
+  rule_type?: RuleType;
+  config?: Record<string, unknown>;
+  scope?: RuleScope;
+  enabled?: boolean;
+}
+
+/** Update body — same shape; the backend PUT replaces the rule. */
+export type UpdateRuleRequest = Partial<CreateRuleRequest>;
+
+// ---------------------------------------------------------------------------
+// Response validation (trust boundary)
+// ---------------------------------------------------------------------------
+
+const RuleSchema = z
+  .object({
+    id: z.string(),
+    staging_repo_id: z.string().nullish(),
+    package_pattern: z.string().nullish(),
+    version_constraint: z.string().nullish(),
+    architecture: z.string().nullish(),
+    action: z.string().nullish(),
+    priority: z.number().nullish(),
+    reason: z.string().nullish(),
+    rule_type: z.string().nullish(),
+    config: z.record(z.string(), z.unknown()).nullish(),
+    scope: z.string().nullish(),
+    enabled: z.boolean().nullish(),
+    created_at: z.string().nullish(),
+    updated_at: z.string().nullish(),
+  })
+  .passthrough();
+
+const RuleListSchema = z.union([
+  z.array(RuleSchema),
+  z.object({ rules: z.array(RuleSchema) }).passthrough(),
+]);
+
+type RawRule = z.infer<typeof RuleSchema>;
+
+function adaptRule(r: RawRule): CurationRule {
+  return {
+    id: r.id,
+    staging_repo_id: r.staging_repo_id ?? null,
+    package_pattern: r.package_pattern ?? "*",
+    version_constraint: r.version_constraint ?? "*",
+    architecture: r.architecture ?? "*",
+    action: r.action ?? "flag",
+    priority: r.priority ?? 100,
+    reason: r.reason ?? null,
+    rule_type: narrowEnum(r.rule_type ?? "pattern", RULE_TYPE_SET, "pattern"),
+    config: r.config ?? {},
+    scope: narrowEnum(r.scope ?? "repository", RULE_SCOPE_SET, "repository"),
+    // A rule with no explicit `enabled` flag is treated as active.
+    enabled: r.enabled ?? true,
+    created_at: r.created_at ?? null,
+    updated_at: r.updated_at ?? null,
+  };
+}
+
+export function parseRule(data: unknown): CurationRule {
+  const parsed = RuleSchema.safeParse(data);
+  if (!parsed.success) {
+    throw new Error("Curation rule response did not match the expected shape");
+  }
+  return adaptRule(parsed.data);
+}
+
+export function parseRuleList(data: unknown): CurationRule[] {
+  const parsed = RuleListSchema.safeParse(data);
+  if (!parsed.success) {
+    throw new Error("Curation rules response did not match the expected shape");
+  }
+  const rows = Array.isArray(parsed.data) ? parsed.data : parsed.data.rules;
+  return rows.map(adaptRule);
+}
+
+// ---------------------------------------------------------------------------
+// Config builders (pure — used by the dialog sub-forms and unit-tested)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a free-form textarea of publishers / packages (comma- or
+ * newline-separated) into a trimmed, de-duplicated, non-empty list.
+ */
+export function parseList(input: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of input.split(/[\n,]/)) {
+    const v = raw.trim();
+    if (v && !seen.has(v)) {
+      seen.add(v);
+      out.push(v);
+    }
+  }
+  return out;
+}
+
+/** Clamp the popularity edit-distance to the backend-supported 1–2 range. */
+export function clampDistance(n: number | undefined): number {
+  if (n == null || Number.isNaN(n)) return 2;
+  return Math.min(2, Math.max(1, Math.trunc(n)));
+}
+
+export const curationRulesApi = {
+  list: async (): Promise<CurationRule[]> => {
+    const data = await apiFetch<unknown>("/api/v1/curation/rules", {
+      method: "GET",
+    });
+    return parseRuleList(data);
+  },
+
+  get: async (id: string): Promise<CurationRule> => {
+    const data = await apiFetch<unknown>(
+      `/api/v1/curation/rules/${encodeURIComponent(id)}`,
+      { method: "GET" }
+    );
+    return parseRule(data);
+  },
+
+  create: async (req: CreateRuleRequest): Promise<CurationRule> => {
+    const data = await apiFetch<unknown>("/api/v1/curation/rules", {
+      method: "POST",
+      body: JSON.stringify(req),
+    });
+    return parseRule(data);
+  },
+
+  update: async (id: string, req: UpdateRuleRequest): Promise<CurationRule> => {
+    const data = await apiFetch<unknown>(
+      `/api/v1/curation/rules/${encodeURIComponent(id)}`,
+      { method: "PUT", body: JSON.stringify(req) }
+    );
+    return parseRule(data);
+  },
+
+  remove: async (id: string): Promise<void> => {
+    await apiFetch<void>(`/api/v1/curation/rules/${encodeURIComponent(id)}`, {
+      method: "DELETE",
+    });
+  },
+};
+
+export default curationRulesApi;

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -23,6 +23,17 @@ export { default as pypiTracksApi } from './pypi-tracks';
 export type { PypiTrack } from './pypi-tracks';
 export { default as curationApi } from './curation';
 export type { CurationPackage, ListCurationParams } from './curation';
+export { default as curationRulesApi } from './curation-rules';
+export type {
+  CurationRule,
+  CreateRuleRequest,
+  UpdateRuleRequest,
+  RuleType,
+  RuleScope,
+  RuleAction,
+  PublisherTrustConfig,
+  PopularityConfig,
+} from './curation-rules';
 export { default as signingApi } from './signing';
 export type { SigningKey, SigningConfig, CreateSigningKeyRequest } from './signing';
 export { default as syncPoliciesApi } from './sync-policies';


### PR DESCRIPTION
Closes #682

## Summary

The curation page (`/curation`) managed only the package review **queue**. The new
1.7.0 curation rule engines — `publisher_trust` and `popularity` (download-count /
typo-squat) — were exposed by the backend but had **no UI**, so a customer
evaluation's two key asks (publisher-trust filtering and popularity/typo-squat
filtering) were unreachable. This adds a **Rules** tab alongside the existing queue.

- **`curationRulesApi`** (`src/lib/api/curation-rules.ts`): an `apiFetch` + `zod`
  client for `GET|POST /api/v1/curation/rules` and `GET|PUT|DELETE /rules/{id}`.
  Deliberately **SDK-free** — it validates responses at the trust boundary (same
  pattern as `rate-limits` / `downloads`) so it is independent of the in-flight SDK
  bump and cannot collide with it.
- **Rules tab** on the curation page: a table (type / pattern / scope / action /
  priority / enabled) with create / edit / delete. The existing package queue is
  untouched, now under a **Review Queue** tab.
- **Create/edit dialog**: common fields (pattern, version, arch, scope, action,
  priority, reason, enabled) plus a **config sub-form that switches on `rule_type`**:
  - `pattern` — package / version / architecture globs;
  - `publisher_trust` — trusted-publisher list + `match` + `action`;
  - `popularity` — `min_downloads` + a typo-squat toggle that reveals
    `homoglyph_check` / `affix_check` / `max_distance` / `affix_max_downloads` + `action`.

## Validation

- `npm test` (vitest) — **159 files / 2949 tests pass**, including the new api-lib and
  component suites and the untouched Review Queue tests.
- `npx tsc --noEmit` — clean on all touched files (pre-existing errors in unrelated
  `audit` / `blast-radius` / `docker-grouping` test files are unchanged by this PR).
- `eslint` — clean on all touched files.

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [x] Accessibility checked (labels/roles on every field; native-select-friendly)
- [ ] Playwright E2E spec covers the change
- [x] Responsive layout verified (mobile + desktop)
- [x] Dark mode verified (uses themed shadcn/ui primitives only)