### PR TITLE
fix(security): evaluate AK_ENFORCE_HTTPS at runtime instead of build time (#679)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,13 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 ARG GIT_SHA=unknown
 ARG APP_VERSION=dev
-# Enable HSTS + the CSP `upgrade-insecure-requests` directive. Next.js bakes
-# `headers()` into the build output (routes-manifest.json), so this must be set
-# at BUILD time, not container runtime. Leave unset (default) for plain-HTTP
-# deployments; set `--build-arg AK_ENFORCE_HTTPS=true` when building an image
-# that will be served behind TLS. See #2222.
+# Enable HSTS + the CSP `upgrade-insecure-requests` directive. The headers are
+# emitted by src/middleware.ts, which reads AK_ENFORCE_HTTPS per request at
+# container RUNTIME (#679), so this build arg only sets the image's default
+# value: operators can override it on the running container with
+# `docker run -e AK_ENFORCE_HTTPS=true ...` (or the compose `environment:`
+# block) without rebuilding. Leave unset (default) for plain-HTTP deployments;
+# set it when the UI will be served behind TLS. See #2222.
 ARG AK_ENFORCE_HTTPS
 ENV GIT_SHA=${GIT_SHA}
 ENV NEXT_PUBLIC_APP_VERSION=${APP_VERSION}

--- a/README.md
+++ b/README.md
@@ -46,15 +46,20 @@ re-enable `Strict-Transport-Security` and `upgrade-insecure-requests`. All other
 security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy,
 Permissions-Policy, and the rest of the CSP) are always emitted regardless.
 
-**Important:** Next.js bakes response headers into the build output, so
-`AK_ENFORCE_HTTPS` is read at **build time**, not container runtime. For the
-Docker image, pass it as a build arg:
+The flag is evaluated **at container runtime** — the headers are emitted by the
+middleware (`src/middleware.ts`), which reads the env var on every request, so
+no rebuild is needed. Set it on the running container:
 
 ```bash
-docker build --build-arg AK_ENFORCE_HTTPS=true -t artifact-keeper-web:tls .
+docker run -e AK_ENFORCE_HTTPS=true ... artifact-keeper-web
 ```
 
-Leave it unset to build the default plain-HTTP-safe image.
+or in the compose `environment:` block. The effective mode is logged once at
+server startup (`[security] AK_ENFORCE_HTTPS ...`) so you can confirm the
+container picked it up.
+
+For custom image builds, `--build-arg AK_ENFORCE_HTTPS=true` still works — it
+only sets the image's **default** value, which a runtime `-e` flag overrides.
 
 ## Project Structure
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,6 @@
 import type { NextConfig } from "next";
 import { readFileSync } from "fs";
 import { execSync } from "child_process";
-import { buildSecurityHeaders, isHttpsEnabled } from "./src/lib/security-headers";
 
 const pkg = JSON.parse(readFileSync("./package.json", "utf-8"));
 
@@ -37,24 +36,6 @@ const nextConfig: NextConfig = {
     // Give large uploads up to 10 minutes before the proxy times out.
     proxyTimeout: 600_000,
   },
-  async headers() {
-    // HSTS and the CSP `upgrade-insecure-requests` directive are only emitted
-    // when the deployment actually terminates TLS (AK_ENFORCE_HTTPS=true|1).
-    // On a plain-HTTP default deploy they would force http->https rewrites the
-    // server can't answer, breaking the whole UI. See #2222.
-    //
-    // NOTE: Next.js serializes `headers()` into the build output
-    // (routes-manifest.json), so AK_ENFORCE_HTTPS is read at BUILD time, not
-    // container runtime. Default (unset) keeps plain-HTTP deploys working out
-    // of the box; build with AK_ENFORCE_HTTPS=true for TLS deployments (see the
-    // Dockerfile build arg and src/lib/security-headers.ts).
-    return [
-      {
-        source: "/(.*)",
-        headers: buildSecurityHeaders(isHttpsEnabled()),
-      },
-    ];
-  },
   async rewrites() {
     return [
       // The backend redirects to /auth/callback after SSO code exchange,
@@ -67,9 +48,13 @@ const nextConfig: NextConfig = {
       },
     ];
   },
