### PR TITLE
fix(lists): surface silent per_page truncation on admin list pages (#670)

### DIFF
--- a/src/app/(app)/(admin)/backups/page.tsx
+++ b/src/app/(app)/(admin)/backups/page.tsx
@@ -64,6 +64,7 @@ import { StatCard } from "@/components/common/stat-card";
 import { StatusBadge } from "@/components/common/status-badge";
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
 import { EmptyState } from "@/components/common/empty-state";
+import { ListTruncationNotice } from "@/components/common/list-truncation-notice";
 
 // -- types --
 
@@ -551,6 +552,7 @@ export default function BackupsPage() {
           rowKey={(b) => b.id}
         />
       )}
+      <ListTruncationNotice shown={backups.length} total={data?.total ?? 0} />
 
       {/* Create Backup Dialog */}
       <Dialog

--- a/src/app/(app)/(admin)/curation/page.tsx
+++ b/src/app/(app)/(admin)/curation/page.tsx
@@ -44,6 +44,7 @@ import {
   TabsContent,
 } from "@/components/ui/tabs";
 import { CurationRulesManager } from "./_components/curation-rules-manager";
+import { ListTruncationNotice } from "@/components/common/list-truncation-notice";
 
 const STATUSES = ["pending", "approved", "blocked"] as const;
 
@@ -218,6 +219,11 @@ export default function CurationPage() {
           </div>
         )}
       </div>
+
+      <ListTruncationNotice
+        shown={repos?.items.length ?? 0}
+        total={repos?.pagination?.total ?? 0}
+      />
 
       {!repoId && (
         <div className="rounded-md border border-dashed py-12 text-center text-sm text-muted-foreground">

--- a/src/app/(app)/(admin)/groups/page.tsx
+++ b/src/app/(app)/(admin)/groups/page.tsx
@@ -53,6 +53,7 @@ import { PageHeader } from "@/components/common/page-header";
 import { DataTable, type DataTableColumn } from "@/components/common/data-table";
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
 import { EmptyState } from "@/components/common/empty-state";
+import { ListTruncationNotice } from "@/components/common/list-truncation-notice";
 
 // -- types --
 
@@ -340,6 +341,10 @@ export default function GroupsPage() {
           rowKey={(g) => g.id}
         />
       )}
+      <ListTruncationNotice
+        shown={groups.length}
+        total={groupsData?.pagination?.total ?? 0}
+      />
 
       {/* Create Group Dialog */}
       <Dialog

--- a/src/app/(app)/(admin)/migration/page.tsx
+++ b/src/app/(app)/(admin)/migration/page.tsx
@@ -92,6 +92,7 @@ import { DataTable, type DataTableColumn } from "@/components/common/data-table"
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
 import { StatusBadge } from "@/components/common/status-badge";
 import { EmptyState } from "@/components/common/empty-state";
+import { ListTruncationNotice } from "@/components/common/list-truncation-notice";
 
 // -- helpers --
 
@@ -998,6 +999,10 @@ export default function MigrationPage() {
               emptyMessage="No migration jobs found."
             />
           )}
+          <ListTruncationNotice
+            shown={migrations.length}
+            total={migrationsData?.pagination?.total ?? 0}
+          />
         </TabsContent>
       </Tabs>
 
@@ -1626,6 +1631,10 @@ export default function MigrationPage() {
                 loading={!detailItems}
                 rowKey={(i) => i.id}
                 emptyMessage="No items."
+              />
+              <ListTruncationNotice
+                shown={detailItems?.items.length ?? 0}
+                total={detailItems?.pagination?.total ?? 0}
               />
             </div>
           )}

--- a/src/app/(app)/(admin)/permissions/page.tsx
+++ b/src/app/(app)/(admin)/permissions/page.tsx
@@ -51,6 +51,7 @@ import { PageHeader } from "@/components/common/page-header";
 import { DataTable, type DataTableColumn } from "@/components/common/data-table";
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
 import { EmptyState } from "@/components/common/empty-state";
