### PR TITLE
fix(query): param-scope repositories-list cache keys (#668)

### DIFF
--- a/src/app/(app)/(protected)/replication/page.tsx
+++ b/src/app/(app)/(protected)/replication/page.tsx
@@ -16,6 +16,7 @@ import type { PeerInstance, PeerConnection } from "@/lib/api/replication";
 import { mutationErrorToast } from "@/lib/error-utils";
 import { formatBytes } from "@/lib/utils";
 import { repositoriesApi } from "@/lib/api/repositories";
+import { QUERY_KEYS } from "@/lib/query-keys";
 import type { Repository } from "@/types";
 
 import { Button } from "@/components/ui/button";
@@ -98,9 +99,11 @@ export default function ReplicationPage() {
   const totalCacheUsed = peers.reduce((a, p) => a + p.cache_used_bytes, 0);
   const totalCacheSize = peers.reduce((a, p) => a + p.cache_size_bytes, 0);
 
-  // Subscriptions tab queries
+  // Subscriptions tab queries. The key is param-scoped so pages requesting a
+  // different page size don't collide on a shared cache entry (#668); prefix
+  // invalidation on ["repositories-list"] still matches.
   const { data: reposData } = useQuery({
-    queryKey: ["repositories-list"],
+    queryKey: [...QUERY_KEYS.REPOSITORIES_LIST, { per_page: 200 }],
     queryFn: () => repositoriesApi.list({ per_page: 200 }),
   });
   const repositories = reposData?.items ?? [];

--- a/src/app/(app)/search/_components/search-content.tsx
+++ b/src/app/(app)/search/_components/search-content.tsx
@@ -44,6 +44,7 @@ import {
 import { searchApi, type SearchResult } from "@/lib/api/search";
 import { artifactsApi } from "@/lib/api/artifacts";
 import { repositoriesApi } from "@/lib/api/repositories";
+import { QUERY_KEYS } from "@/lib/query-keys";
 import { buildMavenSearchQuery } from "@/lib/maven";
 import { QuarantineBadge } from "@/components/common/quarantine-badge";
 import { formatBytes as formatBytesUtil, formatDate } from "@/lib/utils";
@@ -190,9 +191,11 @@ export function SearchContent() {
   const [searchTriggered, setSearchTriggered] = useState(false);
   const [searchKey, setSearchKey] = useState(0);
 
-  // Fetch repositories for select dropdown
+  // Fetch repositories for select dropdown. The key is param-scoped so pages
+  // requesting a different page size don't collide on a shared cache entry
+  // (#668); prefix invalidation on ["repositories-list"] still matches.
   const { data: reposData } = useQuery({
-    queryKey: ["repositories-list"],
+    queryKey: [...QUERY_KEYS.REPOSITORIES_LIST, { per_page: 100 }],
     queryFn: () => repositoriesApi.list({ per_page: 100 }),
   });
 


### PR DESCRIPTION
## Summary

Search (`search-content.tsx`) cached `repositoriesApi.list({ per_page: 100 })` and Replication (`replication/page.tsx`) cached `per_page: 200` under the **same** `["repositories-list"]` TanStack Query key. Whichever page mounted first won the cache; the other silently received the wrong page size — e.g. visiting Search first left Replication with 100 repos instead of 200.

Fix: scope both keys by their params (`[...QUERY_KEYS.REPOSITORIES_LIST, { per_page: N }]`). Prefix-based invalidation on `["repositories-list"]` (invalidation groups in `query-keys.ts`, SSE event handler) still matches both entries, so real-time cache invalidation is unaffected.

Found during a full frontend audit; the broader consolidation of the 5+ repository-list key variants into shared hooks is tracked in #669.

Fixes #668

## Test Checklist
- [x] Unit tests added/updated — existing `search-content.test.tsx` (48 tests) and `query-keys.test.ts` pass unchanged (the test mock resolves by `queryKey[0]`, so param-scoped keys stay compatible)
- [ ] E2E Playwright tests added/updated — N/A, cache-key-only change
- [x] Manually tested locally — vitest run + eslint clean; tsc shows no new errors in changed files (23 pre-existing errors in unrelated test files)
- [x] No regressions in existing tests

## UI Changes
- [x] N/A - no UI changes