### PR TITLE
fix(a11y): remove nested interactive elements from repository list rows (#672)

### DIFF
--- a/e2e/suites/interactions/repositories/repo-dialog-a11y.spec.ts
+++ b/e2e/suites/interactions/repositories/repo-dialog-a11y.spec.ts
@@ -94,18 +94,22 @@ test.describe.serial('Repository Dialog Accessibility', () => {
     await page.waitForTimeout(2000);
 
     // Target the REMOTE repo's actions trigger specifically: the upstream-auth
-    // section only exists on a remote repo's edit dialog. NOTE: the whole repo
-    // row is itself a <button> whose accessible name CONCATENATES the nested
-    // actions button label ("e2e-a11y-remote E2E A11y Remote npm · remote · 0 B
-    // Repository actions for E2E A11y Remote"), so a substring match would also
-    // hit the row card and `.first()` would pick it (clicking it just selects
-    // the repo, never opening the menu). Use an exact name to bind only to the
-    // actual DropdownMenu trigger (aria-label in repo-list-item.tsx).
+    // section only exists on a remote repo's edit dialog. The trigger carries
+    // an explicit aria-label in repo-list-item.tsx.
     const actionsBtn = page.getByRole('button', {
       name: 'Repository actions for E2E A11y Remote',
       exact: true,
     });
     await expect(actionsBtn).toBeVisible({ timeout: 10000 });
+
+    // #672: the row's primary action is a SIBLING of the actions trigger, not
+    // an ancestor wrapping it, so its accessible name must NOT concatenate the
+    // trigger's label. The anchored regex asserts the clean name (previously
+    // this ended in "... Repository actions for E2E A11y Remote").
+    const rowAction = page.getByRole('button', {
+      name: /^e2e-a11y-remote\s+E2E A11y Remote\s+npm\s*·\s*remote\s*·\s*0 B$/,
+    });
+    await expect(rowAction).toBeVisible();
 
     // Open the menu and choose Edit. Retry the whole open: a background list
     // refetch can re-render the row and dismiss the Radix dropdown before the

--- a/src/app/(app)/repositories/_components/repo-list-item.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-list-item.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import type { Repository } from "@/types";
+import { RepoListItem } from "./repo-list-item";
+
+const repo: Repository = {
+  id: "1",
+  key: "npm-proxy",
+  name: "NPM Proxy",
+  format: "npm",
+  repo_type: "remote",
+  storage_used_bytes: 0,
+  is_public: true,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+afterEach(cleanup);
+
+describe("RepoListItem", () => {
+  it("renders the row primary action and the actions trigger as siblings, not nested (#672)", () => {
+    render(
+      <RepoListItem
+        repo={repo}
+        isSelected={false}
+        onSelect={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+
+    const rowAction = screen.getByRole("button", { name: /npm-proxy/i });
+    // The dropdown trigger must NOT be a descendant of the row's primary
+    // action — nested interactives make the row's accessible name
+    // concatenate the trigger's label.
+    expect(
+      within(rowAction).queryByRole("button", { name: /repository actions/i })
+    ).not.toBeInTheDocument();
+
+    const actionsTrigger = screen.getByRole("button", {
+      name: "Repository actions for NPM Proxy",
+    });
+    expect(actionsTrigger).toBeInTheDocument();
+    // Siblings under a shared, non-interactive row container.
+    expect(rowAction.parentElement).toBe(actionsTrigger.parentElement);
+  });
+
+  it("gives the row primary action a clean accessible name without the actions label", () => {
+    render(<RepoListItem repo={repo} isSelected={false} onSelect={vi.fn()} onEdit={vi.fn()} />);
+
+    const rowAction = screen.getByRole("button", { name: /npm-proxy/i });
+    // Anchored: the name must end after the storage size — any concatenated
+    // "Repository actions ..." label fails this.
+    expect(rowAction).toHaveAccessibleName(/^npm-proxy\s*NPM Proxy\s*npm\s*·\s*remote\s*·\s*0 B$/);
+  });
+
+  it("activates onSelect on click and on keyboard Enter/Space", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(<RepoListItem repo={repo} isSelected={false} onSelect={onSelect} />);
+
+    const rowAction = screen.getByRole("button", { name: /npm-proxy/i });
+    await user.click(rowAction);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(repo);
+
+    rowAction.focus();
+    await user.keyboard("{Enter}");
+    await user.keyboard(" ");
+    expect(onSelect).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not trigger onSelect when the actions menu is used", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    const onEdit = vi.fn();
+    render(
+      <RepoListItem repo={repo} isSelected={false} onSelect={onSelect} onEdit={onEdit} />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Repository actions for NPM Proxy" }));
+    await user.click(await screen.findByRole("menuitem", { name: /edit/i }));
+
+    expect(onEdit).toHaveBeenCalledTimes(1);
+    expect(onEdit).toHaveBeenCalledWith(repo);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("omits the actions menu when no edit/delete handlers are provided", () => {
+    render(<RepoListItem repo={repo} isSelected={false} onSelect={vi.fn()} />);
+    expect(
+      screen.queryByRole("button", { name: /repository actions/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/app/(app)/repositories/_components/repo-list-item.tsx
+++ b/src/app/(app)/repositories/_components/repo-list-item.tsx
@@ -21,19 +21,23 @@ interface RepoListItemProps {
 }
 
 export function RepoListItem({ repo, isSelected, onSelect, onEdit, onDelete, artifactMatchCount }: RepoListItemProps) {
+  // #672: the row's primary action is a real <button> that is a SIBLING of the
+  // actions dropdown trigger — never an ancestor — so no interactive element
+  // nests inside another and the row's accessible name stays clean (it no
+  // longer concatenates the "Repository actions" label).
   return (
     <div
-      role="button"
-      tabIndex={0}
-      onClick={() => onSelect(repo)}
-      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onSelect(repo); }}
       className={cn(
-        "group w-full text-left px-3 py-2.5 border-l-2 border-transparent hover:bg-accent/50 transition-colors cursor-pointer",
+        "group flex items-start w-full border-l-2 border-transparent hover:bg-accent/50 transition-colors",
         isSelected && "bg-accent border-l-primary"
       )}
     >
-      <div className="flex items-start justify-between gap-2">
-        <div className="flex items-start gap-2 min-w-0 flex-1">
+      <button
+        type="button"
+        onClick={() => onSelect(repo)}
+        className="flex-1 min-w-0 text-left px-3 py-2.5 cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+      >
+        <div className="flex items-start gap-2 min-w-0">
           <Package className="size-4 mt-0.5 shrink-0 text-muted-foreground" />
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-1.5">
@@ -70,35 +74,35 @@ export function RepoListItem({ repo, isSelected, onSelect, onEdit, onDelete, art
             )}
           </div>
         </div>
-        {(onEdit || onDelete) && (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                className="shrink-0 text-muted-foreground hover:text-foreground"
-                aria-label={`Repository actions for ${repo.name}`}
-              >
-                <Settings className="size-3.5" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {onEdit && (
-                <DropdownMenuItem onClick={(e) => { e.stopPropagation(); onEdit(repo); }}>
-                  <Pencil className="size-3.5 mr-2" />
-                  Edit
-                </DropdownMenuItem>
-              )}
-              {onDelete && (
-                <DropdownMenuItem className="text-destructive" onClick={(e) => { e.stopPropagation(); onDelete(repo); }}>
-                  <Trash2 className="size-3.5 mr-2" />
-                  Delete
-                </DropdownMenuItem>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        )}
-      </div>
+      </button>
+      {(onEdit || onDelete) && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              className="shrink-0 mt-2.5 mr-3 text-muted-foreground hover:text-foreground"
+              aria-label={`Repository actions for ${repo.name}`}
+            >
+              <Settings className="size-3.5" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {onEdit && (
+              <DropdownMenuItem onClick={() => onEdit(repo)}>
+                <Pencil className="size-3.5 mr-2" />
+                Edit
+              </DropdownMenuItem>
+            )}
+            {onDelete && (
+              <DropdownMenuItem className="text-destructive" onClick={() => onDelete(repo)}>
+                <Trash2 className="size-3.5 mr-2" />
+                Delete
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Fixes #672

## Summary
The repository list row was a `div role="button"` wrapping the real `<button>` of the actions dropdown — nested interactive elements. Screen readers announced the row with the dropdown label concatenated into its accessible name (`"e2e-a11y-remote E2E A11y Remote npm · remote · 0 B Repository actions for E2E A11y Remote"`).

The row is now a plain (non-interactive) flex container holding two **sibling** interactives:

- a real `<button type="button">` carrying the row's primary action (`onSelect`), the row padding, and `flex-1` so the full content area stays clickable; keyboard Enter/Space activation comes for free (the manual `onKeyDown` shim is gone), plus a `focus-visible` ring;
- the actions dropdown trigger, unchanged in appearance (`mt-2.5 mr-3` preserves its prior position) and aria-label.

Because nothing wraps the trigger anymore, the `stopPropagation()` calls on the trigger and menu items were removed — there is no row-level click handler left to leak into. Row click/select navigation (desktop master-detail + mobile push), dropdown interactions, and the selected/hover styling are all unchanged.

The e2e a11y spec previously documented the buggy concatenated name; it now asserts the row's clean, anchored accessible name (no trailing "Repository actions …" label).

## Test Checklist
- [x] Unit tests added/updated (new `repo-list-item.test.tsx`: sibling structure, clean accessible name, click + Enter/Space activation, dropdown does not trigger select, menu omitted without handlers)
- [x] E2E Playwright tests added/updated (`repo-dialog-a11y.spec.ts` clean-name assertion)
- [x] Manually tested locally
- [x] No regressions in existing tests (`vitest run` on the repositories suite: 76 passed; eslint clean; no new `tsc` errors)

## UI Changes
- [x] Playwright E2E spec covers the change
- [x] Responsive layout verified (mobile + desktop) — the component is shared by both render paths
- [ ] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader) — this is the point of the change