### PR TITLE
feat(security): send custom header on mutations for CSRF defense-in-depth (#673)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,26 @@ docker build --build-arg AK_ENFORCE_HTTPS=true -t artifact-keeper-web:tls .
 
 Leave it unset to build the default plain-HTTP-safe image.
 
+### CSRF protection
+
+The UI authenticates with httpOnly session cookies (`credentials: "include"`),
+so it relies on a CSRF contract with the backend:
+
+- **Frontend (implemented here):** every API request — SDK calls, `apiFetch`,
+  and the remaining raw `fetch` mutations — carries the custom header
+  `X-Requested-With: XMLHttpRequest` (see `CSRF_HEADER_NAME` in
+  `src/lib/sdk-client.ts`). Cross-site HTML forms cannot set custom headers,
+  so this header forces a CORS preflight a forged request cannot satisfy.
+- **Backend (contract):** the backend MUST
+  1. issue the session cookie with `SameSite=Lax` or `SameSite=Strict`, and
+  2. reject cookie-authenticated mutating requests (POST/PUT/PATCH/DELETE)
+     that lack the `X-Requested-With` header. Native package-manager clients
+     are unaffected — they authenticate with Basic/Bearer credentials, not
+     cookies, so the header requirement applies only to cookie auth.
+
+The backend enforcement half is tracked as a follow-up issue in the
+`artifact-keeper` repository (see issue #673 here for the full audit finding).
+
 ## Project Structure
 
 ```

--- a/src/app/(auth)/callback/page.tsx
+++ b/src/app/(auth)/callback/page.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/providers/auth-provider";
+import { CSRF_HEADER_NAME, CSRF_HEADER_VALUE } from "@/lib/sdk-client";
 
 function getSsoErrorMessage(errorCode: string | null): string {
   const messages: Record<string, string> = {
@@ -46,7 +47,10 @@ function CallbackHandler() {
       try {
         const response = await fetch("/api/v1/auth/sso/exchange", {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            [CSRF_HEADER_NAME]: CSRF_HEADER_VALUE,
+          },
           credentials: "include",
           body: JSON.stringify({ code }),
         });

--- a/src/lib/__tests__/sdk-client.test.ts
+++ b/src/lib/__tests__/sdk-client.test.ts
@@ -284,6 +284,186 @@ describe("sdk-client", () => {
   });
 
   // -------------------------------------------------------------------------
+  // CSRF defense-in-depth header
+  // -------------------------------------------------------------------------
+
+  describe("CSRF header (X-Requested-With)", () => {
+    it("is added to GET requests by the request interceptor", async () => {
+      setupBrowserEnv();
+      mockStorage["ak_active_instance"] = "local";
+      const { CSRF_HEADER_NAME, CSRF_HEADER_VALUE } = await import(
+        "../sdk-client"
+      );
+      const interceptor = requestInterceptors[0];
+      const request = new Request("http://localhost:3000/api/v1/repos");
+      const result = interceptor(request);
+      expect(result.headers.get(CSRF_HEADER_NAME)).toBe(CSRF_HEADER_VALUE);
+    });
+
+    it("is added to mutating requests by the request interceptor", async () => {
+      setupBrowserEnv();
+      mockStorage["ak_active_instance"] = "local";
+      const { CSRF_HEADER_NAME, CSRF_HEADER_VALUE } = await import(
+        "../sdk-client"
+      );
+      const interceptor = requestInterceptors[0];
+      for (const method of ["POST", "PUT", "PATCH", "DELETE"]) {
+        const request = new Request("http://localhost:3000/api/v1/repos", {
+          method,
+        });
+        const result = interceptor(request);
+        expect(result.headers.get(CSRF_HEADER_NAME)).toBe(CSRF_HEADER_VALUE);
+      }
+    });
+
+    it("exports the header name and value constants", async () => {
+      setupBrowserEnv();
+      const mod = await import("../sdk-client");
+      expect(mod.CSRF_HEADER_NAME).toBe("X-Requested-With");
+      expect(mod.CSRF_HEADER_VALUE).toBe("XMLHttpRequest");
+    });
+
+    it("preserves existing headers when adding the CSRF header", async () => {
+      setupBrowserEnv();
+      mockStorage["ak_active_instance"] = "local";
+      await import("../sdk-client");
+      const interceptor = requestInterceptors[0];
+      const request = new Request("http://localhost:3000/api/v1/repos", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+      const result = interceptor(request);
+      expect(result.headers.get("Content-Type")).toBe("application/json");
+      expect(result.headers.get("X-Requested-With")).toBe("XMLHttpRequest");
+    });
+
+    it("survives the remote-instance pathname rewrite", async () => {
+      setupBrowserEnv();
+      mockStorage["ak_active_instance"] = "remote-1";
+      await import("../sdk-client");
+      const interceptor = requestInterceptors[0];
+      const request = new Request("http://localhost:3000/api/v1/repos", {
+        method: "DELETE",
+      });
+      const result = interceptor(request);
+      expect(new URL(result.url).pathname).toBe(
+        "/api/v1/instances/remote-1/proxy/api/v1/repos"
+      );
+      expect(result.headers.get("X-Requested-With")).toBe("XMLHttpRequest");
+    });
+
+    it("is sent on the token refresh request", async () => {
+      setupBrowserEnv();
+      mockStorage["ak_active_instance"] = "local";
+
+      const mockFetch = vi.fn();
+      mockFetch.mockResolvedValueOnce(new Response("{}", { status: 200 }));
+      mockFetch.mockResolvedValueOnce(new Response("{}", { status: 200 }));
+      vi.stubGlobal("fetch", mockFetch);
+
+      await import("../sdk-client");
+      const interceptor = responseInterceptors[0];
+
+      const response = new Response("Unauthorized", { status: 401 });
+      const request = new Request("http://localhost:3000/api/v1/repos");
+
+      await interceptor(response, request);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/v1/auth/refresh",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            "X-Requested-With": "XMLHttpRequest",
+          }),
+        })
+      );
+    });
+
+    it("is preserved on the retried request after a 401 refresh", async () => {
+      setupBrowserEnv();
+      mockStorage["ak_active_instance"] = "local";
+
+      const mockFetch = vi.fn();
+      mockFetch.mockResolvedValueOnce(new Response("{}", { status: 200 }));
+      mockFetch.mockResolvedValueOnce(new Response("{}", { status: 200 }));
+      vi.stubGlobal("fetch", mockFetch);
+
+      await import("../sdk-client");
+      const requestInterceptor = requestInterceptors[0];
+      const responseInterceptor = responseInterceptors[0];
+
+      // Mirror the real flow: the request passed to the response interceptor
+      // has already been through the request interceptor.
+      const original = requestInterceptor(
+        new Request("http://localhost:3000/api/v1/repos", { method: "DELETE" })
+      );
+      const response = new Response("Unauthorized", { status: 401 });
+
+      await responseInterceptor(response, original);
+
+      // Second fetch call is the retry of the original request
+      const retriedRequest = mockFetch.mock.calls[1][0] as Request;
+      expect(retriedRequest.headers.get("X-Requested-With")).toBe(
+        "XMLHttpRequest"
+      );
+      expect(retriedRequest.method).toBe("DELETE");
+    });
+
+    it("is preserved on queued retries that waited for an in-flight refresh", async () => {
+      setupBrowserEnv();
+      mockStorage["ak_active_instance"] = "local";
+
+      let resolveRefresh!: (value: Response) => void;
+      const refreshPromise = new Promise<Response>((resolve) => {
+        resolveRefresh = resolve;
+      });
+
+      const mockFetch = vi.fn();
+      mockFetch.mockImplementationOnce(() => refreshPromise);
+      mockFetch.mockResolvedValueOnce(
+        new Response('{"ok":true}', { status: 200 })
+      );
+      mockFetch.mockResolvedValueOnce(
+        new Response('{"ok":true}', { status: 200 })
+      );
+      vi.stubGlobal("fetch", mockFetch);
+
+      await import("../sdk-client");
+      const requestInterceptor = requestInterceptors[0];
+      const responseInterceptor = responseInterceptors[0];
+
+      const request1 = requestInterceptor(
+        new Request("http://localhost:3000/api/v1/repos", { method: "POST" })
+      );
+      const request2 = requestInterceptor(
+        new Request("http://localhost:3000/api/v1/artifacts", {
+          method: "DELETE",
+        })
+      );
+
+      const result1Promise = responseInterceptor(
+        new Response("Unauthorized", { status: 401 }),
+        request1
+      );
+      const result2Promise = responseInterceptor(
+        new Response("Unauthorized", { status: 401 }),
+        request2
+      );
+
+      resolveRefresh(new Response("{}", { status: 200 }));
+      await Promise.all([result1Promise, result2Promise]);
+
+      // Calls: refresh, retry of request1, queued retry of request2
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      const retry1 = mockFetch.mock.calls[1][0] as Request;
+      const retry2 = mockFetch.mock.calls[2][0] as Request;
+      expect(retry1.headers.get("X-Requested-With")).toBe("XMLHttpRequest");
+      expect(retry2.headers.get("X-Requested-With")).toBe("XMLHttpRequest");
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Response interceptor: 403 SETUP_REQUIRED
   // -------------------------------------------------------------------------
 

--- a/src/lib/api/__tests__/artifacts.test.ts
+++ b/src/lib/api/__tests__/artifacts.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("@/lib/sdk-client", () => ({
   getActiveInstanceBaseUrl: () => "http://localhost:8080",
+  CSRF_HEADER_NAME: "X-Requested-With",
+  CSRF_HEADER_VALUE: "XMLHttpRequest",
 }));
 
 const mockListArtifacts = vi.fn();

--- a/src/lib/api/__tests__/fetch.test.ts
+++ b/src/lib/api/__tests__/fetch.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/sdk-client", () => ({
   getActiveInstanceBaseUrl: () => "http://localhost:8080",
+  CSRF_HEADER_NAME: "X-Requested-With",
+  CSRF_HEADER_VALUE: "XMLHttpRequest",
 }));
 
 const mockFetch = vi.fn();

--- a/src/lib/api/__tests__/promotion.test.ts
+++ b/src/lib/api/__tests__/promotion.test.ts
@@ -11,6 +11,8 @@ import type {
 
 vi.mock("@/lib/sdk-client", () => ({
   getActiveInstanceBaseUrl: () => "http://localhost:8080",
+  CSRF_HEADER_NAME: "X-Requested-With",
+  CSRF_HEADER_VALUE: "XMLHttpRequest",
 }));
 
 const mockListRepositories = vi.fn();

--- a/src/lib/api/__tests__/uploads.test.ts
+++ b/src/lib/api/__tests__/uploads.test.ts
@@ -6,6 +6,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/sdk-client", () => ({
   getActiveInstanceBaseUrl: () => "http://localhost:8080",
+  CSRF_HEADER_NAME: "X-Requested-With",
+  CSRF_HEADER_VALUE: "XMLHttpRequest",
 }));
 
 // Mock the SDK functions that the refactored module now calls

--- a/src/lib/api/fetch.ts
+++ b/src/lib/api/fetch.ts
@@ -1,4 +1,4 @@
-import { getActiveInstanceBaseUrl } from '@/lib/sdk-client';
+import { getActiveInstanceBaseUrl, CSRF_HEADER_NAME, CSRF_HEADER_VALUE } from '@/lib/sdk-client';
 
 /**
  * Throw if a successful SDK response had no body when the caller expects one.
@@ -68,7 +68,10 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
   const { headers: callerHeaders, ...rest } = init ?? {};
 
   // Build headers with defaults first so caller values take precedence.
-  const headers = new Headers({ 'Content-Type': 'application/json' });
+  const headers = new Headers({
+    'Content-Type': 'application/json',
+    [CSRF_HEADER_NAME]: CSRF_HEADER_VALUE,
+  });
   const incoming = new Headers(callerHeaders);
   incoming.forEach((value, key) => {
     headers.set(key, value);

--- a/src/lib/api/promotion.ts
+++ b/src/lib/api/promotion.ts
@@ -21,7 +21,7 @@ import type {
   ArtifactResponse as SdkArtifactResponse,
   ArtifactListResponse as SdkArtifactListResponse,
 } from '@artifact-keeper/sdk';
-import { getActiveInstanceBaseUrl } from '@/lib/sdk-client';
+import { getActiveInstanceBaseUrl, CSRF_HEADER_NAME, CSRF_HEADER_VALUE } from '@/lib/sdk-client';
 import { assertData, narrowEnum } from '@/lib/api/fetch';
 import type {
   PromoteArtifactRequest,
@@ -353,7 +353,10 @@ export const promotionApi = {
       {
         method: 'POST',
         credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          [CSRF_HEADER_NAME]: CSRF_HEADER_VALUE,
+        },
         body: JSON.stringify(request),
       },
     );

--- a/src/lib/api/uploads.ts
+++ b/src/lib/api/uploads.ts
@@ -12,7 +12,7 @@ import type {
   ChunkResponse,
   CompleteResponse,
 } from '@artifact-keeper/sdk';
-import { getActiveInstanceBaseUrl } from '@/lib/sdk-client';
+import { getActiveInstanceBaseUrl, CSRF_HEADER_NAME, CSRF_HEADER_VALUE } from '@/lib/sdk-client';
 import { assertData } from '@/lib/api/fetch';
 
 // --- Re-export SDK types under the names the rest of the codebase expects ---
@@ -90,6 +90,7 @@ export async function uploadChunk(
     headers: {
       'Content-Type': 'application/octet-stream',
       'Content-Range': `bytes ${start}-${end - 1}/${total}`,
+      [CSRF_HEADER_NAME]: CSRF_HEADER_VALUE,
     },
     body: data,
   });

--- a/src/lib/sdk-client.ts
+++ b/src/lib/sdk-client.ts
@@ -3,6 +3,7 @@
  *
  * Configures the generated SDK's fetch-based client with:
  * - Cookie-based auth (httpOnly cookies sent via credentials: 'include')
+ * - CSRF defense-in-depth custom header (X-Requested-With) on all requests
  * - Automatic 401 token refresh with mutex to prevent race conditions
  * - Dynamic baseUrl for remote instance proxy
  * - 403 SETUP_REQUIRED redirect to login
@@ -12,6 +13,21 @@
  */
 
 import { client } from '@artifact-keeper/sdk/client';
+
+// ---------------------------------------------------------------------------
+// CSRF defense-in-depth
+// ---------------------------------------------------------------------------
+
+/**
+ * Custom header sent on every API request. Cross-site HTML forms cannot set
+ * custom headers, so a request carrying this header could only have come from
+ * our own JavaScript — the backend can require it on cookie-authenticated
+ * mutating requests as a CSRF check (the header forces a CORS preflight that
+ * cross-origin forms cannot satisfy). See the "CSRF protection" section of
+ * the README for the full contract.
+ */
+export const CSRF_HEADER_NAME = 'X-Requested-With';
+export const CSRF_HEADER_VALUE = 'XMLHttpRequest';
 
 // ---------------------------------------------------------------------------
 // Remote instance helpers
@@ -54,20 +70,28 @@ client.setConfig({
 // ---------------------------------------------------------------------------
 
 client.interceptors.request.use((request) => {
-  if (typeof window === 'undefined') return request;
-  if (!isRemoteInstance()) return request;
+  // CSRF defense-in-depth: attach the custom header to every request so the
+  // backend can require it on cookie-authenticated mutations. The header is
+  // copied onto the request before any further rewriting so retried requests
+  // (401 refresh) inherit it via request.headers.
+  const headers = new Headers(request.headers);
+  headers.set(CSRF_HEADER_NAME, CSRF_HEADER_VALUE);
+  const withCsrfHeader = new Request(request, { headers });
+
+  if (typeof window === 'undefined') return withCsrfHeader;
+  if (!isRemoteInstance()) return withCsrfHeader;
 
   const base = getActiveInstanceBaseUrl();
-  if (!base) return request;
+  if (!base) return withCsrfHeader;
 
   // For remote instances, prepend the proxy path prefix to the existing URL.
   // Only modify the pathname; never rewrite protocol or host to prevent
   // open redirect attacks via localStorage instance poisoning.
-  const url = new URL(request.url);
+  const url = new URL(withCsrfHeader.url);
   const target = new URL(base, window.location.origin);
   url.pathname = target.pathname + url.pathname;
 
-  return new Request(url.toString(), request);
+  return new Request(url.toString(), withCsrfHeader);
 });
 
 // ---------------------------------------------------------------------------
@@ -143,7 +167,10 @@ client.interceptors.response.use(async (response, request) => {
       `${getActiveInstanceBaseUrl()}/api/v1/auth/refresh`,
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          [CSRF_HEADER_NAME]: CSRF_HEADER_VALUE,
+        },
         body: '{}',
         credentials: 'include',
       }


### PR DESCRIPTION
## Summary

Refs #673 (Part of #673 — the backend enforcement half remains).

The UI authenticates via httpOnly cookies with `credentials: "include"` on every request, but had zero CSRF defense-in-depth. This PR ships the frontend half of the CSRF contract:

- `src/lib/sdk-client.ts` now attaches the custom header **`X-Requested-With: XMLHttpRequest`** (exported as `CSRF_HEADER_NAME`/`CSRF_HEADER_VALUE`) to every SDK request in the request interceptor. Cross-site HTML forms cannot set custom headers, so the header forces a CORS preflight a forged request cannot satisfy — the standard belt-and-suspenders mitigation alongside `SameSite` cookies.
- The header composes with the existing machinery: it is set before the remote-instance pathname rewrite (and survives it), is sent on the raw `POST /api/v1/auth/refresh` call, and is inherited by 401-refresh retries (both the direct retry and queued subscriber retries), which copy `request.headers`.
- Non-SDK raw `fetch` mutations are covered too: the shared `apiFetch` wrapper (`src/lib/api/fetch.ts`, used by all hand-rolled API modules), chunked-upload `PATCH` (`src/lib/api/uploads.ts`), promotion reject `POST` (`src/lib/api/promotion.ts`), and the SSO exchange `POST` (`src/app/(auth)/callback/page.tsx`). GET-only paths (`/health` polls, artifact/tree reads, the SSE stream route) are unchanged.
- README gains a "CSRF protection" section documenting the contract: the backend MUST issue session cookies with `SameSite=Lax`/`Strict` and MUST require the custom header on cookie-authenticated mutations (native Basic/Bearer clients exempt).

Backend enforcement follow-up: artifact-keeper/artifact-keeper#3065

## Test Checklist
- [x] Unit tests added/updated (new "CSRF header" suite in `sdk-client.test.ts`: header on GET + all mutating methods, preservation through the remote-instance rewrite, presence on the refresh request, preservation across direct and queued 401-refresh retries; sdk-client mocks in `fetch`/`artifacts`/`promotion`/`uploads` test files updated for the new exports)
- [ ] E2E Playwright tests added/updated (N/A — no UI behavior change)
- [x] Manually tested locally
- [x] No regressions in existing tests (`npx vitest run`: 161 files / 3022 tests pass; `npx eslint` clean on changed files; `npx tsc --noEmit` identical to main — 23 pre-existing errors in unrelated test files, no new ones)

## UI Changes
- [x] N/A - no UI changes

Fixes #673 — frontend half complete in this PR; the backend enforcement half is tracked separately in artifact-keeper/artifact-keeper#3065.