+import { ListTruncationNotice } from "@/components/common/list-truncation-notice";
 
 // -- constants --
 
@@ -515,6 +516,10 @@ export default function PermissionsPage() {
           rowKey={(p) => p.id}
         />
       )}
+      <ListTruncationNotice
+        shown={permissions.length}
+        total={permissionsData?.pagination?.total ?? 0}
+      />
 
       {/* Create Permission Dialog */}
       <Dialog

--- a/src/app/(app)/(admin)/security/page.tsx
+++ b/src/app/(app)/(admin)/security/page.tsx
@@ -59,6 +59,7 @@ import {
 import { PageHeader } from "@/components/common/page-header";
 import { StatCard } from "@/components/common/stat-card";
 import { DataTable, type DataTableColumn } from "@/components/common/data-table";
+import { ListTruncationNotice } from "@/components/common/list-truncation-notice";
 
 // -- grade badge --
 
@@ -822,6 +823,10 @@ export default function SecurityDashboardPage() {
                       )}
                   </SelectContent>
                 </Select>
+                <ListTruncationNotice
+                  shown={artifactsList?.items.length ?? 0}
+                  total={artifactsList?.pagination?.total ?? 0}
+                />
               </div>
             )}
           </div>

--- a/src/app/(app)/(admin)/security/scans/page.tsx
+++ b/src/app/(app)/(admin)/security/scans/page.tsx
@@ -39,6 +39,7 @@ import {
 
 import { PageHeader } from "@/components/common/page-header";
 import { DataTable, type DataTableColumn } from "@/components/common/data-table";
+import { ListTruncationNotice } from "@/components/common/list-truncation-notice";
 
 // -- status & severity color maps --
 
@@ -511,6 +512,10 @@ export default function SecurityScansPage() {
                       )}
                   </SelectContent>
                 </Select>
+                <ListTruncationNotice
+                  shown={artifactsList?.items.length ?? 0}
+                  total={artifactsList?.pagination?.total ?? 0}
+                />
               </div>
             )}
           </div>

--- a/src/app/(app)/(admin)/telemetry/page.tsx
+++ b/src/app/(app)/(admin)/telemetry/page.tsx
@@ -20,6 +20,7 @@ import type { CrashReport, TelemetrySettings } from "@/types/telemetry";
 import { PageHeader } from "@/components/common/page-header";
 import { StatCard } from "@/components/common/stat-card";
 import { EmptyState } from "@/components/common/empty-state";
+import { ListTruncationNotice } from "@/components/common/list-truncation-notice";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -424,6 +425,11 @@ export default function TelemetryPage() {
               </TableBody>
             </Table>
           )}
+          <ListTruncationNotice
+            className="px-6 pb-4"
+            shown={crashItems.length}
+            total={crashes?.total ?? 0}
+          />
         </CardContent>
       </Card>
 

--- a/src/app/(app)/(protected)/peers/page.tsx
+++ b/src/app/(app)/(protected)/peers/page.tsx
@@ -52,6 +52,7 @@ import { DataTable, type DataTableColumn } from "@/components/common/data-table"
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
 import { StatusBadge } from "@/components/common/status-badge";
 import { EmptyState } from "@/components/common/empty-state";
+import { ListTruncationNotice } from "@/components/common/list-truncation-notice";
 
 // -- helpers --
 
@@ -412,6 +413,7 @@ export default function PeersPage() {
           emptyMessage="No peers found."
         />
       )}
+      <ListTruncationNotice shown={peers.length} total={data?.total ?? 0} />
 
       {/* -- Register Peer Dialog -- */}
       <Dialog

