### PR TITLE
refactor(query): consolidate repository-list queries into shared hooks (#669)

### DIFF
--- a/src/app/(app)/(admin)/curation/_components/curation-rules-manager.test.tsx
+++ b/src/app/(app)/(admin)/curation/_components/curation-rules-manager.test.tsx
@@ -47,7 +47,7 @@ vi.mock("@tanstack/react-query", () => ({
     enabled?: boolean;
   }) => {
     const key = (opts.queryKey as string[])[0];
-    if (key === "repositories-all") return { data: reposData };
+    if (key === "repositories") return { data: reposData };
     if (opts.enabled !== false) {
       try {
         opts.queryFn();

--- a/src/app/(app)/(admin)/curation/_components/curation-rules-manager.tsx
+++ b/src/app/(app)/(admin)/curation/_components/curation-rules-manager.tsx
@@ -25,7 +25,7 @@ import curationRulesApi, {
   parseList,
   clampDistance,
 } from "@/lib/api/curation-rules";
-import { repositoriesApi } from "@/lib/api/repositories";
+import { useRepositories } from "@/hooks/use-repositories";
 import { mutationErrorToast, toUserMessage } from "@/lib/error-utils";
 
 import { Button } from "@/components/ui/button";
@@ -228,10 +228,7 @@ export function CurationRulesManager() {
       queryFn: () => curationRulesApi.list(),
     });
 
-  const { data: repos } = useQuery({
-    queryKey: ["repositories-all"],
-    queryFn: () => repositoriesApi.list({ per_page: 1000 }),
-  });
+  const { data: repos } = useRepositories({ per_page: 1000 });
   const stagingRepos = useMemo(
     () => (repos?.items ?? []).filter((r) => r.repo_type === "staging"),
     [repos?.items],

--- a/src/app/(app)/(admin)/curation/page.test.tsx
+++ b/src/app/(app)/(admin)/curation/page.test.tsx
@@ -33,7 +33,7 @@ let packagesData: { data: unknown; isLoading?: boolean; isError?: boolean; error
 vi.mock("@tanstack/react-query", () => ({
   useQuery: (opts: { queryKey: unknown[]; queryFn: () => unknown; enabled?: boolean }) => {
     const key = (opts.queryKey as string[])[0];
-    if (key === "repositories-all") return { data: reposData };
+    if (key === "repositories") return { data: reposData };
     // curation packages
     if (opts.enabled !== false) {
       try {

--- a/src/app/(app)/(admin)/curation/page.tsx
+++ b/src/app/(app)/(admin)/curation/page.tsx
@@ -13,7 +13,7 @@ import {
 import { toast } from "sonner";
 
 import curationApi, { type CurationPackage } from "@/lib/api/curation";
-import { repositoriesApi } from "@/lib/api/repositories";
+import { useRepositories } from "@/hooks/use-repositories";
 import { mutationErrorToast, toUserMessage } from "@/lib/error-utils";
 import { useAuth } from "@/providers/auth-provider";
 
@@ -57,11 +57,10 @@ export default function CurationPage() {
   const [bulkAction, setBulkAction] = useState<null | "approve" | "block">(null);
   const [reason, setReason] = useState("");
 
-  const { data: repos } = useQuery({
-    queryKey: ["repositories-all", "staging"],
-    queryFn: () => repositoriesApi.list({ per_page: 1000 }),
-    enabled: !!user?.is_admin,
-  });
+  const { data: repos } = useRepositories(
+    { per_page: 1000 },
+    { enabled: !!user?.is_admin },
+  );
   const stagingRepos = useMemo(
     () => (repos?.items ?? []).filter((r) => r.repo_type === "staging"),
     [repos?.items],

--- a/src/app/(app)/(admin)/lifecycle/page.tsx
+++ b/src/app/(app)/(admin)/lifecycle/page.tsx
@@ -18,7 +18,7 @@ import {
 } from "lucide-react";
 import { useAuth } from "@/providers/auth-provider";
 import lifecycleApi from "@/lib/api/lifecycle";
-import { repositoriesApi } from "@/lib/api/repositories";
+import { useRepositories } from "@/hooks/use-repositories";
 import { mutationErrorToast } from "@/lib/error-utils";
 import { formatBytes } from "@/lib/utils";
 import type {
@@ -134,11 +134,10 @@ export default function LifecyclePage() {
     data: repositoriesPage,
     isLoading: isLoadingRepositories,
     isError: repositoriesError,
-  } = useQuery({
-    queryKey: ["repositories", "lifecycle-policy-selector"],
-    queryFn: () => repositoriesApi.list({ per_page: 1000 }),
-    enabled: !!user?.is_admin && createOpen && requiresRepositoryId,
-  });
+  } = useRepositories(
+    { per_page: 1000 },
+    { enabled: !!user?.is_admin && createOpen && requiresRepositoryId },
+  );
 
   const repositories = useMemo(
     () => repositoriesPage?.items ?? [],

--- a/src/app/(app)/(admin)/permissions/page.tsx
+++ b/src/app/(app)/(admin)/permissions/page.tsx
@@ -14,7 +14,7 @@ import type {
   CreatePermissionRequest,
 } from "@/lib/api/permissions";
 import { groupsApi } from "@/lib/api/groups";
-import { repositoriesApi } from "@/lib/api/repositories";
+import { useRepositories } from "@/hooks/use-repositories";
 import { adminApi } from "@/lib/api/admin";
 import { mutationErrorToast } from "@/lib/error-utils";
 import { useAuth } from "@/providers/auth-provider";
@@ -114,11 +114,10 @@ export default function PermissionsPage() {
     enabled: !!currentUser?.is_admin,
   });
 
-  const { data: repositoriesData } = useQuery({
-    queryKey: ["admin-repositories"],
-    queryFn: () => repositoriesApi.list({ per_page: 1000 }),
-    enabled: !!currentUser?.is_admin,
-  });
+  const { data: repositoriesData } = useRepositories(
+    { per_page: 1000 },
+    { enabled: !!currentUser?.is_admin },
+  );
 
   const permissions = permissionsData?.items ?? [];
   const users = usersData ?? [];

--- a/src/app/(app)/(admin)/promotion-rules/page.test.tsx
+++ b/src/app/(app)/(admin)/promotion-rules/page.test.tsx
@@ -30,7 +30,7 @@ let reposData: unknown = { items: [] };
 vi.mock("@tanstack/react-query", () => ({
   useQuery: (opts: { queryKey: unknown[]; queryFn: () => unknown; enabled?: boolean }) => {
     const key = (opts.queryKey as string[])[0];
-    if (key === "repositories-all") return { data: reposData };
+    if (key === "repositories") return { data: reposData };
     if (opts.enabled !== false) {
       try {
         opts.queryFn();

--- a/src/app/(app)/(admin)/promotion-rules/page.tsx
+++ b/src/app/(app)/(admin)/promotion-rules/page.tsx
@@ -9,7 +9,7 @@ import promotionRulesApi, {
   type PromotionRule,
   type CreatePromotionRuleRequest,
 } from "@/lib/api/promotion-rules";
-import { repositoriesApi } from "@/lib/api/repositories";
+import { useRepositories } from "@/hooks/use-repositories";
 import { mutationErrorToast, toUserMessage } from "@/lib/error-utils";
 import { useAuth } from "@/providers/auth-provider";
 
@@ -103,11 +103,10 @@ export default function PromotionRulesPage() {
     enabled: !!user?.is_admin,
   });
 
-  const { data: repos } = useQuery({
-    queryKey: ["repositories-all"],
-    queryFn: () => repositoriesApi.list({ per_page: 1000 }),
-    enabled: !!user?.is_admin,
-  });
+  const { data: repos } = useRepositories(
+    { per_page: 1000 },
+    { enabled: !!user?.is_admin },
+  );
   const repoKey = useMemo(() => {
     const map = new Map<string, string>();
     for (const r of repos?.items ?? []) map.set(r.id, r.key);

--- a/src/app/(app)/(admin)/security/__tests__/page.test.tsx
+++ b/src/app/(app)/(admin)/security/__tests__/page.test.tsx
@@ -305,8 +305,10 @@ function setupQueries(overrides: {
     if (key === "dt" && (subKey === "portfolio-violations" || String(opts.queryKey?.[1]).startsWith("portfolio-violations"))) {
       return { data: overrides.dtViolations ?? undefined, isLoading: false };
     }
-    if (key === "repositories-for-scan") {
-      return { data: overrides.repos ?? undefined };
+    if (key === "repositories") {
+      // useRepositories returns the paginated response; fixtures keep the
+      // shorthand raw-array shape, so wrap it here (#669).
+      return { data: overrides.repos ? { items: overrides.repos } : undefined };
     }
     if (key === "artifacts-for-scan") {
       return { data: overrides.artifacts ?? undefined, isLoading: false };
@@ -512,9 +514,9 @@ describe("SecurityDashboardPage", () => {
 
       render(<SecurityDashboardPage />);
 
-      // Verify the repositories-for-scan query was called
+      // Verify the repositories query was called
       const repoCall = mockUseQuery.mock.calls.find(
-        (call: any[]) => call[0]?.queryKey?.[0] === "repositories-for-scan"
+        (call: any[]) => call[0]?.queryKey?.[0] === "repositories"
       );
       expect(repoCall).toBeDefined();
       // The query should NOT have enabled: false (since the gate was removed)

--- a/src/app/(app)/(admin)/security/page.tsx
+++ b/src/app/(app)/(admin)/security/page.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 "use client";
 
 import { useState, useMemo } from "react";
@@ -20,11 +19,11 @@ import {
 } from "lucide-react";
 
 import "@/lib/sdk-client";
-import { listRepositories } from "@artifact-keeper/sdk";
 import securityApi from "@/lib/api/security";
 import { mutationErrorToast } from "@/lib/error-utils";
 import dtApi from "@/lib/api/dependency-track";
 import { artifactsApi } from "@/lib/api/artifacts";
+import { useRepositories } from "@/hooks/use-repositories";
 import type { RepoSecurityScore } from "@/types/security";
 import type { DtProjectMetrics } from "@/types/dependency-track";
 import {
@@ -187,22 +186,14 @@ export default function SecurityDashboardPage() {
     enabled: !!dtEnabled && !!dtProjects && dtProjects.length > 0,
   });
 
-  const { data: repos } = useQuery({
-    queryKey: ["repositories-for-scan"],
-    queryFn: async () => {
-      const { data, error } = await listRepositories({
-        query: { per_page: 100 },
-      });
-      if (error) throw error;
-      return (data as any)?.items ?? data ?? [];
-    },
-  });
+  const { data: reposPage } = useRepositories({ per_page: 100 });
+  const repos = reposPage?.items;
 
   // Build a lookup map from repository ID to display name (key) for the scores table
   const repoNameMap = useMemo(() => {
     const map = new Map<string, string>();
     if (repos) {
-      for (const r of repos as Array<{ id: string; name: string; key: string }>) {
+      for (const r of repos) {
         map.set(r.id, r.name || r.key);
       }
     }
@@ -211,7 +202,7 @@ export default function SecurityDashboardPage() {
 
   // Find the repo key from repo id for the artifact list API call
   const selectedRepoKey = selectedRepoId
-    ? ((repos as Array<{ id: string; key: string }>) ?? []).find(
+    ? (repos ?? []).find(
         (r) => r.id === selectedRepoId
       )?.key
     : undefined;
@@ -775,14 +766,7 @@ export default function SecurityDashboardPage() {
                   <SelectValue placeholder="Select a repository..." />
                 </SelectTrigger>
                 <SelectContent>
-                  {(
-                    (repos as Array<{
-                      id: string;
-                      name: string;
-                      key: string;
-                      format: string;
-                    }>) ?? []
-                  ).map((r) => (
+                  {(repos ?? []).map((r) => (
                     <SelectItem key={r.id} value={r.id}>
                       {r.name || r.key} ({r.format})
                     </SelectItem>

--- a/src/app/(app)/(admin)/security/policies/page.tsx
+++ b/src/app/(app)/(admin)/security/policies/page.tsx
@@ -6,7 +6,7 @@ import { Plus, Pencil, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
 import securityApi from "@/lib/api/security";
-import { repositoriesApi } from "@/lib/api/repositories";
+import { useRepositories } from "@/hooks/use-repositories";
 import { mutationErrorToast } from "@/lib/error-utils";
 import type {
   ScanPolicy,
@@ -248,10 +248,7 @@ export default function SecurityPoliciesPage() {
   // Repositories for the scope picker and to resolve a policy's repository_id
   // (a UUID) to a human name+key in the list. Same call the release-target
   // picker uses.
-  const { data: repoList, isLoading: reposLoading } = useQuery({
-    queryKey: ["repositories", "policy-scope"],
-    queryFn: () => repositoriesApi.list({ per_page: 200 }),
-  });
+  const { data: repoList, isLoading: reposLoading } = useRepositories({ per_page: 200 });
   const repoById = useMemo(() => {
     const map = new Map<string, Repository>();
     for (const repo of repoList?.items ?? []) map.set(repo.id, repo);

--- a/src/app/(app)/(admin)/security/scans/page.tsx
+++ b/src/app/(app)/(admin)/security/scans/page.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 "use client";
 
 import { useState } from "react";
@@ -8,13 +7,11 @@ import { RefreshCw, Zap } from "lucide-react";
 import { toast } from "sonner";
 
 import "@/lib/sdk-client";
-import {
-  listRepositories,
-  listScanConfigs,
-} from "@artifact-keeper/sdk";
+import { listScanConfigs } from "@artifact-keeper/sdk";
 import securityApi from "@/lib/api/security";
 import { mutationErrorToast } from "@/lib/error-utils";
 import { artifactsApi } from "@/lib/api/artifacts";
+import { useRepositories } from "@/hooks/use-repositories";
 import { isScanIncomplete, isScanFailed, isScanClean } from "@/lib/scan-utils";
 import type { ScanResult } from "@/types/security";
 
@@ -129,17 +126,11 @@ export default function SecurityScansPage() {
       }),
   });
 
-  const { data: repos } = useQuery({
-    queryKey: ["repositories-for-scan"],
-    queryFn: async () => {
-      const { data, error } = await listRepositories({
-        query: { per_page: 100 },
-      });
-      if (error) throw error;
-      return (data as any)?.items ?? data ?? [];
-    },
-    enabled: triggerOpen,
-  });
+  const { data: reposPage } = useRepositories(
+    { per_page: 100 },
+    { enabled: triggerOpen },
+  );
+  const repos = reposPage?.items;
 
   const { data: scanConfigs } = useQuery({
     queryKey: ["security", "scan-configs"],
@@ -157,9 +148,7 @@ export default function SecurityScansPage() {
 
   // Find the repo key from repo id for the artifact list API call
   const selectedRepoKey = selectedRepoId
-    ? ((repos as Array<{ id: string; key: string }>) ?? []).find(
-        (r) => r.id === selectedRepoId
-      )?.key
+    ? (repos ?? []).find((r) => r.id === selectedRepoId)?.key
     : undefined;
 
   const { data: artifactsList, isLoading: artifactsLoading } = useQuery({
@@ -456,14 +445,7 @@ export default function SecurityScansPage() {
                   <SelectValue placeholder="Select a repository..." />
                 </SelectTrigger>
                 <SelectContent>
-                  {(
-                    (repos as Array<{
-                      id: string;
-                      name: string;
-                      key: string;
-                      format: string;
-                    }>) ?? []
-                  ).map((r) => {
+                  {(repos ?? []).map((r) => {
                     const enabled = scanConfigs?.has(r.id) ?? true;
                     return (
                       <SelectItem

--- a/src/app/(app)/(protected)/replication/page.tsx
+++ b/src/app/(app)/(protected)/replication/page.tsx
@@ -15,7 +15,7 @@ import { peersApi } from "@/lib/api/replication";
 import type { PeerInstance, PeerConnection } from "@/lib/api/replication";
 import { mutationErrorToast } from "@/lib/error-utils";
 import { formatBytes } from "@/lib/utils";
-import { repositoriesApi } from "@/lib/api/repositories";
+import { useRepositories } from "@/hooks/use-repositories";
 import type { Repository } from "@/types";
 
 import { Button } from "@/components/ui/button";
@@ -99,10 +99,7 @@ export default function ReplicationPage() {
   const totalCacheSize = peers.reduce((a, p) => a + p.cache_size_bytes, 0);
 
   // Subscriptions tab queries
-  const { data: reposData } = useQuery({
-    queryKey: ["repositories-list"],
-    queryFn: () => repositoriesApi.list({ per_page: 200 }),
-  });
+  const { data: reposData } = useRepositories({ per_page: 200 });
   const repositories = reposData?.items ?? [];
 
   const { data: assignedRepos = [] } = useQuery({

--- a/src/app/(app)/packages/page.tsx
+++ b/src/app/(app)/packages/page.tsx
@@ -45,8 +45,8 @@ import {
   ResizableHandle,
 } from "@/components/ui/resizable";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { useRepositories } from "@/hooks/use-repositories";
 import { packagesApi } from "@/lib/api/packages";
-import { repositoriesApi } from "@/lib/api/repositories";
 import { getInstallCommand, FORMAT_OPTIONS } from "@/lib/package-utils";
 import { formatBytes as formatBytesUtil, formatDate, formatNumber, isSafeUrl } from "@/lib/utils";
 import type {
@@ -419,10 +419,7 @@ function PackagesContent() {
   const pageSize = 24;
 
   // Fetch repositories
-  const { data: reposData } = useQuery({
-    queryKey: ["repositories-for-packages"],
-    queryFn: () => repositoriesApi.list({ per_page: 100 }),
-  });
+  const { data: reposData } = useRepositories({ per_page: 100 });
   const repositories: Repository[] = reposData?.items ?? [];
 
   // Fetch packages

--- a/src/app/(app)/repositories/_components/release-target-settings.tsx
+++ b/src/app/(app)/repositories/_components/release-target-settings.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Loader2, Target, Info } from "lucide-react";
 import { toast } from "sonner";
 
+import { useRepositories } from "@/hooks/use-repositories";
 import { repositoriesApi } from "@/lib/api/repositories";
 import { mutationErrorToast } from "@/lib/error-utils";
 import type { Repository } from "@/types";
@@ -46,18 +47,16 @@ export function ReleaseTargetSettings({ repository }: ReleaseTargetSettingsProps
   // Only staging repositories support release-target linking.
   const isStaging = repository.repo_type === "staging";
 
-  const { data: repoList, isLoading: candidatesLoading } = useQuery({
-    queryKey: ["repositories", "release-target-candidates", repository.format],
+  const { data: repoList, isLoading: candidatesLoading } = useRepositories(
     // Pull local repos of the matching format. The backend enforces the same
     // format + local-type constraints, so this keeps the picker in sync.
-    queryFn: () =>
-      repositoriesApi.list({
-        repo_type: "local",
-        format: repository.format,
-        per_page: 200,
-      }),
-    enabled: isStaging,
-  });
+    {
+      repo_type: "local",
+      format: repository.format,
+      per_page: 200,
+    },
+    { enabled: isStaging },
+  );
 
   const candidates = useMemo(
     () => (repoList?.items ?? []).filter((r) => r.id !== repository.id),

--- a/src/app/(app)/repositories/_components/repositories-content.test.tsx
+++ b/src/app/(app)/repositories/_components/repositories-content.test.tsx
@@ -75,6 +75,7 @@ vi.mock("@/lib/api/search", () => ({
 
 vi.mock("@/lib/query-keys", () => ({
   invalidateGroup: vi.fn(),
+  QUERY_KEYS: { REPOSITORIES: ["repositories"] },
 }));
 
 const mockUseAuth = vi.fn();

--- a/src/app/(app)/repositories/_components/repositories-content.tsx
+++ b/src/app/(app)/repositories/_components/repositories-content.tsx
@@ -11,6 +11,7 @@ import { invalidateGroup } from "@/lib/query-keys";
 import type { Repository, CreateRepositoryRequest } from "@/types";
 import { useAuth } from "@/providers/auth-provider";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { useRepositories } from "@/hooks/use-repositories";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -76,21 +77,11 @@ export function RepositoriesContent() {
   }>({ state: "idle" });
 
   // --- query ---
-  const { data, isLoading, isFetching, isError, error, refetch } = useQuery({
-    queryKey: [
-      "repositories",
-      formatFilter === "__all__" ? undefined : formatFilter,
-      typeFilter === "__all__" ? undefined : typeFilter,
-      page,
-      pageSize,
-    ],
-    queryFn: () =>
-      repositoriesApi.list({
-        per_page: pageSize,
-        page,
-        format: formatFilter === "__all__" ? undefined : formatFilter,
-        repo_type: typeFilter === "__all__" ? undefined : typeFilter,
-      }),
+  const { data, isLoading, isFetching, isError, error, refetch } = useRepositories({
+    per_page: pageSize,
+    page,
+    format: formatFilter === "__all__" ? undefined : formatFilter,
+    repo_type: typeFilter === "__all__" ? undefined : typeFilter,
   });
 
   // --- mutations ---

--- a/src/app/(app)/repositories/_components/virtual-members-panel.tsx
+++ b/src/app/(app)/repositories/_components/virtual-members-panel.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Plus, Trash2, ChevronUp, ChevronDown, Loader2 } from "lucide-react";
 
+import { useRepositories } from "@/hooks/use-repositories";
 import { repositoriesApi } from "@/lib/api/repositories";
 import { mutationErrorToast } from "@/lib/error-utils";
 import type { Repository, VirtualRepoMember } from "@/types";
@@ -46,11 +47,10 @@ export function VirtualMembersPanel({ repository }: VirtualMembersPanelProps) {
   });
 
   // Fetch all repositories to find eligible members
-  const { data: allReposData, isLoading: reposLoading } = useQuery({
-    queryKey: ["repositories-all"],
-    queryFn: () => repositoriesApi.list({ per_page: 1000 }),
-    enabled: addDialogOpen,
-  });
+  const { data: allReposData, isLoading: reposLoading } = useRepositories(
+    { per_page: 1000 },
+    { enabled: addDialogOpen },
+  );
 
   const members = useMemo(() => membersData?.members ?? [], [membersData?.members]);
   const sortedMembers = useMemo(

--- a/src/app/(app)/repositories/page.test.tsx
+++ b/src/app/(app)/repositories/page.test.tsx
@@ -70,6 +70,7 @@ vi.mock('@/lib/api/search', () => ({
 
 vi.mock('@/lib/query-keys', () => ({
   invalidateGroup: vi.fn(),
+  QUERY_KEYS: { REPOSITORIES: ["repositories"] },
 }));
 
 vi.mock('@/providers/auth-provider', () => ({

--- a/src/app/(app)/search/_components/search-content.test.tsx
+++ b/src/app/(app)/search/_components/search-content.test.tsx
@@ -198,7 +198,7 @@ describe("SearchContent", () => {
     useQueryCallIndex = 0;
 
     useQueryResponses = {
-      "repositories-list": {
+      "repositories": {
         data: {
           items: [
             { id: "1", key: "npm-local", name: "NPM Local" },

--- a/src/app/(app)/search/_components/search-content.tsx
+++ b/src/app/(app)/search/_components/search-content.tsx
@@ -43,7 +43,7 @@ import {
 } from "@/components/ui/table";
 import { searchApi, type SearchResult } from "@/lib/api/search";
 import { artifactsApi } from "@/lib/api/artifacts";
-import { repositoriesApi } from "@/lib/api/repositories";
+import { useRepositories } from "@/hooks/use-repositories";
 import { buildMavenSearchQuery } from "@/lib/maven";
 import { QuarantineBadge } from "@/components/common/quarantine-badge";
 import { formatBytes as formatBytesUtil, formatDate } from "@/lib/utils";
@@ -191,10 +191,7 @@ export function SearchContent() {
   const [searchKey, setSearchKey] = useState(0);
 
   // Fetch repositories for select dropdown
-  const { data: reposData } = useQuery({
-    queryKey: ["repositories-list"],
-    queryFn: () => repositoriesApi.list({ per_page: 100 }),
-  });
+  const { data: reposData } = useRepositories({ per_page: 100 });
 
   const repositories = reposData?.items ?? [];
 

--- a/src/app/(app)/setup/page.tsx
+++ b/src/app/(app)/setup/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { useQuery } from "@tanstack/react-query";
 import {
   Code,
   Rocket,
@@ -10,7 +9,7 @@ import {
   Filter,
 } from "lucide-react";
 
-import { repositoriesApi } from "@/lib/api/repositories";
+import { useRepositories } from "@/hooks/use-repositories";
 import type { Repository, RepositoryType } from "@/types";
 
 import { Button } from "@/components/ui/button";
@@ -962,10 +961,7 @@ export default function SetupPage() {
   const [search, setSearch] = useState("");
   const [categoryFilter, setCategoryFilter] = useState<string>("all");
 
-  const { data: repositoriesData } = useQuery({
-    queryKey: ["repositories"],
-    queryFn: () => repositoriesApi.list({ per_page: 100 }),
-  });
+  const { data: repositoriesData } = useRepositories({ per_page: 100 });
 
   const repositories = repositoriesData?.items ?? [];
 

--- a/src/hooks/__tests__/use-repositories.test.ts
+++ b/src/hooks/__tests__/use-repositories.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockUseQuery = vi.hoisted(() => vi.fn());
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (opts: unknown) => mockUseQuery(opts),
+}));
+
+const mockList = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/api/repositories", () => ({
+  repositoriesApi: {
+    list: (...args: unknown[]) => mockList(...args),
+  },
+}));
+
+import { repositoryListKey, useRepositories } from "../use-repositories";
+import { QUERY_KEYS } from "@/lib/query-keys";
+
+describe("repositoryListKey", () => {
+  it("scopes the key under the canonical repositories prefix", () => {
+    expect(repositoryListKey({ per_page: 100 })).toEqual([
+      "repositories",
+      { per_page: 100 },
+    ]);
+  });
+
+  it("defaults to an empty params object", () => {
+    expect(repositoryListKey()).toEqual(["repositories", {}]);
+  });
+
+  it("shares the QUERY_KEYS.REPOSITORIES prefix so prefix invalidation matches (#669)", () => {
+    const key = repositoryListKey({ per_page: 1000 });
+    expect(key[0]).toBe(QUERY_KEYS.REPOSITORIES[0]);
+  });
+});
+
+describe("useRepositories", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseQuery.mockReturnValue({ data: undefined });
+  });
+
+  it("calls useQuery with the param-scoped key", () => {
+    useRepositories({ per_page: 1000 });
+    expect(mockUseQuery).toHaveBeenCalledTimes(1);
+    const opts = mockUseQuery.mock.calls[0][0];
+    expect(opts.queryKey).toEqual(["repositories", { per_page: 1000 }]);
+  });
+
+  it("passes the params through to repositoriesApi.list", () => {
+    const params = { per_page: 200, repo_type: "local", format: "maven" };
+    useRepositories(params);
+    const opts = mockUseQuery.mock.calls[0][0];
+    opts.queryFn();
+    expect(mockList).toHaveBeenCalledTimes(1);
+    expect(mockList).toHaveBeenCalledWith(params);
+  });
+
+  it("defaults params to an empty object", () => {
+    useRepositories();
+    const opts = mockUseQuery.mock.calls[0][0];
+    expect(opts.queryKey).toEqual(["repositories", {}]);
+    opts.queryFn();
+    expect(mockList).toHaveBeenCalledWith({});
+  });
+
+  it("forwards the enabled option and leaves it undefined otherwise", () => {
+    useRepositories({ per_page: 100 }, { enabled: false });
+    expect(mockUseQuery.mock.calls[0][0].enabled).toBe(false);
+
+    useRepositories({ per_page: 100 });
+    expect(mockUseQuery.mock.calls[1][0].enabled).toBeUndefined();
+  });
+
+  it("returns the useQuery result unchanged", () => {
+    const result = { data: { items: [], pagination: {} }, isLoading: false };
+    mockUseQuery.mockReturnValue(result);
+    expect(useRepositories({ per_page: 5 })).toBe(result);
+  });
+});

--- a/src/hooks/use-repositories.ts
+++ b/src/hooks/use-repositories.ts
@@ -1,0 +1,47 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import {
+  repositoriesApi,
+  type ListRepositoriesParams,
+} from "@/lib/api/repositories";
+import { QUERY_KEYS } from "@/lib/query-keys";
+import type { PaginatedResponse, Repository } from "@/types";
+
+/**
+ * Canonical key factory for repository-list queries (#669).
+ *
+ * Every repository-list variant lives under the single `["repositories"]`
+ * prefix, param-scoped by the list params: pages that request the same
+ * params share one cache entry, and prefix invalidation on
+ * `QUERY_KEYS.REPOSITORIES` catches every variant — no more enumerating
+ * per-page key strings in the invalidation registry.
+ *
+ * TanStack Query hashes object key segments deterministically (object keys
+ * are sorted), so `useRepositories({ per_page: 1000 })` at different call
+ * sites resolves to the same cache entry.
+ */
+export function repositoryListKey(params: ListRepositoriesParams = {}) {
+  return [...QUERY_KEYS.REPOSITORIES, params] as const;
+}
+
+export interface UseRepositoriesOptions {
+  /** Passed through to `useQuery`; defaults to `true` when omitted. */
+  enabled?: boolean;
+}
+
+/**
+ * Shared query for the repository list (`repositoriesApi.list`).
+ *
+ * Replaces the ad-hoc `["repositories-all"]` / `["admin-repositories"]` /
+ * `["repositories-for-scan"]` / `["repositories-list"]` query declarations
+ * that duplicated the same fetch under different cache keys (#669).
+ */
+export function useRepositories(
+  params: ListRepositoriesParams = {},
+  options?: UseRepositoriesOptions,
+): UseQueryResult<PaginatedResponse<Repository>, Error> {
+  return useQuery({
+    queryKey: repositoryListKey(params),
+    queryFn: () => repositoriesApi.list(params),
+    enabled: options?.enabled,
+  });
+}

--- a/src/lib/__tests__/query-keys.test.ts
+++ b/src/lib/__tests__/query-keys.test.ts
@@ -27,9 +27,6 @@ describe("QUERY_KEYS", () => {
     ADMIN_STATS: ["admin-stats"],
     RECENT_REPOS: ["recent-repositories"],
     REPOSITORIES: ["repositories"],
-    REPOSITORIES_LIST: ["repositories-list"],
-    REPOSITORIES_FOR_SCAN: ["repositories-for-scan"],
-    REPOSITORIES_ALL: ["repositories-all"],
     QUALITY_HEALTH: ["quality-health-dashboard"],
     QUALITY_GATES: ["quality-gates"],
     ADMIN_USERS: ["admin-users"],
@@ -43,8 +40,8 @@ describe("QUERY_KEYS", () => {
     PLUGINS: ["plugins"],
   };
 
-  it("has 17 key constants (#213)", () => {
-    expect(Object.keys(QUERY_KEYS)).toHaveLength(17);
+  it("has 14 key constants (#213, #669)", () => {
+    expect(Object.keys(QUERY_KEYS)).toHaveLength(14);
   });
 
   it.each(Object.entries(expectedKeys))(
@@ -98,15 +95,23 @@ describe("INVALIDATION_GROUPS", () => {
     }
   });
 
-  it("repositories group contains all 6 repo-related keys", () => {
+  it("repositories group contains the repo key family root plus related keys (#669)", () => {
     const group = INVALIDATION_GROUPS.repositories;
-    expect(group).toHaveLength(6);
+    expect(group).toHaveLength(3);
     for (const key of [
-      ["repositories"], ["repositories-list"], ["repositories-for-scan"],
-      ["repositories-all"], ["recent-repositories"], ["quality-health-dashboard"],
+      ["repositories"], ["recent-repositories"], ["quality-health-dashboard"],
     ]) {
       expect(group).toContainEqual(key);
     }
+  });
+
+  it("repositories group invalidates by prefix, so param-scoped list keys are covered (#669)", () => {
+    // Every repository-list query uses ["repositories", params]; invalidating
+    // the ["repositories"] prefix matches all of them, so the group must not
+    // need per-variant entries.
+    const group = INVALIDATION_GROUPS.repositories;
+    expect(group).toContainEqual(["repositories"]);
+    expect(group.some((key) => key.length > 1 && key[0] === "repositories")).toBe(false);
   });
 
   it("every group value references existing QUERY_KEYS", () => {
@@ -205,9 +210,9 @@ describe("getKeysForEvent", () => {
 
   it("returns repository keys for repository.deleted", () => {
     const keys = getKeysForEvent("repository.deleted");
-    expect(keys).toHaveLength(6);
+    expect(keys).toHaveLength(3);
     expect(keys).toContainEqual(["repositories"]);
-    expect(keys).toContainEqual(["repositories-list"]);
+    expect(keys).toContainEqual(["recent-repositories"]);
   });
 
   it("returns quality gate keys for quality_gate.updated", () => {
@@ -227,7 +232,7 @@ describe("getKeysForEvent", () => {
 
 describe("invalidateGroup", () => {
   it.each([
-    ["repositories", 6, [["repositories"], ["repositories-list"], ["repositories-for-scan"], ["repositories-all"], ["recent-repositories"], ["quality-health-dashboard"]]],
+    ["repositories", 3, [["repositories"], ["recent-repositories"], ["quality-health-dashboard"]]],
     ["dashboard", 2, [["admin-stats"], ["recent-repositories"]]],
     ["users", 2, [["admin-users"], ["admin-groups"]]],
     ["groups", 2, [["admin-groups"], ["admin-permissions"]]],

--- a/src/lib/query-keys.ts
+++ b/src/lib/query-keys.ts
@@ -13,10 +13,11 @@ import type { QueryClient } from "@tanstack/react-query";
 export const QUERY_KEYS = {
   ADMIN_STATS: ["admin-stats"],
   RECENT_REPOS: ["recent-repositories"],
+  // Root of the single repository-list key family. All repository-list
+  // queries use param-scoped keys `["repositories", params]` (see
+  // repositoryListKey in src/hooks/use-repositories.ts), so prefix
+  // invalidation on this key catches every variant (#669).
   REPOSITORIES: ["repositories"],
-  REPOSITORIES_LIST: ["repositories-list"],
-  REPOSITORIES_FOR_SCAN: ["repositories-for-scan"],
-  REPOSITORIES_ALL: ["repositories-all"],
   QUALITY_HEALTH: ["quality-health-dashboard"],
   QUALITY_GATES: ["quality-gates"],
   ADMIN_USERS: ["admin-users"],
@@ -41,9 +42,6 @@ export const INVALIDATION_GROUPS: Record<string, readonly (readonly string[])[]>
   dashboard: [QUERY_KEYS.ADMIN_STATS, QUERY_KEYS.RECENT_REPOS],
   repositories: [
     QUERY_KEYS.REPOSITORIES,
-    QUERY_KEYS.REPOSITORIES_LIST,
-    QUERY_KEYS.REPOSITORIES_FOR_SCAN,
-    QUERY_KEYS.REPOSITORIES_ALL,
     QUERY_KEYS.RECENT_REPOS,
     QUERY_KEYS.QUALITY_HEALTH,
   ],


### PR DESCRIPTION
## Summary

Fixes #669.

The same repository-list data was fetched under 6+ distinct TanStack Query cache keys (`repositories-all`, `admin-repositories`, `repositories-for-scan`, `repositories-list`, `repositories-for-packages`, plus ad-hoc `["repositories", ...]` variants), so identical `per_page: 1000` fetches lived in 5 separate cache entries and SSE-driven invalidation had to enumerate every variant in `query-keys.ts` — any new variant silently broke invalidation.

**Design chosen: one canonical key family + prefix invalidation.** A new shared hook, `useRepositories(params, { enabled })` in `src/hooks/use-repositories.ts`, issues every list query under the param-scoped key `["repositories", params]` (via the exported `repositoryListKey` factory). TanStack hashes object key segments deterministically, so all five `per_page: 1000` call sites now share a single cache entry, and prefix invalidation on `QUERY_KEYS.REPOSITORIES` catches every variant. The deprecated `REPOSITORIES_LIST` / `REPOSITORIES_FOR_SCAN` / `REPOSITORIES_ALL` constants were removed from the `QUERY_KEYS` registry and the `repositories` invalidation group (6 keys → 3).

15 call sites migrated, with identical params, `enabled` gates, and consumed data shapes:

- `["repositories-all"]` (per_page 1000): `virtual-members-panel.tsx`, `curation/page.tsx`, `curation-rules-manager.tsx`, `promotion-rules/page.tsx`
- `["admin-repositories"]` (per_page 1000): `permissions/page.tsx`
- `["repositories-for-scan"]`: `security/page.tsx` and `security/scans/page.tsx` — the two verbatim-duplicated 10-line `queryFn`s with the `(data as any)?.items ?? data ?? []` cast are deleted; both pages now consume the adapted `PaginatedResponse<Repository>` like every other caller (also dropped the raw-SDK `listRepositories` imports and the now-unneeded file-level `eslint-disable no-explicit-any`)
- `["repositories-list"]` (per_page 100/200): `search-content.tsx`, `replication/page.tsx`
- Ad-hoc keys: `packages/page.tsx` (`repositories-for-packages`), `setup/page.tsx` (bare `["repositories"]`), `lifecycle/page.tsx`, `security/policies/page.tsx`, `release-target-settings.tsx`, and the main `repositories-content.tsx` list (now keyed by its real params object instead of positional segments)

Intentionally out of scope: `dashboard-content.tsx` keeps its registered `["recent-repositories"]` key — it is semantically distinct (dashboard "recent repos" widget), already centrally registered and invalidated, and no other site fetches `per_page: 5`, so there is no dedup win.

**Relation to #684 (fix/668):** #684 is still open and param-scopes the `repositories-list` keys in `search-content.tsx` and `replication/page.tsx` as `[...QUERY_KEYS.REPOSITORIES_LIST, { per_page: N }]`. This PR supersedes that param-scoping: those two call sites are migrated to `useRepositories`, and the `REPOSITORIES_LIST` constant #684 builds on is removed. Whichever merges second will conflict in those two files + `query-keys.ts`; merging #684 first is fine (this PR subsumes it), or #684 can be closed in favor of this one.

## Test Checklist

- [x] Unit tests added/updated — new `src/hooks/__tests__/use-repositories.test.ts` (key factory, param passthrough, `enabled` forwarding); `query-keys.test.ts` updated for the slimmed registry (17 → 14 constants, repositories group 6 → 3 keys, plus a prefix-invariant test); page tests updated for the new key family (curation ×2, promotion-rules, security dashboard, search-content, repositories-content/page mock exports)
- [ ] E2E Playwright tests added/updated — N/A, no behavior change (same params, same `enabled` gates, same rendered data)
- [x] Manually tested locally — `npm run build` (Next.js production build) passes
- [x] No regressions in existing tests — full `vitest run`: **162 files / 3020 tests passed**; `eslint` on all changed files: 0 errors, no new warnings; `tsc --noEmit`: only the 23 pre-existing errors in unrelated test files

## UI Changes

- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [x] N/A - no UI changes