### PR TITLE
fix(age-gate): direct re-decide for decided reviews, fix reopened-row display (#698)

### DIFF
--- a/src/app/(app)/(admin)/age-gate/page.test.tsx
+++ b/src/app/(app)/(admin)/age-gate/page.test.tsx
@@ -25,7 +25,7 @@ const mutationConfigs: MutationConfig[] = [];
 const mutateFns: Array<ReturnType<typeof vi.fn>> = [];
 const mockInvalidate = vi.fn();
 let reviewsData: { data: unknown; isLoading?: boolean; isError?: boolean; error?: unknown } = {
-  data: [],
+  data: { items: [], total: 0 },
   isLoading: false,
 };
 let repoConfigsData: unknown = {};
@@ -83,20 +83,7 @@ const api = {
 };
 vi.mock("@/lib/api/age-gate", () => {
   // Declared inside the factory (vi.mock is hoisted) and re-imported below, so
-  // the page's `instanceof` check and the tests share one class. Constructor
-  // signature matches the real one.
-  class AgeGatePartialTransitionError extends Error {
-    constructor(
-      readonly currentStatus: string,
-      readonly intendedStatus: string,
-      readonly failure: unknown,
-    ) {
-      super(
-        `The review was reopened but could not be ${intendedStatus}. It is now ${currentStatus}.`,
-      );
-      this.name = "AgeGatePartialTransitionError";
-    }
-  }
+  // the page and the tests share one class.
   class ReopenUnsupportedError extends Error {
     constructor() {
       super("This server does not support reopening a decided age gate review.");
@@ -105,7 +92,6 @@ vi.mock("@/lib/api/age-gate", () => {
   }
   return {
   AGE_GATE_STATUSES: ["pending", "approved", "rejected"],
-  AgeGatePartialTransitionError,
   ReopenUnsupportedError,
   isReopenSupported: () => capability.reopenSupported,
   subscribeReopenSupport: () => () => {},
@@ -161,7 +147,7 @@ vi.mock("@/components/ui/select", () => ({
   SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => <option value={value}>{children}</option>,
 }));
 
-import { AgeGatePartialTransitionError, ReopenUnsupportedError } from "@/lib/api/age-gate";
+import { ReopenUnsupportedError } from "@/lib/api/age-gate";
 import AgeGatePage from "./page";
 
 const REVIEW = {
@@ -195,7 +181,7 @@ beforeEach(() => {
   mutateFns.length = 0;
   vi.clearAllMocks();
   isAdmin = true;
-  reviewsData = { data: [], isLoading: false };
+  reviewsData = { data: { items: [], total: 0 }, isLoading: false };
   repoConfigsData = {};
   usersData = [];
   capability.reopenSupported = true;
@@ -212,7 +198,7 @@ describe("AgeGatePage", () => {
   it("shows the empty queue by default (pending)", () => {
     render(<AgeGatePage />);
     expect(screen.getByText(/No pending releases/i)).toBeInTheDocument();
-    expect(api.listReviews).toHaveBeenCalledWith({ statuses: ["pending"] });
+    expect(api.listReviews).toHaveBeenCalledWith({ statuses: ["pending"], perPage: 100 });
   });
 
   it("shows an error state with retry", () => {
@@ -228,7 +214,7 @@ describe("AgeGatePage", () => {
   });
 
   it("lists held releases with age-at-request and repository", () => {
-    reviewsData = { data: [REVIEW], isLoading: false };
+    reviewsData = { data: { items: [REVIEW], total: 1 }, isLoading: false };
     repoConfigsData = { "npm-remote": { repositoryKey: "npm-remote", enabled: true, minAgeDays: 14 } };
     render(<AgeGatePage />);
     expect(screen.getByText("leftpad-clone")).toBeInTheDocument();
@@ -240,7 +226,7 @@ describe("AgeGatePage", () => {
     const user = userEvent.setup();
     render(<AgeGatePage />);
     await user.click(screen.getByLabelText("Show approved"));
-    expect(api.listReviews).toHaveBeenLastCalledWith({ statuses: ["pending", "approved"] });
+    expect(api.listReviews).toHaveBeenLastCalledWith({ statuses: ["pending", "approved"], perPage: 100 });
   });
 
   it("makes no request and says so when every status is unticked", async () => {
@@ -253,7 +239,7 @@ describe("AgeGatePage", () => {
 
   describe("decision metadata", () => {
     it("shows the recorded reason, the reviewer's name and the decision date", () => {
-      reviewsData = { data: [APPROVED_REVIEW], isLoading: false };
+      reviewsData = { data: { items: [APPROVED_REVIEW], total: 1 }, isLoading: false };
       usersData = [
         { id: "11111111-2222-3333-4444-555555555555", username: "sam", display_name: "Sam Reviewer" },
       ];
@@ -263,28 +249,47 @@ describe("AgeGatePage", () => {
       // Rendered in the viewer's local zone, so assert the shape and keep the
       // exact instant on the title attribute.
       expect(screen.getByTitle("2026-07-21T00:00:00Z")).toHaveTextContent(/on Jul \d+, 2026/);
-      expect(mockListUsers).toHaveBeenCalled();
+      expect(mockListUsers).toHaveBeenCalledWith({ perPage: 100 });
     });
 
     it("falls back to a shortened user id when the reviewer is not in the user list", () => {
-      reviewsData = { data: [APPROVED_REVIEW], isLoading: false };
+      reviewsData = { data: { items: [APPROVED_REVIEW], total: 1 }, isLoading: false };
       usersData = [];
       render(<AgeGatePage />);
       expect(screen.getByText(/11111111…/)).toBeInTheDocument();
     });
 
     it("marks a pending review as not yet decided", () => {
-      reviewsData = { data: [REVIEW], isLoading: false };
+      reviewsData = { data: { items: [REVIEW], total: 1 }, isLoading: false };
       render(<AgeGatePage />);
       expect(screen.getByText(/Not yet decided/i)).toBeInTheDocument();
       expect(mockListUsers).not.toHaveBeenCalled();
+    });
+
+    it("marks a reopened review as not yet decided even though the backend leaves reviewer metadata on it", () => {
+      // Reopen sets reviewed_by to the reopening admin with reviewed_at = NOW()
+      // and keeps the reopen reason; the row is still pending and must not
+      // read as decided.
+      const reopened = {
+        ...APPROVED_REVIEW,
+        status: "pending",
+        reviewReason: "approved the wrong package",
+      };
+      reviewsData = { data: { items: [reopened], total: 1 }, isLoading: false };
+      usersData = [
+        { id: "11111111-2222-3333-4444-555555555555", username: "sam", display_name: "Sam Reviewer" },
+      ];
+      render(<AgeGatePage />);
+      expect(screen.getByText(/Not yet decided/i)).toBeInTheDocument();
+      expect(screen.queryByText(/Sam Reviewer/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/approved the wrong package/)).not.toBeInTheDocument();
     });
   });
 
   describe("status control", () => {
     it("confirms before approving, spelling out that the version gets released", async () => {
       const user = userEvent.setup();
-      reviewsData = { data: [REVIEW], isLoading: false };
+      reviewsData = { data: { items: [REVIEW], total: 1 }, isLoading: false };
       render(<AgeGatePage />);
       await user.selectOptions(screen.getByLabelText("Status for leftpad-clone"), "approved");
       const dialog = await screen.findByRole("dialog");
@@ -297,7 +302,7 @@ describe("AgeGatePage", () => {
 
     it("lets a pending review be rejected without a reason", async () => {
       const user = userEvent.setup();
-      reviewsData = { data: [REVIEW], isLoading: false };
+      reviewsData = { data: { items: [REVIEW], total: 1 }, isLoading: false };
       render(<AgeGatePage />);
       await user.selectOptions(screen.getByLabelText("Status for leftpad-clone"), "rejected");
       const dialog = await screen.findByRole("dialog");
@@ -307,7 +312,7 @@ describe("AgeGatePage", () => {
 
     it("requires a reason to reverse a recorded decision", async () => {
       const user = userEvent.setup();
-      reviewsData = { data: [APPROVED_REVIEW], isLoading: false };
+      reviewsData = { data: { items: [APPROVED_REVIEW], total: 1 }, isLoading: false };
       render(<AgeGatePage />);
       await user.selectOptions(screen.getByLabelText("Status for leftpad-clone"), "pending");
       const dialog = await screen.findByRole("dialog");
@@ -325,19 +330,21 @@ describe("AgeGatePage", () => {
       });
     });
 
-    it("says a decided-to-decided change runs in two steps and can stop at pending", async () => {
+    it("says a decided-to-decided change is a single step that reverses the recorded decision", async () => {
       const user = userEvent.setup();
-      reviewsData = { data: [APPROVED_REVIEW], isLoading: false };
+      reviewsData = { data: { items: [APPROVED_REVIEW], total: 1 }, isLoading: false };
       render(<AgeGatePage />);
       await user.selectOptions(screen.getByLabelText("Status for leftpad-clone"), "rejected");
       const dialog = await screen.findByRole("dialog");
-      expect(within(dialog).getByText(/two steps/i)).toBeInTheDocument();
-      expect(within(dialog).getByText(/left pending, not approved/i)).toBeInTheDocument();
+      expect(
+        within(dialog).getByText(/reverses the recorded approved decision and marks the review rejected instead, in a single step/i),
+      ).toBeInTheDocument();
+      expect(within(dialog).queryByText(/two steps/i)).not.toBeInTheDocument();
     });
 
     it("clears the reason when the dialog is cancelled", async () => {
       const user = userEvent.setup();
-      reviewsData = { data: [REVIEW], isLoading: false };
+      reviewsData = { data: { items: [REVIEW], total: 1 }, isLoading: false };
       render(<AgeGatePage />);
       const control = screen.getByLabelText("Status for leftpad-clone");
       await user.selectOptions(control, "approved");
@@ -360,7 +367,7 @@ describe("AgeGatePage", () => {
       );
 
     it("says nothing about the capability when the endpoint is there", () => {
-      reviewsData = { data: [APPROVED_REVIEW], isLoading: false };
+      reviewsData = { data: { items: [APPROVED_REVIEW], total: 1 }, isLoading: false };
       render(<AgeGatePage />);
       expect(screen.queryByText(/does not support reopening/i)).not.toBeInTheDocument();
       expect(optionsOf("Status for leftpad-clone")).toEqual({
@@ -372,19 +379,19 @@ describe("AgeGatePage", () => {
 
     it("explains the gap and offers no reopen-dependent transition on a decided review", () => {
       capability.reopenSupported = false;
-      reviewsData = { data: [APPROVED_REVIEW], isLoading: false };
+      reviewsData = { data: { items: [APPROVED_REVIEW], total: 1 }, isLoading: false };
       render(<AgeGatePage />);
       expect(screen.getByText(/does not support reopening a decided review/i)).toBeInTheDocument();
       expect(optionsOf("Status for leftpad-clone")).toEqual({
         pending: true, // needs reopen
         approved: false, // the status it is already in
-        rejected: true, // needs reopen, then reject
+        rejected: true, // a backend without reopen also predates direct re-decide
       });
     });
 
     it("still offers approve and reject on a pending review", () => {
       capability.reopenSupported = false;
-      reviewsData = { data: [REVIEW], isLoading: false };
+      reviewsData = { data: { items: [REVIEW], total: 1 }, isLoading: false };
       render(<AgeGatePage />);
       expect(optionsOf("Status for leftpad-clone")).toEqual({
         pending: false,
@@ -396,7 +403,7 @@ describe("AgeGatePage", () => {
     it("submits an approval normally even though reopen is unavailable", async () => {
       const user = userEvent.setup();
       capability.reopenSupported = false;
-      reviewsData = { data: [REVIEW], isLoading: false };
+      reviewsData = { data: { items: [REVIEW], total: 1 }, isLoading: false };
       render(<AgeGatePage />);
       await user.selectOptions(screen.getByLabelText("Status for leftpad-clone"), "approved");
       const dialog = await screen.findByRole("dialog");
@@ -407,11 +414,7 @@ describe("AgeGatePage", () => {
     it("surfaces the capability message rather than a raw 404", () => {
       render(<AgeGatePage />);
       const [change] = mutationConfigs;
-      change.onError?.(new ReopenUnsupportedError(), {
-        review: APPROVED_REVIEW,
-        target: "rejected",
-        why: "cve landed",
-      });
+      change.onError?.(new ReopenUnsupportedError());
       expect(mockToastError).toHaveBeenCalledWith(
         "This server does not support reopening a decided age gate review.",
       );
@@ -435,29 +438,11 @@ describe("AgeGatePage", () => {
       expect(mockToastSuccess).toHaveBeenCalledWith("Returned to pending leftpad-clone@0.0.1");
     });
 
-    it("reports a half-completed reopen-then-decide as pending, and refetches", () => {
-      render(<AgeGatePage />);
-      const [change] = mutationConfigs;
-      const partial = new AgeGatePartialTransitionError("pending", "rejected", {
-        status: 500,
-        message: "boom",
-      });
-      change.onError?.(partial, { review: APPROVED_REVIEW, target: "rejected", why: "cve landed" });
-
-      // The review really did move, so the table must be refetched rather than
-      // left showing the approved state the operator started from.
-      expect(mockInvalidate).toHaveBeenCalled();
-      const message = mockToastError.mock.calls[0][0] as string;
-      expect(message).toMatch(/leftpad-clone@0\.0\.1/);
-      expect(message).toMatch(/reopened but could not be rejected/i);
-      expect(message).toMatch(/now pending/i);
-      expect(message).toMatch(/boom/);
-      expect(mockToastSuccess).not.toHaveBeenCalled();
-    });
-
     it("leaves the queue alone when a transition fails outright", () => {
       render(<AgeGatePage />);
       const [change] = mutationConfigs;
+      // A transition is a single call now, so a failure means the review
+      // never moved: no refetch, no reconcile, just the error.
       change.onError?.(new Error("API error 403: forbidden"), {
         review: APPROVED_REVIEW,
         target: "rejected",
@@ -465,6 +450,20 @@ describe("AgeGatePage", () => {
       });
       expect(mockInvalidate).not.toHaveBeenCalled();
       expect(mockToastError).toHaveBeenCalledWith("API error 403: forbidden");
+    });
+  });
+
+  describe("truncation notice", () => {
+    it("warns when the server reports more reviews than the page fetched", () => {
+      reviewsData = { data: { items: [REVIEW], total: 240 }, isLoading: false };
+      render(<AgeGatePage />);
+      expect(screen.getByText(/Showing first 1 of 240/)).toBeInTheDocument();
+    });
+
+    it("stays hidden when every matching review is on the page", () => {
+      reviewsData = { data: { items: [REVIEW], total: 1 }, isLoading: false };
+      render(<AgeGatePage />);
+      expect(screen.queryByText(/Showing first/)).not.toBeInTheDocument();
     });
   });
 });

--- a/src/app/(app)/(admin)/age-gate/page.tsx
+++ b/src/app/(app)/(admin)/age-gate/page.tsx
@@ -10,7 +10,6 @@ import { toast } from "sonner";
 import {
   ageGateApi,
   AGE_GATE_STATUSES,
-  AgeGatePartialTransitionError,
   isReopenSupported,
   subscribeReopenSupport,
   type AgeGateReview,
@@ -27,6 +26,7 @@ import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { ListTruncationNotice } from "@/components/common/list-truncation-notice";
 import {
   Select,
   SelectTrigger,
@@ -71,8 +71,11 @@ function transitionVerb(target: AgeGateStatus): string {
 }
 
 /**
- * Whether moving `from` to `to` has to reopen the review first. Only a review
- * that already carries a decision does; a pending one is decided outright.
+ * Whether moving `from` to `to` needs a backend with the reopen endpoint.
+ * Reopen is only called for transitions TO pending, but the backend that
+ * shipped it (artifact-keeper#2968) is also the one that allowed direct
+ * re-decide of a decided review — so a backend without reopen rejects every
+ * transition out of a decided status, and all of them are gated on it.
  */
 function needsReopen(from: string, to: AgeGateStatus): boolean {
   return from !== "pending" && from !== to;
@@ -80,7 +83,7 @@ function needsReopen(from: string, to: AgeGateStatus): boolean {
 
 /**
  * What a transition will do, said plainly enough that an admin can tell a
- * one-call decision from a reopen-then-decide before they commit to it.
+ * first decision from a reversal before they commit to it.
  */
 function describeTransition(from: string, to: AgeGateStatus): string {
   if (from === "pending") {
@@ -91,7 +94,7 @@ function describeTransition(from: string, to: AgeGateStatus): string {
   if (to === "pending") {
     return `This reverses the recorded ${from} decision and puts the version back behind the gate until someone decides it again.`;
   }
-  return `This runs in two steps: the recorded ${from} decision is reversed first, then the review is ${to}. If the second step fails the review is left pending, not ${from}.`;
+  return `This reverses the recorded ${from} decision and marks the review ${to} instead, in a single step.`;
 }
 
 export default function AgeGatePage() {
@@ -106,21 +109,21 @@ export default function AgeGatePage() {
   const [reason, setReason] = useState("");
 
   // Latched off the first time the endpoint 404s, so a backend without
-  // artifact-keeper#2939 stops being offered transitions it cannot perform.
+  // artifact-keeper#2968 stops being offered transitions it cannot perform.
   const reopenSupported = useSyncExternalStore(
     subscribeReopenSupport,
     isReopenSupported,
     isReopenSupported,
   );
 
-  // A reopen carries a mandatory reason, and every transition out of a decided
-  // status starts with one. Deciding a pending review does not.
+  // Reversing a recorded decision always requires a reason for the audit
+  // log; deciding a pending review for the first time does not.
   const reasonRequired = transition !== null && transition.review.status !== "pending";
   const reasonMissing = reasonRequired && reason.trim() === "";
 
   const statusKey = [...statuses].sort().join(",");
   const {
-    data: reviews,
+    data: reviewPage,
     isLoading,
     isError,
     error,
@@ -128,11 +131,13 @@ export default function AgeGatePage() {
     isFetching,
   } = useQuery({
     queryKey: ["age-gate-reviews", statusKey],
-    queryFn: () => ageGateApi.listReviews({ statuses }),
+    // Capped page without pagination; the truncation notice below surfaces it
+    // when the server's total exceeds what this one fetch returned.
+    queryFn: () => ageGateApi.listReviews({ statuses, perPage: 100 }),
     enabled: !!user?.is_admin && statuses.length > 0,
   });
 
-  const rows = useMemo(() => reviews ?? [], [reviews]);
+  const rows = useMemo(() => reviewPage?.items ?? [], [reviewPage]);
   const repositoryKeys = useMemo(() => [...new Set(rows.map((r) => r.repositoryKey))], [rows]);
 
   const { data: repoConfigs } = useQuery({
@@ -142,12 +147,12 @@ export default function AgeGatePage() {
   });
 
   // The review carries the reviewer's user id and nothing else, so the names
-  // come from the admin user list. A failed lookup degrades to a short id
-  // rather than hiding who decided.
+  // come from the admin user list. Only the first page is fetched: a reviewer
+  // beyond it degrades to a shortened id rather than hiding who decided.
   const hasReviewers = rows.some((r) => r.reviewedBy);
   const { data: users } = useQuery({
     queryKey: ["age-gate-reviewers"],
-    queryFn: () => adminApi.listUsers(),
+    queryFn: () => adminApi.listUsers({ perPage: 100 }),
     enabled: !!user?.is_admin && hasReviewers,
   });
   const reviewerNames = useMemo(() => {
@@ -191,20 +196,7 @@ export default function AgeGatePage() {
         `${transitionVerb(target)} ${review.packageName}@${review.packageVersion}`,
       );
     },
-    onError: (err, { review }) => {
-      // A half-completed reopen-then-decide really did change the review, so
-      // refetch and say what it is now. Reporting a plain failure here would
-      // leave the operator believing the old decision still stands.
-      if (err instanceof AgeGatePartialTransitionError) {
-        invalidate();
-        closeDialog();
-        toast.error(
-          `${review.packageName}@${review.packageVersion}: ${err.message} ${toUserMessage(err.failure, "The second step failed.")}`,
-        );
-        return;
-      }
-      mutationErrorToast("Age gate review failed")(err);
-    },
+    onError: mutationErrorToast("Age gate review failed"),
   });
 
   if (!user?.is_admin) {
@@ -326,7 +318,10 @@ export default function AgeGatePage() {
                   </td>
                   <td className="px-3 py-2 text-xs text-muted-foreground">{formatDate(r.requestedAt)}</td>
                   <td className="px-3 py-2 text-xs text-muted-foreground">
-                    {r.reviewedBy || r.reviewedAt || r.reviewReason ? (
+                    {/* Keyed off status, not reviewer metadata: the backend
+                        leaves reviewed_by/reviewed_at set on a reopened
+                        (pending) row, pointing at the admin who reopened it. */}
+                    {r.status !== "pending" && (r.reviewedBy || r.reviewedAt || r.reviewReason) ? (
                       <div className="max-w-xs space-y-0.5">
                         {(r.reviewedBy || r.reviewedAt) && (
                           <div>
@@ -380,6 +375,8 @@ export default function AgeGatePage() {
           </table>
         </div>
       )}
+
+      <ListTruncationNotice shown={rows.length} total={reviewPage?.total ?? 0} />
 
       <Dialog open={transition !== null} onOpenChange={(o) => { if (!o) closeDialog(); }}>
         <DialogContent>

--- a/src/lib/api/__tests__/admin.test.ts
+++ b/src/lib/api/__tests__/admin.test.ts
@@ -80,6 +80,13 @@ describe("adminApi", () => {
     ]);
   });
 
+  it("listUsers passes pagination params through to the SDK query", async () => {
+    mockListUsers.mockResolvedValue({ data: { items: [], pagination: {} }, error: undefined });
+    const { adminApi } = await import("../admin");
+    await adminApi.listUsers({ perPage: 100 });
+    expect(mockListUsers).toHaveBeenCalledWith({ query: { page: undefined, per_page: 100 } });
+  });
+
   it("listUsers throws on error", async () => {
     mockListUsers.mockResolvedValue({ data: undefined, error: "unauthorized" });
     const { adminApi } = await import("../admin");

--- a/src/lib/api/__tests__/age-gate.test.ts
+++ b/src/lib/api/__tests__/age-gate.test.ts
@@ -31,7 +31,6 @@ vi.mock("@artifact-keeper/sdk", () => ({
 import { ApiError } from "../fetch";
 import {
   ageGateApi,
-  AgeGatePartialTransitionError,
   ReopenUnsupportedError,
   isReopenSupported,
   resetReopenSupport,
@@ -77,14 +76,14 @@ beforeEach(() => {
 describe("ageGateApi", () => {
   it("listReviews sends the status filter and maps results, computing age at request", async () => {
     m.listReviews.mockResolvedValue({
-      data: { items: [REVIEW], pagination: { page: 1, per_page: 20, total: 1 } },
+      data: { items: [REVIEW], pagination: { page: 1, per_page: 100, total: 1 } },
       error: undefined,
     });
-    const out = await ageGateApi.listReviews({ statuses: ["pending"] });
+    const out = await ageGateApi.listReviews({ statuses: ["pending"], perPage: 100 });
     expect(m.listReviews).toHaveBeenCalledWith({
-      query: { status: "pending", repository_key: undefined, page: undefined, per_page: undefined },
+      query: { status: "pending", repository_key: undefined, page: undefined, per_page: 100 },
     });
-    expect(out[0]).toMatchObject({
+    expect(out.items[0]).toMatchObject({
       id: "rv1",
       packageName: "leftpad-clone",
       packageVersion: "0.0.1",
@@ -92,6 +91,17 @@ describe("ageGateApi", () => {
       status: "pending",
       ageDaysAtRequest: 5,
     });
+    expect(out.total).toBe(1);
+  });
+
+  it("listReviews surfaces the server-reported total so callers can spot truncation", async () => {
+    m.listReviews.mockResolvedValue({
+      data: { items: [REVIEW], pagination: { page: 1, per_page: 100, total: 240 } },
+      error: undefined,
+    });
+    const out = await ageGateApi.listReviews({ perPage: 100 });
+    expect(out.items).toHaveLength(1);
+    expect(out.total).toBe(240);
   });
 
   it("listReviews throws on error", async () => {
@@ -105,7 +115,7 @@ describe("ageGateApi", () => {
       error: undefined,
     });
     const out = await ageGateApi.listReviews();
-    expect(out[0].ageDaysAtRequest).toBeNull();
+    expect(out.items[0].ageDaysAtRequest).toBeNull();
   });
 
   it("getReview / approveReview / rejectReview pass the id path param and an optional reason", async () => {
@@ -126,7 +136,7 @@ describe("ageGateApi", () => {
   });
 
   it("listReviews joins several statuses into one comma-separated filter", async () => {
-    m.listReviews.mockResolvedValue({ data: { items: [], pagination: {} }, error: undefined });
+    m.listReviews.mockResolvedValue({ data: { items: [], pagination: { page: 1, per_page: 20, total: 0 } }, error: undefined });
     await ageGateApi.listReviews({ statuses: ["approved", "rejected"] });
     expect(m.listReviews).toHaveBeenCalledWith({
       query: { status: "approved,rejected", repository_key: undefined, page: undefined, per_page: undefined },
@@ -134,7 +144,7 @@ describe("ageGateApi", () => {
   });
 
   it("listReviews omits the status filter entirely when no statuses are given", async () => {
-    m.listReviews.mockResolvedValue({ data: { items: [], pagination: {} }, error: undefined });
+    m.listReviews.mockResolvedValue({ data: { items: [], pagination: { page: 1, per_page: 20, total: 0 } }, error: undefined });
     await ageGateApi.listReviews({ statuses: [] });
     expect(m.listReviews.mock.calls[0][0].query.status).toBeUndefined();
   });
@@ -163,55 +173,64 @@ describe("ageGateApi", () => {
     expect(out.status).toBe("approved");
   });
 
-  it("changeReviewStatus reopens a decided review on its way to the other decision", async () => {
-    mockApiFetch.mockResolvedValue({ ...REVIEW, status: "pending" });
+  it("changeReviewStatus re-decides a decided review with a single direct call, no reopen", async () => {
     m.rejectReview.mockResolvedValue({ data: { ...REVIEW, status: "rejected" }, error: undefined });
     const out = await ageGateApi.changeReviewStatus(
       { ...LOCAL_REVIEW, status: "approved" },
       "rejected",
       "cve landed",
     );
-    expect(mockApiFetch).toHaveBeenCalledWith("/api/v1/admin/age-gate/reviews/rv1/reopen", {
-      method: "POST",
-      body: JSON.stringify({ reason: "cve landed" }),
-    });
+    // Never a pending halfway state: the version is never un-gated mid-flip.
+    expect(mockApiFetch).not.toHaveBeenCalled();
+    expect(m.approveReview).not.toHaveBeenCalled();
+    expect(m.rejectReview).toHaveBeenCalledTimes(1);
     expect(m.rejectReview).toHaveBeenCalledWith({ path: { id: "rv1" }, body: { reason: "cve landed" } });
     expect(out.status).toBe("rejected");
   });
 
-  it("changeReviewStatus stops after the reopen when the target is pending", async () => {
+  it("changeReviewStatus re-decides rejected back to approved directly", async () => {
+    m.approveReview.mockResolvedValue({ data: { ...REVIEW, status: "approved" }, error: undefined });
+    const out = await ageGateApi.changeReviewStatus(
+      { ...LOCAL_REVIEW, status: "rejected" },
+      "approved",
+      "false positive",
+    );
+    expect(mockApiFetch).not.toHaveBeenCalled();
+    expect(m.approveReview).toHaveBeenCalledWith({ path: { id: "rv1" }, body: { reason: "false positive" } });
+    expect(out.status).toBe("approved");
+  });
+
+  it("changeReviewStatus goes through reopen only when the target is pending", async () => {
     mockApiFetch.mockResolvedValue({ ...REVIEW, status: "pending" });
     const out = await ageGateApi.changeReviewStatus(
       { ...LOCAL_REVIEW, status: "approved" },
       "pending",
       "needs another look",
     );
+    expect(mockApiFetch).toHaveBeenCalledWith("/api/v1/admin/age-gate/reviews/rv1/reopen", {
+      method: "POST",
+      body: JSON.stringify({ reason: "needs another look" }),
+    });
     expect(m.approveReview).not.toHaveBeenCalled();
     expect(m.rejectReview).not.toHaveBeenCalled();
     expect(out.status).toBe("pending");
   });
 
-  it("changeReviewStatus reports the review as pending when the reopen lands but the decision fails", async () => {
-    mockApiFetch.mockResolvedValue({ ...REVIEW, status: "pending" });
+  it("changeReviewStatus surfaces a failed re-decide as an ordinary error, with no state change", async () => {
     m.rejectReview.mockResolvedValue({ data: undefined, error: { status: 500 } });
-    const err = await ageGateApi
-      .changeReviewStatus({ ...LOCAL_REVIEW, status: "approved" }, "rejected", "cve landed")
-      .catch((e: unknown) => e);
-    expect(err).toBeInstanceOf(AgeGatePartialTransitionError);
-    const partial = err as AgeGatePartialTransitionError;
-    expect(partial.currentStatus).toBe("pending");
-    expect(partial.intendedStatus).toBe("rejected");
-    expect(partial.failure).toEqual({ status: 500 });
-    expect(partial.message).toMatch(/reopened but could not be rejected.*now pending/i);
+    await expect(
+      ageGateApi.changeReviewStatus({ ...LOCAL_REVIEW, status: "approved" }, "rejected", "cve landed"),
+    ).rejects.toEqual({ status: 500 });
+    // A single failed call means the review is still approved; nothing to
+    // reconcile and no halfway state to report.
+    expect(mockApiFetch).not.toHaveBeenCalled();
   });
 
-  it("changeReviewStatus surfaces a failed reopen as an ordinary error, not a partial transition", async () => {
+  it("changeReviewStatus surfaces a failed reopen as an ordinary error", async () => {
     mockApiFetch.mockRejectedValue(new Error("API error 403: forbidden"));
-    const err = await ageGateApi
-      .changeReviewStatus({ ...LOCAL_REVIEW, status: "approved" }, "rejected", "cve landed")
-      .catch((e: unknown) => e);
-    expect(err).not.toBeInstanceOf(AgeGatePartialTransitionError);
-    expect(m.rejectReview).not.toHaveBeenCalled();
+    await expect(
+      ageGateApi.changeReviewStatus({ ...LOCAL_REVIEW, status: "approved" }, "pending", "needs another look"),
+    ).rejects.toThrow(/403/);
   });
 
   it("changeReviewStatus refuses a no-op transition to the status already recorded", async () => {
@@ -263,21 +282,37 @@ describe("ageGateApi", () => {
       expect(isReopenSupported()).toBe(true);
     });
 
-    it("blocks a reopen-dependent transition without touching either endpoint", async () => {
+    it("blocks a return to pending without touching the endpoint once it is known to be absent", async () => {
       mockApiFetch.mockRejectedValue(missingEndpoint());
       await ageGateApi.reopenReview("rv1", "probe").catch(() => {});
       mockApiFetch.mockClear();
 
-      const err = await ageGateApi
-        .changeReviewStatus({ ...LOCAL_REVIEW, status: "approved" }, "rejected", "cve landed")
-        .catch((e: unknown) => e);
-
-      expect(err).toBeInstanceOf(ReopenUnsupportedError);
-      // Nothing was attempted, so this is not a partial transition: the review
-      // is still exactly where the operator found it.
-      expect(err).not.toBeInstanceOf(AgeGatePartialTransitionError);
+      await expect(
+        ageGateApi.changeReviewStatus({ ...LOCAL_REVIEW, status: "approved" }, "pending", "needs another look"),
+      ).rejects.toBeInstanceOf(ReopenUnsupportedError);
+      // Nothing was attempted: the review is still exactly where the operator
+      // found it.
       expect(mockApiFetch).not.toHaveBeenCalled();
+      expect(m.approveReview).not.toHaveBeenCalled();
       expect(m.rejectReview).not.toHaveBeenCalled();
+    });
+
+    it("still re-decides a decided review directly when reopen is unsupported", async () => {
+      mockApiFetch.mockRejectedValue(missingEndpoint());
+      await ageGateApi.reopenReview("rv1", "probe").catch(() => {});
+      expect(isReopenSupported()).toBe(false);
+
+      // The direct decide endpoints exist on every backend; only a backend
+      // old enough to lack reopen also rejects the re-decide server-side,
+      // and that error surfaces as an ordinary failure.
+      m.rejectReview.mockResolvedValue({ data: { ...REVIEW, status: "rejected" }, error: undefined });
+      const out = await ageGateApi.changeReviewStatus(
+        { ...LOCAL_REVIEW, status: "approved" },
+        "rejected",
+        "cve landed",
+      );
+      expect(out.status).toBe("rejected");
+      expect(mockApiFetch).toHaveBeenCalledTimes(1); // the probe only
     });
 
     it("still decides a pending review when reopen is unsupported", async () => {

--- a/src/lib/api/admin.ts
+++ b/src/lib/api/admin.ts
@@ -104,8 +104,10 @@ export const adminApi = {
     return adaptStats(assertData(data, 'adminApi.getStats'));
   },
 
-  listUsers: async (): Promise<User[]> => {
-    const data = await unwrap(listUsers());
+  listUsers: async (params: { page?: number; perPage?: number } = {}): Promise<User[]> => {
+    const data = await unwrap(listUsers({
+      query: { page: params.page, per_page: params.perPage },
+    }));
     return assertData(data, 'adminApi.listUsers').items.map(adaptUser);
   },
 

--- a/src/lib/api/age-gate.ts
+++ b/src/lib/api/age-gate.ts
@@ -44,9 +44,11 @@ export interface AgeGateReview {
   reviewReason: string | null;
   reviewedAt: string | null;
   /**
-   * User id of the admin who decided, not a username. Null on a pending
-   * review, including one that was reopened: the backend clears the reviewer
-   * so a reopened row does not read as already handled.
+   * User id of the admin who last acted on the review, not a username. The
+   * backend does NOT clear this on reopen: reopening sets it to the
+   * reopening admin with `reviewed_at = NOW()`, so a reopened row is pending
+   * yet still carries reviewer metadata. Key "decided or not" off `status`,
+   * never off this field.
    */
   reviewedBy: string | null;
 }
@@ -141,35 +143,6 @@ function isMissingEndpoint(err: unknown): boolean {
   }
 }
 
-/**
- * Raised when a status change that took two calls completed the first and
- * failed on the second.
- *
- * Moving a decided review straight to the other decision is reopen followed by
- * approve or reject. If the second call fails the review is not in the status
- * the operator saw when they picked, and it is not in the one they asked for
- * either: it is pending, and the gate is back on. Reporting a plain failure
- * would leave them believing the original decision still stands.
- */
-export class AgeGatePartialTransitionError extends Error {
-  /** What the review is actually in now. */
-  readonly currentStatus: AgeGateStatus;
-  /** What the operator asked for and did not get. */
-  readonly intendedStatus: AgeGateStatus;
-  /** Whatever the failing second call threw, for the underlying detail. */
-  readonly failure: unknown;
-
-  constructor(currentStatus: AgeGateStatus, intendedStatus: AgeGateStatus, failure: unknown) {
-    super(
-      `The review was reopened but could not be ${intendedStatus === 'approved' ? 'approved' : 'rejected'}. It is now ${currentStatus}.`,
-    );
-    this.name = 'AgeGatePartialTransitionError';
-    this.currentStatus = currentStatus;
-    this.intendedStatus = intendedStatus;
-    this.failure = failure;
-  }
-}
-
 /** A repository's age gate policy: hold releases younger than `minAgeDays`. */
 export interface AgeGateRepoConfig {
   repositoryKey: string;
@@ -211,9 +184,16 @@ function adaptConfig(sdk: AgeGateConfigResponse): AgeGateRepoConfig {
   };
 }
 
+/** One page of the review queue plus the server-reported total across pages. */
+export interface AgeGateReviewPage {
+  items: AgeGateReview[];
+  /** Total matching reviews on the server; larger than `items.length` when the page was truncated. */
+  total: number;
+}
+
 export const ageGateApi = {
   /** List package versions in the age gate review queue. */
-  listReviews: async (params: ListAgeGateReviewsParams = {}): Promise<AgeGateReview[]> => {
+  listReviews: async (params: ListAgeGateReviewsParams = {}): Promise<AgeGateReviewPage> => {
     const data = await unwrap(listReviews({
       query: {
         status: params.statuses?.length ? params.statuses.join(',') : undefined,
@@ -222,7 +202,11 @@ export const ageGateApi = {
         per_page: params.perPage,
       },
     }));
-    return assertData(data, 'ageGateApi.listReviews').items.map(adaptReview);
+    const response = assertData(data, 'ageGateApi.listReviews');
+    return {
+      items: response.items.map(adaptReview),
+      total: response.pagination.total,
+    };
   },
 
   getReview: async (id: string): Promise<AgeGateReview> => {
@@ -245,10 +229,10 @@ export const ageGateApi = {
    * version is withheld again until someone decides it a second time.
    *
    * Goes through `apiFetch` because `reopen` is not in the generated SDK yet.
-   * The reason is required and non-blank here as well as on the server, since
-   * a blank one costs a round trip to learn nothing, and the reopen is the one
-   * action whose audit entry has nothing else to say why a recorded decision
-   * was reversed.
+   * The reason is required and non-blank here; the server accepts a blank one
+   * (`reason` is `Option<String>` and goes unvalidated), so the guard lives
+   * client-side. Reopen is the one action whose audit entry has nothing else
+   * to say why a recorded decision was reversed.
    */
   reopenReview: async (id: string, reason: string): Promise<AgeGateReview> => {
     const why = reason.trim();
@@ -273,14 +257,14 @@ export const ageGateApi = {
   },
 
   /**
-   * Move a review to `target`, whatever it is in now.
+   * Move a review to `target`, whatever it is in now, with a single call.
    *
-   * Approve and reject only accept a pending review, so changing a decision
-   * means reopening first and deciding second. That is two calls presented as
-   * one action, and the halfway state is real: if the second call fails the
-   * review sits at `pending` rather than at either end. That case throws
-   * `AgeGatePartialTransitionError` so the caller can say what actually
-   * happened instead of reporting the whole thing as a no-op.
+   * The backend accepts approve and reject from any status but the one
+   * already recorded (artifact-keeper#2968 relaxed the pending-only guard to
+   * "no no-op transitions"), so changing a decision is one direct decide
+   * call — never reopen-then-decide, which would briefly leave the review
+   * pending and un-gate a version that has aged past `min_age_days`. Only a
+   * transition TO `pending` goes through `reopenReview`.
    */
   changeReviewStatus: async (
     review: AgeGateReview,
@@ -292,27 +276,13 @@ export const ageGateApi = {
       throw new Error(`This review is already ${target}.`);
     }
 
-    const decide = (id: string) =>
-      target === 'approved'
-        ? ageGateApi.approveReview(id, why || undefined)
-        : ageGateApi.rejectReview(id, why || undefined);
-
-    if (review.status === 'pending') {
-      // target cannot be 'pending' here: the equality guard above covers it.
-      return decide(review.id);
+    if (target === 'pending') {
+      return ageGateApi.reopenReview(review.id, why);
     }
 
-    // Outside the try below on purpose: a reopen that never happened, whether
-    // because the endpoint is missing or for any other reason, leaves the
-    // review exactly as it was. Only a failure after a successful reopen is a
-    // partial transition.
-    const reopened = await ageGateApi.reopenReview(review.id, why);
-    if (target === 'pending') return reopened;
-    try {
-      return await decide(review.id);
-    } catch (failure) {
-      throw new AgeGatePartialTransitionError('pending', target, failure);
-    }
+    return target === 'approved'
+      ? ageGateApi.approveReview(review.id, why || undefined)
+      : ageGateApi.rejectReview(review.id, why || undefined);
   },
 
   /**


### PR DESCRIPTION
## Summary

Fixes #698

Follow-up to the post-merge review of #655. Verified against the shipped backend before changing anything:

- **Direct re-decide is supported.** `require_distinct_status` (`backend/src/services/age_gate_service.rs:190`) refuses only same-status no-ops; `approve` (`:586`) and `reject` (`:620`) accept a review in any other status, including the opposite decision (artifact-keeper#2968).
- **Reopen does not clear the reviewer.** `reopen` (`:655`) sets `reviewed_by` to the reopening admin with `reviewed_at = NOW()` (`:668`), so a reopened pending row still carries reviewer metadata.

Changes:

- **decided→decided is now a single direct `approveReview`/`rejectReview` call** in `ageGateApi.changeReviewStatus`; `reopenReview` is only used for →pending transitions. This closes the transient exposure window where an approved→rejected flip briefly left the version pending — and thus downloadable once past `min_age_days`. The `AgeGatePartialTransitionError` halfway-state machinery is gone: a single failed call leaves the review exactly where it was.
- **Decision cell keys off `status`, not reviewer metadata**: a reopened (pending) row renders "Not yet decided" even though the backend leaves `reviewed_by`/`reviewed_at`/`review_reason` set on it. Fixed the wrong `reviewedBy` docblock in `src/lib/api/age-gate.ts` and the "reason validated on the server" claim in the `reopenReview` docblock (the backend takes `reason` as unvalidated `Option<String>`).
- **Review queue fetches `perPage: 100`** (backend max; default was 20) and renders the shared `ListTruncationNotice` from the pagination total; `ageGateApi.listReviews` now returns `{ items, total }`. The reviewer-name lookup calls `adminApi.listUsers({ perPage: 100 })` with a comment noting that a reviewer beyond the first page degrades to a shortened id.
- **Kept the `ReopenUnsupportedError` 404-body capability heuristic**: it is still reachable for →pending transitions against pre-#2968 backends. Since that backend release shipped both the reopen endpoint and the relaxed re-decide guard, a backend without reopen also rejects direct re-decide, so transitions out of a decided status stay disabled when the capability latches off (rationale documented on `needsReopen`). Also corrected the stale `#2939` reference to `#2968`.

## Test Checklist

- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [ ] Manually tested locally
- [x] No regressions in existing tests

Unit tests updated to the new contract: single direct call for re-decide (no reopen, no halfway state), reopen only for →pending, reopened-pending rows render "Not yet decided", truncation notice shown/hidden from the server total, `listUsers` pagination passthrough. Full suite: 167 files / 3077 tests pass; `npx eslint` clean on changed files; `npx tsc --noEmit` shows only the 23 pre-existing baseline errors (audit/blast-radius/docker-grouping tests, none in changed files); `npm run build` succeeds.

## UI Changes

- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [x] N/A - no UI changes

Dialog copy and Decision-cell rendering changes are covered by the jsdom page tests; no layout, styling, or interaction-pattern changes.
