### PR TITLE
test(e2e): adopt backend 1.7.0 grouped-metadata format in maven grouped browser spec (#665)

### DIFF
--- a/e2e/suites/interactions/repositories/maven-grouped-browser.spec.ts
+++ b/e2e/suites/interactions/repositories/maven-grouped-browser.spec.ts
@@ -14,6 +14,23 @@ import { test, expect, type APIRequestContext } from '@playwright/test';
  * Strategy mirrors artifact-download.spec.ts: seed artifacts through the API,
  * then drive the real UI.  The repository `e2e-maven-local` is created by the
  * E2E seed step.
+ *
+ * Seeding note (issue #665): backend 1.7.0 (ak#2723) serves hosted grouped
+ * listings from the package catalog — component keys are the catalog's
+ * `(packages.name = groupId:artifactId, package_versions.version)` pairs, and
+ * each page's files are resolved under the real
+ * `<groupId>/<artifactId>/<version>/` directory.  The generic
+ * `/api/v1/repositories/:key/artifacts/*path` upload derives name/version from
+ * the first two path segments (`com` / `example` for a Maven layout), so files
+ * seeded that way land in the catalog under a bogus version whose component
+ * key matches no files and is dropped — the grouped browser then renders its
+ * empty state.  Seed through the Maven-native deploy endpoint (`PUT
+ * /maven/:key/*path`, the same endpoint `mvn deploy` uses) so the catalog
+ * records real GAV coordinates.  Exception: the checksum sidecar — the native
+ * endpoint stores `.sha1` files row-less (no artifact row), so the #445 file
+ * listing would never see it; that one file still goes through the generic
+ * API, which does create an artifact row that the grouped listing picks up by
+ * path.
  */
 test.describe('Maven Grouped Browser (#443, #444, #445)', () => {
   const REPO_KEY = 'e2e-maven-local';
@@ -43,6 +60,28 @@ test.describe('Maven Grouped Browser (#443, #444, #445)', () => {
   }
 
   /**
+   * PUT one file through the Maven-native deploy endpoint (the same route
+   * `mvn deploy` uses) so the backend records the real GAV coordinates in the
+   * package catalog that the 1.7.0 grouped listing is built from (#665).
+   */
+  async function putMaven(
+    request: APIRequestContext,
+    relPath: string,
+    body: string,
+  ): Promise<void> {
+    const resp = await request.put(`/maven/${REPO_KEY}/${relPath}`, {
+      data: body,
+      headers: { 'Content-Type': 'application/octet-stream' },
+    });
+    // Same 409 tolerance as `put`: redeploying an existing non-SNAPSHOT
+    // coordinate conflicts, and that is fine for these read-oriented tests.
+    expect(
+      resp.ok() || resp.status() === 409,
+      `PUT /maven ${relPath} failed: ${resp.status()}`,
+    ).toBeTruthy();
+  }
+
+  /**
    * Deploy `count` distinct GAV components (one artifact + pom each) so the
    * grouped listing has more than one page at the default page size of 20.
    * Returns the list of artifactIds created.
@@ -56,8 +95,8 @@ test.describe('Maven Grouped Browser (#443, #444, #445)', () => {
       const artifactId = `lib-${i}`;
       const version = '1.0.0';
       const base = `${GROUP_PATH}/${artifactId}/${version}/${artifactId}-${version}`;
-      await put(request, `${base}.jar`, `jar-${i}`);
-      await put(request, `${base}.pom`, `<project>${i}</project>`);
+      await putMaven(request, `${base}.jar`, `jar-${i}`);
+      await putMaven(request, `${base}.pom`, `<project>${i}</project>`);
       ids.push(artifactId);
     }
     return ids;
@@ -80,9 +119,12 @@ test.describe('Maven Grouped Browser (#443, #444, #445)', () => {
       `${artifactId}-${version}.zip`,
       `${artifactId}-${version}.jar.sha1`,
     ];
-    await put(request, `${base}.pom`, '<project>zip</project>');
-    await put(request, `${base}.jar`, 'jar-bytes');
-    await put(request, `${base}.zip`, 'zip-bytes');
+    await putMaven(request, `${base}.pom`, '<project>zip</project>');
+    await putMaven(request, `${base}.jar`, 'jar-bytes');
+    await putMaven(request, `${base}.zip`, 'zip-bytes');
+    // The Maven-native endpoint stores checksum sidecars row-less (no artifact
+    // row), which would hide the file from the grouped listing #445 asserts
+    // on — seed it through the generic API instead (see the header comment).
     await put(request, `${base}.jar.sha1`, 'abc123');
     return { artifactId, files };
   }


### PR DESCRIPTION
## Summary

Fixes #665

The E2E test `maven-grouped-browser.spec.ts:121` ("#443: grouped mode renders pagination when there are many components") fails deterministically on main's CI (run 30664895087, shard 3/3) and is the only red check blocking otherwise-green PRs.

**Root cause (web-1.6.0-vs-backend-1.7.0 skew):** the E2E stack runs `BACKEND_TAG=dev`. Backend 1.7.0 (artifact-keeper#2723) replaced the in-memory grouped listing with a SQL keyset over the **package catalog**: component keys are `(packages.name = groupId:artifactId, package_versions.version)` pairs, and each page's files are then resolved under the real `<groupId>/<artifactId>/<version>/` directory. Keys whose catalog version doesn't match a real GAV directory resolve to zero files and are dropped.

The spec seeded artifacts through the **generic** `PUT /api/v1/repositories/:key/artifacts/*path` endpoint, which derives name/version from the first two path segments — for a Maven layout `com/example/gNNN/lib-0/1.0.0/...` that's `com` / `example`. The catalog name is normalized to `groupId:artifactId` on the write path, but the version stays `example`, so every seeded component's catalog key matched no files and the grouped listing came back empty. The UI correctly rendered its empty state; `data-testid="maven-component-list"` never appeared.

**Fix:** seed through the **Maven-native deploy endpoint** `PUT /maven/:key/*path` (the same route `mvn deploy` uses), which records real GAV coordinates in the catalog. One exception: the `.jar.sha1` checksum sidecar in `seedGavWithZip` — the native endpoint stores checksums row-less (no artifact row), which would hide the file from the grouped listing that #445 asserts on, so that one file still goes through the generic API (its artifact row is picked up by path). No assertions were weakened; the UI component is unchanged because the 1.7.0 response shape (`components[]` of GAV groups) is unchanged — only the catalog contract behind it changed.

## Test Checklist

- [x] Unit tests added/updated — N/A (no src/ changes); related unit tests pass: `maven-component-list.test.tsx`, `maven.test.ts`, `maven-component-path.test.ts` (37/37 via `npx vitest run`)
- [x] E2E Playwright tests added/updated — this spec
- [ ] Manually tested locally — **the full E2E cannot run locally here (needs the Docker backend stack); E2E verification depends on CI.** Verified locally: `npx eslint` clean on the changed file, `npx tsc --noEmit` shows only the 23 pre-existing errors in unrelated files (none in this spec)
- [x] No regressions in existing tests — #444/#445 keep their self-skip fallbacks; the `.jar.sha1` seeding path is unchanged

## UI Changes

- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [x] N/A - no UI changes

## Notes

- `maven-gav-search-pom.spec.ts` (#442 grouped-POM test) seeds through the same generic endpoint and currently self-skips its grouped assertions for the same reason. Left untouched here to keep this PR minimal and un-block CI; it can adopt the same `putMaven` seeding in the broader 1.7.0 web catch-up.
- The issue's interim option (pinning `BACKEND_TAG` to a 1.6.x tag) was not taken: this PR adopts the 1.7.0 reality instead, keeping the dev-backend coverage.