-  // API proxy is handled by src/middleware.ts at runtime (reads BACKEND_URL
-  // env var on each request) so that Docker containers can be configured
-  // without rebuilding.  See: https://github.com/artifact-keeper/artifact-keeper-web/issues/56
+  // API proxy AND security headers are handled by src/middleware.ts at runtime
+  // (reads BACKEND_URL and AK_ENFORCE_HTTPS env vars on each request) so that
+  // Docker containers can be configured without rebuilding. A next.config.ts
+  // `headers()` block would be serialized into the build output
+  // (routes-manifest.json), making AK_ENFORCE_HTTPS build-time-only — see
+  // https://github.com/artifact-keeper/artifact-keeper-web/issues/679 and
+  // https://github.com/artifact-keeper/artifact-keeper-web/issues/56
 };
 
 export default nextConfig;

--- a/src/__tests__/dockerfile.test.ts
+++ b/src/__tests__/dockerfile.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Guards the runtime contract for AK_ENFORCE_HTTPS (#679): the shipped image
+ * must carry the flag as a plain container ENV so that
+ * `docker run -e AK_ENFORCE_HTTPS=true` overrides the image default and the
+ * middleware picks it up per request — no rebuild required.
+ */
+const dockerfile = readFileSync(join(__dirname, "../../Dockerfile"), "utf-8");
+
+describe("Dockerfile AK_ENFORCE_HTTPS wiring", () => {
+  it("exposes AK_ENFORCE_HTTPS as a container ENV (runtime-overridable)", () => {
+    expect(dockerfile).toMatch(/^ARG AK_ENFORCE_HTTPS$/m);
+    expect(dockerfile).toContain("ENV AK_ENFORCE_HTTPS=${AK_ENFORCE_HTTPS}");
+  });
+
+  it("documents the flag as runtime-evaluated, not build-time-only", () => {
+    const lines = dockerfile.split("\n");
+    const argIdx = lines.findIndex((l) => l === "ARG AK_ENFORCE_HTTPS");
+    expect(argIdx).toBeGreaterThan(0);
+    const comments: string[] = [];
+    for (let i = argIdx - 1; i >= 0 && lines[i].startsWith("#"); i--) {
+      comments.unshift(lines[i]);
+    }
+    const commentBlock = comments.join("\n");
+    expect(commentBlock).not.toMatch(/must be set\s+at BUILD time/i);
+    expect(commentBlock).toMatch(/runtime/i);
+  });
+});

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -7,15 +7,38 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 const mockRewrite = vi.fn();
 const mockNext = vi.fn();
 
+interface MockResponse {
+  type: string;
+  args: unknown[];
+  headers: {
+    set: (key: string, value: string) => void;
+    get: (key: string) => string | undefined;
+    entries: () => [string, string][];
+  };
+}
+
+function makeMockResponse(type: string, args: unknown[]): MockResponse {
+  const headers = new Map<string, string>();
+  return {
+    type,
+    args,
+    headers: {
+      set: (key, value) => void headers.set(key, value),
+      get: (key) => headers.get(key),
+      entries: () => [...headers.entries()],
+    },
+  };
+}
+
 vi.mock("next/server", () => ({
   NextResponse: {
     rewrite: (...args: unknown[]) => {
       mockRewrite(...args);
-      return { type: "rewrite", args };
+      return makeMockResponse("rewrite", args);
     },
     next: (...args: unknown[]) => {
       mockNext(...args);
-      return { type: "next" };
+      return makeMockResponse("next", args);
     },
   },
 }));
@@ -25,6 +48,7 @@ const originalEnv = process.env;
 beforeEach(() => {
   vi.resetModules();
   process.env = { ...originalEnv };
+  delete process.env.AK_ENFORCE_HTTPS;
   mockRewrite.mockClear();
   mockNext.mockClear();
 });
@@ -51,15 +75,15 @@ function expectRewriteTo(pathname: string, origin = "http://backend:8080") {
   return url;
 }
 
-describe("middleware", () => {
+describe("middleware proxying", () => {
   it("skips SSE event stream path and calls NextResponse.next()", async () => {
     const { middleware } = await import("../middleware");
     const request = createMockNextRequest("/api/v1/events/stream");
-    const result = middleware(request);
+    const result = middleware(request) as unknown as MockResponse;
 
     expect(mockNext).toHaveBeenCalled();
     expect(mockRewrite).not.toHaveBeenCalled();
-    expect(result).toEqual({ type: "next" });
+    expect(result.type).toBe("next");
   });
 
   it.each([
@@ -74,11 +98,11 @@ describe("middleware", () => {
     // accidental refactors to a single-slash variant. See #337.
     const { middleware } = await import("../middleware");
     const request = createMockNextRequest(path);
-    const result = middleware(request);
+    const result = middleware(request) as unknown as MockResponse;
 
     expect(mockNext).toHaveBeenCalled();
     expect(mockRewrite).not.toHaveBeenCalled();
-    expect(result).toEqual({ type: "next" });
+    expect(result.type).toBe("next");
   });
 
   it("rewrites other API paths to backend", async () => {
@@ -149,18 +173,130 @@ describe("middleware", () => {
     }
   });
 
-  it("exports matcher config for API, health, and native format routes", async () => {
+  it("passes page routes through with NextResponse.next()", async () => {
+    const { middleware } = await import("../middleware");
+
+    for (const path of ["/", "/login", "/repositories", "/repositories/npm/my-repo/packages/lodash/1.0.0"]) {
+      mockNext.mockClear();
+      mockRewrite.mockClear();
+      middleware(createMockNextRequest(path));
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockRewrite).not.toHaveBeenCalled();
+    }
+  });
+
+  it("exports a catch-all matcher that excludes only Next.js internals", async () => {
+    // The matcher must cover page routes (for runtime security headers, #679)
+    // as well as the proxy paths; the middleware function itself decides
+    // which is which.
     const { config } = await import("../middleware");
-    expect(config.matcher).toContain("/api/:path*");
-    expect(config.matcher).toContain("/health");
-    expect(config.matcher).toContain("/pypi/:path*");
-    expect(config.matcher).toContain("/npm/:path*");
-    expect(config.matcher).toContain("/maven/:path*");
-    expect(config.matcher).toContain("/v2");
-    expect(config.matcher).toContain("/v2/:path*");
-    // lxc-format repos proxy on /lxc/* (artifact-keeper#1272), alongside /incus.
-    expect(config.matcher).toContain("/incus/:path*");
-    expect(config.matcher).toContain("/lxc/:path*");
-    expect(config.matcher.length).toBeGreaterThan(30);
+    expect(config.matcher).toHaveLength(1);
+    expect(config.matcher[0]).toBe(
+      "/((?!_next/static|_next/image|favicon.ico).*)",
+    );
+  });
+});
+
+describe("middleware security headers (#679)", () => {
+  it("emits the always-on baseline headers on page routes by default", async () => {
+    const { middleware } = await import("../middleware");
+    const result = middleware(
+      createMockNextRequest("/repositories"),
+    ) as unknown as MockResponse;
+
+    expect(result.headers.get("X-Frame-Options")).toBe("DENY");
+    expect(result.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(result.headers.get("Referrer-Policy")).toBe(
+      "strict-origin-when-cross-origin",
+    );
+    expect(result.headers.get("Permissions-Policy")).toBe(
+      "camera=(), microphone=(), geolocation=()",
+    );
+    expect(result.headers.get("Content-Security-Policy")).toContain(
+      "default-src 'self'",
+    );
+  });
+
+  it("emits the baseline headers on proxied API responses too", async () => {
+    const { middleware } = await import("../middleware");
+    const result = middleware(
+      createMockNextRequest("/api/v1/users"),
+    ) as unknown as MockResponse;
+
+    expect(result.type).toBe("rewrite");
+    expect(result.headers.get("X-Frame-Options")).toBe("DENY");
+    expect(result.headers.get("Content-Security-Policy")).toContain(
+      "default-src 'self'",
+    );
+  });
+
+  it("emits the baseline headers on the SSE pass-through path", async () => {
+    const { middleware } = await import("../middleware");
+    const result = middleware(
+      createMockNextRequest("/api/v1/events/stream"),
+    ) as unknown as MockResponse;
+
+    expect(result.type).toBe("next");
+    expect(result.headers.get("X-Frame-Options")).toBe("DENY");
+  });
+
+  it("omits HSTS and upgrade-insecure-requests when AK_ENFORCE_HTTPS is unset", async () => {
+    const { middleware } = await import("../middleware");
+    const result = middleware(
+      createMockNextRequest("/repositories"),
+    ) as unknown as MockResponse;
+
+    expect(result.headers.get("Strict-Transport-Security")).toBeUndefined();
+    expect(result.headers.get("Content-Security-Policy")).not.toContain(
+      "upgrade-insecure-requests",
+    );
+  });
+
+  it.each(["true", "1"])(
+    "emits HSTS and upgrade-insecure-requests when AK_ENFORCE_HTTPS=%s is set at runtime",
+    async (value) => {
+      // Set AFTER import to prove the flag is read per request, not at
+      // module load (i.e. not baked in at build time).
+      const { middleware } = await import("../middleware");
+      process.env.AK_ENFORCE_HTTPS = value;
+      const result = middleware(
+        createMockNextRequest("/repositories"),
+      ) as unknown as MockResponse;
+
+      expect(result.headers.get("Strict-Transport-Security")).toBe(
+        "max-age=31536000; includeSubDomains",
+      );
+      expect(result.headers.get("Content-Security-Policy")).toContain(
+        "upgrade-insecure-requests",
+      );
+    },
+  );
+
+  it("applies the runtime HTTPS headers on proxied API responses as well", async () => {
+    const { middleware } = await import("../middleware");
+    process.env.AK_ENFORCE_HTTPS = "true";
+    const result = middleware(
+      createMockNextRequest("/api/v1/users"),
+    ) as unknown as MockResponse;
+
+    expect(result.type).toBe("rewrite");
+    expect(result.headers.get("Strict-Transport-Security")).toBe(
+      "max-age=31536000; includeSubDomains",
+    );
+  });
+
+  it("stops emitting HSTS when the flag is removed at runtime", async () => {
+    const { middleware } = await import("../middleware");
+    process.env.AK_ENFORCE_HTTPS = "true";
+    const on = middleware(
+      createMockNextRequest("/repositories"),
+    ) as unknown as MockResponse;
+    expect(on.headers.get("Strict-Transport-Security")).toBeDefined();
+
+    delete process.env.AK_ENFORCE_HTTPS;
+    const off = middleware(
+      createMockNextRequest("/repositories"),
+    ) as unknown as MockResponse;
+    expect(off.headers.get("Strict-Transport-Security")).toBeUndefined();
   });
 });

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,25 @@
+import { isHttpsEnabled } from "./lib/security-headers";
+
+/**
+ * Next.js instrumentation hook — runs once at server startup. Surfaces the
+ * effective security-header mode so operators can confirm from the container
+ * logs that AK_ENFORCE_HTTPS was picked up (it is evaluated per request in
+ * src/middleware.ts, so a runtime `docker run -e` change takes effect without
+ * a rebuild). See #679.
+ */
+export function register() {
+  if (process.env.NEXT_RUNTIME !== "nodejs") return;
+
+  if (isHttpsEnabled()) {
+    console.log(
+      "[security] AK_ENFORCE_HTTPS is set — emitting Strict-Transport-Security " +
+        "and CSP upgrade-insecure-requests on every response.",
+    );
+  } else {
+    console.log(
+      "[security] AK_ENFORCE_HTTPS is not set — HSTS and CSP " +
+        "upgrade-insecure-requests are DISABLED (plain-HTTP mode). Set " +
+        "AK_ENFORCE_HTTPS=true on the container when the UI is served behind TLS.",
+    );
+  }
+}

--- a/src/lib/security-headers.ts
+++ b/src/lib/security-headers.ts
@@ -1,6 +1,7 @@
 /**
- * Security response headers for every route (wired into `next.config.ts`'s
- * `async headers()`).
+ * Security response headers for every route (applied per-request from
+ * `src/middleware.ts`, so the HTTPS-gated headers below honor the
+ * `AK_ENFORCE_HTTPS` env var at container runtime, not just at build time).
  *
  * Two of these headers only make sense when the deployment actually terminates
  * TLS, and are actively harmful on a plain-HTTP deployment:
@@ -101,9 +102,9 @@ export function buildSecurityHeaders(httpsEnabled: boolean): SecurityHeader[] {
  * enable HSTS + `upgrade-insecure-requests`. Leave unset/false for plain-HTTP
  * deployments. Any other value is treated as false.
  *
- * NOTE: this is consumed from `next.config.ts` `headers()`, which Next.js
- * serializes into the build output, so the flag is read at BUILD time (e.g. the
- * Dockerfile `AK_ENFORCE_HTTPS` build arg), not container runtime.
+ * NOTE: this is consumed from `src/middleware.ts`, which runs per request, so
+ * the flag is read at container RUNTIME (e.g. `docker run -e
+ * AK_ENFORCE_HTTPS=true`), not baked into the image at build time. See #679.
  */
 export function isHttpsEnabled(
   env: Record<string, string | undefined> = process.env,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,11 +1,86 @@
 import { type NextRequest, NextResponse } from "next/server";
+import { buildSecurityHeaders, isHttpsEnabled } from "./lib/security-headers";
 
 /**
- * Runtime proxy middleware — rewrites /api/*, /health, and native package
- * format requests to the backend server. Unlike next.config.ts `rewrites()`,
- * environment variables are read at **request time**, so `BACKEND_URL` can
- * be set when the container starts rather than when the image is built.
+ * Runtime proxy + security-header middleware.
+ *
+ * Two jobs, both evaluated per request so container env vars work at runtime
+ * rather than being baked in at image build time:
+ *
+ * 1. Rewrites /api/*, /health, and native package format requests to the
+ *    backend server (BACKEND_URL env var). See #56.
+ * 2. Emits the security response headers (see src/lib/security-headers.ts),
+ *    including the AK_ENFORCE_HTTPS-gated HSTS and CSP
+ *    `upgrade-insecure-requests` directives. next.config.ts `headers()` is
+ *    serialized into the build output, so keeping them there made
+ *    AK_ENFORCE_HTTPS a build-time-only flag that silently did nothing when
+ *    set on a running container. See #679.
  */
+
+/**
+ * Path prefixes proxied to the backend server: the management API plus every
+ * native package-format endpoint the backend serves through the web UI.
+ */
+const PROXY_PATH_PREFIXES: readonly string[] = [
+  "/api",
+  "/health",
+  // Native package format endpoints proxied to the backend
+  "/pypi",
+  "/npm",
+  "/maven",
+  "/debian",
+  "/nuget",
+  "/rpm",
+  "/cargo",
+  "/gems",
+  "/lfs",
+  "/pub",
+  "/go",
+  "/helm",
+  "/composer",
+  "/conan",
+  "/alpine",
+  "/conda",
+  "/swift",
+  "/terraform",
+  "/cocoapods",
+  "/hex",
+  "/huggingface",
+  "/jetbrains",
+  "/chef",
+  "/puppet",
+  "/ansible",
+  "/cran",
+  "/ivy",
+  "/vscode",
+  "/proto",
+  "/incus",
+  // lxc-format repos are served on /lxc/* by the backend (alias of the Incus
+  // handler, artifact-keeper#1272). Without this the proxy 404s lxc clients.
+  "/lxc",
+  "/ext",
+  "/v2",
+];
+
+function isProxyPath(pathname: string): boolean {
+  return PROXY_PATH_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
+/**
+ * Attach the security headers to a response. `AK_ENFORCE_HTTPS` is read from
+ * the environment on every request, so flipping it on a running container
+ * takes effect without a rebuild. Applied to both page responses and proxied
+ * API responses so the headers survive the rewrite path.
+ */
+function withSecurityHeaders(response: NextResponse): NextResponse {
+  for (const { key, value } of buildSecurityHeaders(isHttpsEnabled())) {
+    response.headers.set(key, value);
+  }
+  return response;
+}
+
 export function middleware(request: NextRequest) {
   const { pathname, search } = request.nextUrl;
 
@@ -15,55 +90,27 @@ export function middleware(request: NextRequest) {
   // variants must match too: `skipTrailingSlashRedirect` (next.config.ts)
   // means `/api/v1/events/stream/` reaches us verbatim. See #337.
   if (pathname.replace(/\/+$/, "") === "/api/v1/events/stream") {
-    return NextResponse.next();
+    return withSecurityHeaders(NextResponse.next());
+  }
+
+  if (!isProxyPath(pathname)) {
+    // Page or asset route: let Next.js handle it, with headers attached.
+    return withSecurityHeaders(NextResponse.next());
   }
 
   // Default targets the Docker Compose internal network (plain HTTP between containers)
   const backendUrl = process.env.BACKEND_URL || "http://backend:8080"; // NOSONAR — internal service-mesh traffic
 
-  return NextResponse.rewrite(new URL(`${pathname}${search}`, backendUrl));
+  return withSecurityHeaders(
+    NextResponse.rewrite(new URL(`${pathname}${search}`, backendUrl)),
+  );
 }
 
 export const config = {
   matcher: [
-    "/api/:path*",
-    "/health",
-    // Native package format endpoints proxied to the backend
-    "/pypi/:path*",
-    "/npm/:path*",
-    "/maven/:path*",
-    "/debian/:path*",
-    "/nuget/:path*",
-    "/rpm/:path*",
-    "/cargo/:path*",
-    "/gems/:path*",
-    "/lfs/:path*",
-    "/pub/:path*",
-    "/go/:path*",
-    "/helm/:path*",
-    "/composer/:path*",
-    "/conan/:path*",
-    "/alpine/:path*",
-    "/conda/:path*",
-    "/swift/:path*",
-    "/terraform/:path*",
-    "/cocoapods/:path*",
-    "/hex/:path*",
-    "/huggingface/:path*",
-    "/jetbrains/:path*",
-    "/chef/:path*",
-    "/puppet/:path*",
-    "/ansible/:path*",
-    "/cran/:path*",
-    "/ivy/:path*",
-    "/vscode/:path*",
-    "/proto/:path*",
-    "/incus/:path*",
-    // lxc-format repos are served on /lxc/* by the backend (alias of the Incus
-    // handler, artifact-keeper#1272). Without this the proxy 404s lxc clients.
-    "/lxc/:path*",
-    "/ext/:path*",
-    "/v2",
-    "/v2/:path*",
+    // Run on every request except Next.js build/asset internals so that page
+    // routes get the runtime security headers too. The middleware function
+    // itself decides whether to proxy the path or pass it through.
+    "/((?!_next/static|_next/image|favicon.ico).*)",
   ],
 };


### PR DESCRIPTION
## Summary

Fixes #679.

`AK_ENFORCE_HTTPS` was evaluated in `next.config.ts` `headers()`, which Next.js serializes into the build output (`routes-manifest.json`), so setting the env var on a **running** container silently did nothing — no HSTS, no CSP `upgrade-insecure-requests`, no warning.

**What changed:**

- **Security headers moved from `next.config.ts` `headers()` to `src/middleware.ts`**, which reads `process.env.AK_ENFORCE_HTTPS` on every request. The same image now behaves correctly whether the flag is flipped via `docker run -e`, compose `environment:`, or the build arg (which now only sets the image's default env value). This mirrors the existing runtime-`BACKEND_URL` proxy pattern (#56).
- **Middleware matcher widened** from proxy-paths-only to a catch-all (`/((?!_next/static|_next/image|favicon.ico).*)`) so page routes get headers too; the middleware function itself decides proxy-rewrite vs pass-through from a shared prefix list (same proxy surface as before).
- **Baseline headers unchanged and unconditional** — X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, X-DNS-Prefetch-Control, and the base CSP are emitted on every response, including the proxied API/rewrite path and the SSE pass-through path.
- **Startup log** via `src/instrumentation.ts` (`register()`): logs once at server start whether HTTPS enforcement is active, so operators can confirm the container picked the flag up (and plain-HTTP deploys see an explicit notice that HSTS is off).
- **Docs**: README section rewritten for runtime behavior; Dockerfile comments updated (build arg now just sets the overridable image default).

## Test Checklist

- [x] Unit tests added/updated — `src/__tests__/middleware.test.ts` (rewritten: per-request env toggling, headers on page/proxy/SSE paths, matcher), `src/lib/__tests__/security-headers.test.ts` (unchanged, still green), new `src/__tests__/dockerfile.test.ts` guarding the runtime ENV contract
- [ ] E2E Playwright tests added/updated — N/A (no UI change; header behavior covered by unit tests + standalone-server smoke test below)
- [x] Manually tested locally — see below
- [x] No regressions in existing tests — `npx vitest run`: 162 files / 3025 tests pass; `npx eslint` clean on changed files; `npx tsc --noEmit` shows only the 23 pre-existing errors in unrelated test files; `npm run build` succeeds and `.next/routes-manifest.json` now has `"headers": []`

**Standalone-server smoke test** (one build, two runs — proves runtime evaluation):

- `PORT=3100 node .next/standalone/server.js` (no flag) → `/login` has baseline headers, no HSTS, no `upgrade-insecure-requests`; startup logs the plain-HTTP notice.
- `AK_ENFORCE_HTTPS=true BACKEND_URL=http://127.0.0.1:18181 node .next/standalone/server.js` → `/login` gets `strict-transport-security: max-age=31536000; includeSubDomains` and CSP with `upgrade-insecure-requests`; a proxied `/api/v1/*` response (against a fake backend) also carries HSTS; startup logs the enabled message.

**Not verified locally:** behavior inside the actual Docker image (the multi-stage UBI build was not run here — no Docker image build performed). The smoke test used the same `output: "standalone"` artifact the image ships, and the Dockerfile change is comment-only (the `ENV AK_ENFORCE_HTTPS=${AK_ENFORCE_HTTPS}` passthrough is unchanged), but CI should still build the image to confirm.

## UI Changes

- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [x] N/A - no UI changes