--- a/src/app/(app)/(protected)/replication/page.tsx
+++ b/src/app/(app)/(protected)/replication/page.tsx
@@ -50,6 +50,7 @@ import { PageHeader } from "@/components/common/page-header";
 import { DataTable, type DataTableColumn } from "@/components/common/data-table";
 import { StatusBadge } from "@/components/common/status-badge";
 import { EmptyState } from "@/components/common/empty-state";
+import { ListTruncationNotice } from "@/components/common/list-truncation-notice";
 
 // -- helpers --
 
@@ -484,6 +485,11 @@ export default function ReplicationPage() {
               })}
             </div>
           )}
+          <ListTruncationNotice
+            className="mt-4"
+            shown={peers.length}
+            total={data?.total ?? 0}
+          />
         </TabsContent>
 
         {/* -- Subscriptions Tab -- */}
@@ -525,6 +531,10 @@ export default function ReplicationPage() {
               emptyMessage="No repositories found."
             />
           )}
+          <ListTruncationNotice
+            shown={repositories.length}
+            total={reposData?.pagination?.total ?? 0}
+          />
         </TabsContent>
 
         {/* -- Topology Tab -- */}

--- a/src/app/(app)/(protected)/webhooks/page.tsx
+++ b/src/app/(app)/(protected)/webhooks/page.tsx
@@ -61,6 +61,7 @@ import { DataTable, type DataTableColumn } from "@/components/common/data-table"
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
 import { StatusBadge } from "@/components/common/status-badge";
 import { EmptyState } from "@/components/common/empty-state";
+import { ListTruncationNotice } from "@/components/common/list-truncation-notice";
 
 // -- constants --
 
@@ -444,6 +445,10 @@ export default function WebhooksPage() {
           emptyMessage="No webhooks found."
         />
       )}
+      <ListTruncationNotice
+        shown={webhooks.length}
+        total={data?.total ?? 0}
+      />
 
       {/* -- Create Webhook Dialog -- */}
       <Dialog

--- a/src/app/(app)/repositories/_components/virtual-members-panel.tsx
+++ b/src/app/(app)/repositories/_components/virtual-members-panel.tsx
@@ -22,6 +22,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
+import { ListTruncationNotice } from "@/components/common/list-truncation-notice";
 import {
   Tooltip,
   TooltipTrigger,
@@ -281,6 +282,11 @@ export function VirtualMembersPanel({ repository }: VirtualMembersPanelProps) {
                 ))}
               </div>
             )}
+            <ListTruncationNotice
+              className="mt-3"
+              shown={allReposData?.items.length ?? 0}
+              total={allReposData?.pagination?.total ?? 0}
+            />
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setAddDialogOpen(false)}>

--- a/src/components/common/__tests__/list-truncation-notice.test.tsx
+++ b/src/components/common/__tests__/list-truncation-notice.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { ListTruncationNotice } from "../list-truncation-notice";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ListTruncationNotice", () => {
+  it("renders nothing when the total fits within the shown items", () => {
+    const { container } = render(<ListTruncationNotice shown={25} total={25} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when fewer items exist than were fetched", () => {
+    const { container } = render(<ListTruncationNotice shown={25} total={10} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when the server reports no total", () => {
+    const { container } = render(<ListTruncationNotice shown={100} total={0} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the counts when the server reports more items than shown", () => {
+    render(<ListTruncationNotice shown={100} total={1024} />);
+    expect(
+      screen.getByText(/Showing first 100 of 1024/)
+    ).toBeInTheDocument();
+  });
+
+  it("exposes the notice as a polite live region", () => {
+    render(<ListTruncationNotice shown={100} total={101} />);
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Showing first 100 of 101"
+    );
+  });
+
+  it("advises narrowing the results", () => {
+    render(<ListTruncationNotice shown={100} total={101} />);
+    expect(
+      screen.getByText(/refine your search or filters/)
+    ).toBeInTheDocument();
+  });
+
+  it("merges a custom className", () => {
+    render(
+      <ListTruncationNotice shown={1} total={2} className="mt-4" />
+    );
+    expect(screen.getByRole("status")).toHaveClass("mt-4");
+  });
+});

--- a/src/components/common/list-truncation-notice.tsx
+++ b/src/components/common/list-truncation-notice.tsx
@@ -1,0 +1,28 @@
+import { cn } from "@/lib/utils";
+
+interface ListTruncationNoticeProps {
+  /** Number of items currently rendered. */
+  shown: number;
+  /** Total number of items reported by the server. */
+  total: number;
+  className?: string;
+}
+
+/**
+ * Surfaces silent truncation on lists that fetch a capped page
+ * (e.g. `per_page: 100`) without pagination. Renders nothing when the
+ * server-reported total fits within the fetched items.
+ */
+export function ListTruncationNotice({
+  shown,
+  total,
+  className,
+}: ListTruncationNoticeProps) {
+  if (total <= shown) return null;
+  return (
+    <p role="status" className={cn("text-sm text-muted-foreground", className)}>
+      Showing first {shown} of {total} — refine your search or filters to
+      narrow results.
+    </p>
+  );
+}


### PR DESCRIPTION
## Summary
Fixes #670.

Many admin list pages fetch a hardcoded `per_page` (100/200/1000) and render `data.items` with no indication that more items exist server-side — at scale these screens silently lie by omission.

This PR takes the issue's "at minimum" option (no pagination rewrites):

- Adds one shared component, `ListTruncationNotice` (`src/components/common/list-truncation-notice.tsx`), in the style of the existing `common/` primitives. It renders only when the server-reported `total` exceeds the number of fetched items: "Showing first N of M — refine your search or filters to narrow results." Uses `text-muted-foreground` design tokens and a `role="status"` polite live region.
- Wires it into every audited call site whose API response carries a total:
  - `webhooks/page.tsx` (`webhooksApi.list` → `total`)
  - `peers/page.tsx` (`peersApi.list` → `total`)
  - `replication/page.tsx` (peers overview + subscriptions repository table)
  - `groups/page.tsx` (`pagination.total`)
  - `permissions/page.tsx` (permissions table)
  - `curation/page.tsx` (staging-repository selector list)
  - `security/page.tsx` + `security/scans/page.tsx` (artifact selector in the trigger-scan dialog)
  - `repositories/_components/virtual-members-panel.tsx` (eligible-members list in the Add Member dialog)
  - Additional grep-found list pages with the same silent-cap pattern: `backups/page.tsx`, `migration/page.tsx` (jobs table + job-detail items), `telemetry/page.tsx` (crash reports)

Skipped call sites (no invented totals):

- `security/page.tsx:194` and `security/scans/page.tsx:136` — the repository list is fetched via the raw SDK and the query discards the pagination envelope (`(data as any)?.items ?? data ?? []`); it also only feeds a dialog picker (the #564 picker class).
- `permissions/page.tsx:113,119` — groups/repositories feed form dropdowns, not a rendered list (picker class, #564).
- `curation/page.tsx` package queue — `curationApi.listPackages` returns a plain array with no total.
- Repository-picklist fetches in `packages`, `search-content`, `setup`, `security/policies`, `lifecycle`, `promotion-rules`, `release-target-settings`, `lib/api/promotion.ts` — dropdown/select pickers, tracked under #564.

## Test Checklist
- [x] Unit tests added/updated (`src/components/common/__tests__/list-truncation-notice.test.tsx`: renders when truncated, renders nothing when total fits, live-region role, className merge)
- [ ] E2E Playwright tests added/updated
- [ ] Manually tested locally
- [x] No regressions in existing tests (vitest suites for curation, migration, security, webhooks, permissions, policies, lifecycle, release-target-settings all pass; eslint 0 errors on changed files; `tsc --noEmit` shows only the 23 pre-existing errors in unrelated test files)

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader) — notice is a `role="status"` polite live region
