### PR TITLE
fix(quarantine): align listing badges with shipped backend contract (#697)

### DIFF
--- a/src/app/(app)/repositories/_components/__tests__/docker-tag-list.test.tsx
+++ b/src/app/(app)/repositories/_components/__tests__/docker-tag-list.test.tsx
@@ -54,8 +54,8 @@ function art(overrides: Partial<Artifact> & Pick<Artifact, "path" | "id">): Arti
     download_count: 0,
     created_at: "2026-04-10T12:00:00Z",
     // The tag list is built from the repository artifacts listing, which
-    // carries a quarantine verdict on every row (artifact-keeper#2940).
-    is_blocked: false,
+    // serializes `quarantine_status` on every row (artifact-keeper#2966).
+    quarantine_status: "not_quarantined",
     ...overrides,
   };
 }
@@ -175,9 +175,9 @@ describe("DockerTagList", () => {
   it("renders a QuarantineBadge for quarantined manifests", () => {
     const qTag = {
       ...TAG_14,
-      is_blocked: true,
+      // The shipped listing shape: the verdict, and the expiry for a timed
+      // hold — never `is_blocked`, never the reason (artifact-keeper#2966).
       quarantine_status: "quarantined",
-      quarantine_reason: "vulnerability",
       quarantine_until: "2099-01-01T00:00:00Z",
     };
     render(<DockerTagList artifacts={[qTag]} />);
@@ -186,9 +186,9 @@ describe("DockerTagList", () => {
   });
 
   it("does not claim OK when the response carried no quarantine verdict", () => {
-    // Absent is not false: a manifest whose quarantine state was never loaded
-    // must not be reported as clean (#650).
-    const unknown = { ...TAG_14, is_blocked: undefined };
+    // Absent is not clear: a manifest whose quarantine state was never loaded
+    // (older backend) must not be reported as clean (#650).
+    const unknown = { ...TAG_14, quarantine_status: undefined };
     render(<DockerTagList artifacts={[unknown]} />);
     expect(screen.queryByText("OK")).not.toBeInTheDocument();
     expect(screen.queryByTestId("quarantine-badge")).not.toBeInTheDocument();

--- a/src/app/(app)/repositories/_components/__tests__/repo-detail-quarantine.test.tsx
+++ b/src/app/(app)/repositories/_components/__tests__/repo-detail-quarantine.test.tsx
@@ -205,12 +205,23 @@ vi.mock("@/components/common/copy-button", () => ({ CopyButton: () => <div /> })
 
 import { RepoDetailContent } from "../repo-detail-content";
 
+// A listing row for a held artifact, exactly as the shipped backend
+// serializes it (artifact-keeper#2966): the verdict and the timed-hold expiry,
+// never `is_blocked`, never the reason.
 const HELD = {
   ...BASE_ARTIFACT,
+  quarantine_status: "quarantined",
+  quarantine_until: "2099-01-01T00:00:00Z",
+};
+
+// The status endpoint's answer for the same artifact: the only surface that
+// discloses the reason, and only to callers who hold the repository (#2912).
+const HELD_STATUS = {
+  artifact_id: "a1",
   is_blocked: true,
   quarantine_status: "quarantined",
-  quarantine_reason: "Policy block-critical: 3 critical findings",
   quarantine_until: "2099-01-01T00:00:00Z",
+  quarantine_reason: "Policy block-critical: 3 critical findings",
 };
 
 async function openDetailDialog() {
@@ -239,11 +250,22 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("artifact detail dialog — quarantine banner reachability", () => {
-  it("shows the banner for an artifact the listing reports as blocked", async () => {
+  it("shows the banner for an artifact the listing reports as held", async () => {
     artifactRow = HELD;
     await openDetailDialog();
 
     expect(screen.getByText("This artifact is quarantined")).toBeInTheDocument();
+  });
+
+  it("lazy-fetches the reason for a held artifact, which the listing never carries", async () => {
+    artifactRow = HELD;
+    quarantineStatusData = HELD_STATUS;
+    await openDetailDialog();
+
+    // Blocked is not clear, so the dialog asks the status endpoint for the
+    // reason rather than rendering the hold unexplained.
+    expect(quarantineStatusQuery()?.enabled).toBe(true);
+    expect(quarantineStatusQuery()?.queryKey).toEqual(["quarantine-status", "a1"]);
     // Banner and the Quarantine detail row both carry it.
     expect(
       screen.getAllByText("Policy block-critical: 3 critical findings").length,
@@ -251,7 +273,7 @@ describe("artifact detail dialog — quarantine banner reachability", () => {
   });
 
   it("shows no banner when the listing reports the artifact as clear", async () => {
-    artifactRow = { ...BASE_ARTIFACT, is_blocked: false, quarantine_status: null };
+    artifactRow = { ...BASE_ARTIFACT, quarantine_status: "not_quarantined" };
     await openDetailDialog();
 
     expect(screen.queryByText("This artifact is quarantined")).not.toBeInTheDocument();
@@ -260,10 +282,11 @@ describe("artifact detail dialog — quarantine banner reachability", () => {
   });
 
   it("renders the banner without a reason when the reason was redacted", async () => {
-    // Present status, absent reason: the caller cannot access the repository,
+    // Blocked verdict, absent reason: the caller cannot access the repository,
     // so the backend withholds the policy detail but not the verdict.
-    artifactRow = {
-      ...BASE_ARTIFACT,
+    artifactRow = HELD;
+    quarantineStatusData = {
+      artifact_id: "a1",
       is_blocked: true,
       quarantine_status: "quarantined",
       quarantine_until: "2099-01-01T00:00:00Z",
@@ -281,12 +304,13 @@ describe("artifact detail dialog — quarantine banner reachability", () => {
   });
 
   it("uses terminal wording and offers no admin action for a rejected artifact", async () => {
-    artifactRow = {
-      ...BASE_ARTIFACT,
+    artifactRow = { ...BASE_ARTIFACT, quarantine_status: "rejected" };
+    quarantineStatusData = {
+      artifact_id: "a1",
       is_blocked: true,
       quarantine_status: "rejected",
-      quarantine_reason: "Confirmed malware",
       quarantine_until: null,
+      quarantine_reason: "Confirmed malware",
     };
     await openDetailDialog();
 
@@ -299,10 +323,11 @@ describe("artifact detail dialog — quarantine banner reachability", () => {
 });
 
 describe("artifact detail dialog — absent quarantine state is not a clean bill of health", () => {
-  it("looks the verdict up when the response carried no quarantine fields", async () => {
-    // The by-path detail endpoint omits all four keys. Absent means the server
-    // did not look, so the dialog asks rather than assuming the artifact is
-    // fine — the collapse that made the banner dead code in the first place.
+  it("looks the verdict up when the response carried no quarantine status", async () => {
+    // An older backend serializes no `quarantine_status` at all. Absent means
+    // the server did not look, so the dialog asks rather than assuming the
+    // artifact is fine — the collapse that made the banner dead code in the
+    // first place.
     artifactRow = { ...BASE_ARTIFACT };
     await openDetailDialog();
 

--- a/src/app/(app)/repositories/_components/docker-tag-list.tsx
+++ b/src/app/(app)/repositories/_components/docker-tag-list.tsx
@@ -217,8 +217,9 @@ export function DockerTagList({
                 </td>
                 <td className="px-3 py-2">
                   {isActivelyQuarantined(group.manifest) ? (
+                    // The listing carries no reason (#2966); the badge
+                    // tooltip falls back to the hold expiry.
                     <QuarantineBadge
-                      reason={group.manifest.quarantine_reason}
                       quarantineUntil={group.manifest.quarantine_until}
                     />
                   ) : isQuarantineStateKnown(group.manifest) ? (

--- a/src/app/(app)/repositories/_components/repo-detail-content.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.tsx
@@ -36,7 +36,7 @@ import { mutationErrorToast } from "@/lib/error-utils";
 import {
   isActivelyQuarantined,
   isQuarantineRejected,
-  isQuarantineStateKnown,
+  quarantineKnowledge,
   quarantineDownloadBlockedReason,
   type QuarantineFields,
 } from "@/lib/quarantine";
@@ -257,27 +257,29 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
 
   // --- quarantine state for the artifact in the detail dialog ---
   //
-  // Listing rows carry a quarantine verdict on every artifact
-  // (artifact-keeper#2940), so an artifact opened from the table already has
-  // one and costs no extra request. An artifact opened from the Maven grouped
-  // view arrives through the by-path detail endpoint instead, which omits the
-  // four quarantine keys entirely. Absent means "the server did not look", not
-  // "not held" — reading it as the latter is what left the quarantine banner
-  // unreachable (#650) — so that case is resolved with an explicit status
-  // lookup rather than assumed clean.
+  // Every current artifact payload (listing, by-id, by-path) carries the
+  // verdict as `quarantine_status` (artifact-keeper#2966), but never the
+  // *reason* — that is disclosed only by the authenticated,
+  // repo-visibility-checked GET /api/v1/quarantine/{id} (#2912). So the
+  // status endpoint is queried exactly when the dialog has something to gain
+  // from it: the artifact is held (the reason is worth showing) or the
+  // payload carried no verdict at all (older backend — absent means "the
+  // server did not look", not "not held"; reading it as the latter is what
+  // left the quarantine banner unreachable, #650). A clear artifact costs no
+  // extra request.
   const selectedArtifactId = selectedArtifact?.id;
-  const selectedQuarantineLoaded = isQuarantineStateKnown(selectedArtifact);
+  const selectedKnowledge = quarantineKnowledge(selectedArtifact);
   const { data: fetchedQuarantine } = useQuery({
     queryKey: ["quarantine-status", selectedArtifactId],
     queryFn: async () =>
       selectedArtifactId ? await quarantineApi.getStatus(selectedArtifactId) : null,
-    enabled: detailOpen && !!selectedArtifactId && !selectedQuarantineLoaded,
+    enabled: detailOpen && !!selectedArtifactId && selectedKnowledge !== "clear",
   });
+  // Prefer the fetched status once it lands: it carries the reason and a
+  // freshly computed verdict, while the listing row only has the verdict.
   const quarantine: QuarantineFields | null = !selectedArtifact
     ? null
-    : selectedQuarantineLoaded
-      ? selectedArtifact
-      : (fetchedQuarantine ?? null);
+    : (fetchedQuarantine ?? selectedArtifact);
   const quarantineBlocked = isActivelyQuarantined(quarantine);
   // A rejection is terminal: the backend only accepts
   // `quarantined -> released|rejected`, so offering either on an already
@@ -366,25 +368,24 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
       action === "release"
         ? quarantineApi.release(artifactId)
         : quarantineApi.reject(artifactId, reason || undefined),
-    onSuccess: (_result, { artifactId, action, reason }) => {
+    onSuccess: (_result, { artifactId, action }) => {
       // The listing row for this artifact now carries a stale verdict, as does
       // any cached status lookup for it.
       queryClient.invalidateQueries({ queryKey: ["artifacts", repoKey] });
       queryClient.invalidateQueries({ queryKey: ["quarantine-status", artifactId] });
       // Apply the same transition the backend just wrote to the copy the open
       // dialog holds: both transitions clear `quarantine_until`, a release
-      // clears the reason, a rejection keeps or replaces it. Without this the
-      // dialog would keep describing the old hold until it was closed and
-      // reopened, and the refetched listing would silently disagree with it.
+      // moves the status to "released", a rejection to "rejected". The status
+      // lookup above was invalidated and refetches the reason on its own.
+      // Without this the dialog would keep describing the old hold until it
+      // was closed and reopened, and the refetched listing would silently
+      // disagree with it.
       setSelectedArtifact((prev) =>
         prev && prev.id === artifactId
           ? {
               ...prev,
-              is_blocked: action === "reject",
               quarantine_status: action === "release" ? "released" : "rejected",
               quarantine_until: null,
-              quarantine_reason:
-                action === "release" ? null : reason || prev.quarantine_reason,
             }
           : prev,
       );
@@ -510,10 +511,9 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
             {a.name}
           </button>
           {isActivelyQuarantined(a) && (
-            <QuarantineBadge
-              reason={a.quarantine_reason}
-              quarantineUntil={a.quarantine_until}
-            />
+            // The listing carries no reason (#2966); the badge tooltip falls
+            // back to the hold expiry.
+            <QuarantineBadge quarantineUntil={a.quarantine_until} />
           )}
         </div>
       ),

--- a/src/lib/__tests__/quarantine.test.ts
+++ b/src/lib/__tests__/quarantine.test.ts
@@ -36,23 +36,31 @@ describe("quarantineKnowledge", () => {
     vi.useRealTimers();
   });
 
-  // The regression behind #650: the backend omits all four quarantine keys on
-  // surfaces that never load quarantine state, so "the server did not look"
-  // and "the server looked and it is fine" must stay distinguishable.
-  it("reports unknown when is_blocked is absent, not clear", () => {
+  // The shipped contract (artifact-keeper#2966) always serializes
+  // `quarantine_status` on artifact payloads; an absent status means the
+  // response came from an older backend that never looked. The regression
+  // behind #650: "the server did not look" and "the server looked and it is
+  // fine" must stay distinguishable.
+  it("reports unknown when quarantine_status is absent, not clear", () => {
     expect(quarantineKnowledge(makeArtifact())).toBe("unknown");
     expect(isQuarantineStateKnown(makeArtifact())).toBe(false);
   });
 
-  it("reports clear when is_blocked is explicitly false", () => {
-    const artifact = makeArtifact({ is_blocked: false });
+  it("reports clear for the explicit not_quarantined default", () => {
+    const artifact = makeArtifact({ quarantine_status: "not_quarantined" });
     expect(quarantineKnowledge(artifact)).toBe("clear");
     expect(isQuarantineStateKnown(artifact)).toBe(true);
   });
 
-  it("does not treat an absent field as a false one", () => {
+  it("reports clear for the scan-lifecycle states", () => {
+    for (const status of ["clean", "flagged", "unscanned", "released"]) {
+      expect(quarantineKnowledge(makeArtifact({ quarantine_status: status }))).toBe("clear");
+    }
+  });
+
+  it("does not treat an absent field as a clear one", () => {
     const absent = makeArtifact();
-    const looked = makeArtifact({ is_blocked: false });
+    const looked = makeArtifact({ quarantine_status: "not_quarantined" });
     // Both are "not blocked" ...
     expect(isActivelyQuarantined(absent)).toBe(false);
     expect(isActivelyQuarantined(looked)).toBe(false);
@@ -62,10 +70,12 @@ describe("quarantineKnowledge", () => {
     expect(isQuarantineStateKnown(looked)).toBe(true);
   });
 
-  it("treats a null is_blocked as unknown", () => {
-    // The contract omits the key rather than nulling it, but a deployment that
-    // sends null must not read as "the server looked and it is fine".
-    expect(quarantineKnowledge({ is_blocked: null })).toBe("unknown");
+  it("treats a null or empty status as unknown", () => {
+    // The status endpoint serializes `quarantine_status: null` for an artifact
+    // with no recorded state; that must not read as "the server looked and it
+    // is fine" either.
+    expect(quarantineKnowledge({ quarantine_status: null })).toBe("unknown");
+    expect(quarantineKnowledge({ quarantine_status: "" })).toBe("unknown");
   });
 
   it("reports unknown for a missing source", () => {
@@ -73,10 +83,16 @@ describe("quarantineKnowledge", () => {
     expect(quarantineKnowledge(undefined)).toBe("unknown");
   });
 
-  it("reports unknown when a status is present but the verdict is not", () => {
-    // Cannot happen under the contract (the four fields travel together), but
-    // a status without the verdict must not silently read as downloadable.
-    expect(quarantineKnowledge({ quarantine_status: "quarantined" })).toBe("unknown");
+  it("reports blocked for a live hold", () => {
+    expect(
+      quarantineKnowledge(makeArtifact({ quarantine_status: "quarantined" })),
+    ).toBe("blocked");
+  });
+
+  it("reports blocked for a rejection", () => {
+    expect(
+      quarantineKnowledge(makeArtifact({ quarantine_status: "rejected" })),
+    ).toBe("blocked");
   });
 });
 
@@ -90,21 +106,25 @@ describe("isActivelyQuarantined", () => {
     vi.useRealTimers();
   });
 
-  it("returns false when is_blocked is undefined", () => {
+  it("returns false when quarantine_status is undefined", () => {
     expect(isActivelyQuarantined(makeArtifact())).toBe(false);
   });
 
-  it("returns false when is_blocked is false", () => {
-    expect(isActivelyQuarantined(makeArtifact({ is_blocked: false }))).toBe(false);
+  it("returns false for a clear status", () => {
+    expect(
+      isActivelyQuarantined(makeArtifact({ quarantine_status: "not_quarantined" })),
+    ).toBe(false);
   });
 
-  it("returns true when is_blocked is true with no expiry", () => {
-    expect(isActivelyQuarantined(makeArtifact({ is_blocked: true }))).toBe(true);
+  it("returns true for a hold with no expiry", () => {
+    expect(
+      isActivelyQuarantined(makeArtifact({ quarantine_status: "quarantined" })),
+    ).toBe(true);
   });
 
-  it("returns true when is_blocked is true and quarantine_until is null", () => {
+  it("returns true for a hold with quarantine_until null", () => {
     const artifact = makeArtifact({
-      is_blocked: true,
+      quarantine_status: "quarantined",
       quarantine_until: null,
     });
     expect(isActivelyQuarantined(artifact)).toBe(true);
@@ -112,15 +132,18 @@ describe("isActivelyQuarantined", () => {
 
   it("returns true when quarantine_until is in the future", () => {
     const artifact = makeArtifact({
-      is_blocked: true,
+      quarantine_status: "quarantined",
       quarantine_until: "2026-04-20T00:00:00Z",
     });
     expect(isActivelyQuarantined(artifact)).toBe(true);
   });
 
-  it("returns false when quarantine_until has passed since the response was rendered", () => {
+  it("returns false when a timed hold has lapsed since the response was rendered", () => {
+    // Same semantics as the backend's check_download_allowed: the row keeps
+    // the "quarantined" label until the background job transitions it, but an
+    // expired hold no longer blocks downloads.
     const artifact = makeArtifact({
-      is_blocked: true,
+      quarantine_status: "quarantined",
       quarantine_until: "2026-04-10T00:00:00Z",
     });
     expect(isActivelyQuarantined(artifact)).toBe(false);
@@ -128,7 +151,7 @@ describe("isActivelyQuarantined", () => {
 
   it("stays blocked when quarantine_until is unparseable", () => {
     const artifact = makeArtifact({
-      is_blocked: true,
+      quarantine_status: "quarantined",
       quarantine_until: "not-a-date",
     });
     expect(isActivelyQuarantined(artifact)).toBe(true);
@@ -136,11 +159,18 @@ describe("isActivelyQuarantined", () => {
 
   it("keeps a rejected artifact blocked (the backend clears quarantine_until on reject)", () => {
     const artifact = makeArtifact({
-      is_blocked: true,
       quarantine_status: "rejected",
       quarantine_until: null,
     });
     expect(isActivelyQuarantined(artifact)).toBe(true);
+  });
+
+  it("ignores a stray quarantine_until on a clear status", () => {
+    const artifact = makeArtifact({
+      quarantine_status: "not_quarantined",
+      quarantine_until: "2099-01-01T00:00:00Z",
+    });
+    expect(isActivelyQuarantined(artifact)).toBe(false);
   });
 });
 
@@ -167,7 +197,7 @@ describe("quarantineDownloadBlockedReason", () => {
   });
 
   it("falls back to the hold wording when the status is absent", () => {
-    expect(quarantineDownloadBlockedReason({ is_blocked: true })).toBe(
+    expect(quarantineDownloadBlockedReason({})).toBe(
       QUARANTINE_HOLD_DOWNLOAD_REASON,
     );
   });

--- a/src/lib/api/artifacts.ts
+++ b/src/lib/api/artifacts.ts
@@ -35,8 +35,10 @@ export interface ListArtifactsParams {
 }
 
 // Local Artifact extends ArtifactResponse with quarantine fields the SDK
-// doesn't model yet. The repository artifacts listing populates all four
-// (artifact-keeper#2940); every other artifact surface omits them.
+// doesn't model yet. Every artifact surface (listing, by-id, by-path)
+// serializes `quarantine_status` — and `quarantine_until` for timed holds —
+// since artifact-keeper#2966; the reason is never on the listing and is
+// disclosed only by GET /api/v1/quarantine/{id}.
 function adaptArtifact(sdk: ArtifactResponse): Artifact {
   // The backend ships new optional fields (cache_cached_at, cache_expires_at)
   // via artifact-keeper#1541, but the generated SDK type doesn't carry them
@@ -49,10 +51,8 @@ function adaptArtifact(sdk: ArtifactResponse): Artifact {
     cache_cached_at?: string | null;
     cache_expires_at?: string | null;
     analyzable?: boolean;
-    is_blocked?: boolean;
     quarantine_status?: string | null;
     quarantine_until?: string | null;
-    quarantine_reason?: string | null;
   };
   return {
     id: sdk.id,
@@ -69,14 +69,12 @@ function adaptArtifact(sdk: ArtifactResponse): Artifact {
     cache_cached_at: sdkAny.cache_cached_at ?? undefined,
     cache_expires_at: sdkAny.cache_expires_at ?? undefined,
     // Copied through verbatim, including absence. `??` is deliberately not
-    // used on is_blocked: coercing a missing verdict to `false` here is
-    // exactly the collapse that made the quarantine banner unreachable
-    // (#650). Absent stays absent and `@/lib/quarantine` reads it as "the
-    // server did not look".
-    is_blocked: sdkAny.is_blocked,
+    // used: coercing a missing status to a state here is exactly the collapse
+    // that made the quarantine banner unreachable (#650). Absent stays absent
+    // and `@/lib/quarantine` reads it as "the server did not look" (older
+    // backend), never as "clear".
     quarantine_status: sdkAny.quarantine_status,
     quarantine_until: sdkAny.quarantine_until,
-    quarantine_reason: sdkAny.quarantine_reason,
     // Default to `true` when the backend omits the field (older responses /
     // not-yet-regenerated SDK): only an explicit `false` disables SBOM/scan
     // for an artifact (artifact-keeper#2292). Matches the backend's safe

--- a/src/lib/api/quarantine.ts
+++ b/src/lib/api/quarantine.ts
@@ -39,9 +39,10 @@ function quarantinePath(artifactId: string, action?: string): string {
 }
 
 /**
- * The backend takes `reason` as an optional field of a required JSON body, so
- * the key is always sent; a blank or whitespace-only reason becomes null
- * rather than an empty string the audit log would have to store.
+ * The backend deserializes the body with a required JSON extractor, so a body
+ * is always sent; `reason` itself is optional, and a blank or whitespace-only
+ * reason becomes null rather than an empty string the audit log would have to
+ * store.
  */
 function reasonBody(reason?: string): string {
   const trimmed = reason?.trim();
@@ -50,10 +51,11 @@ function reasonBody(reason?: string): string {
 
 export const quarantineApi = {
   /**
-   * Read one artifact's quarantine state. Needed for artifacts reached through
-   * a surface that does not carry the quarantine fields (the by-path detail
-   * endpoint behind the Maven grouped view, for instance), where their absence
-   * means "not loaded" rather than "not held".
+   * Read one artifact's quarantine state, including the reason. Artifact
+   * payloads carry the verdict (`quarantine_status`) but never the reason
+   * (artifact-keeper#2966), so this is the only way to show why a held
+   * artifact is held — and the fallback verdict source for a response from
+   * a backend too old to serialize `quarantine_status` at all.
    */
   getStatus: (artifactId: string): Promise<QuarantineStatus> =>
     apiFetch<QuarantineStatus>(quarantinePath(artifactId)),

--- a/src/lib/quarantine.ts
+++ b/src/lib/quarantine.ts
@@ -1,36 +1,48 @@
 /**
- * The quarantine columns exactly as the backend serializes them
- * (artifact-keeper#2940).
+ * The quarantine fields an artifact payload may carry, exactly as the shipped
+ * backend serializes them (artifact-keeper#2966; listing side #2940).
  *
- * Every field is optional because all four are emitted with
- * `skip_serializing_if = "Option::is_none"`: they are present on every row of
- * the repository artifacts listing and on the quarantine status endpoint, and
- * *absent* on the surfaces that never load quarantine state (the by-id and
- * by-path artifact endpoints, version history, the upload response,
- * proxy-cache rows).
+ * `quarantine_status` is present on every artifact surface that loads
+ * quarantine state — the repository artifacts listing, the by-id and the
+ * by-path artifact responses — as one of:
  *
- * Absent is not the same as `false`. Absent means the server did not look;
- * `false` means it looked and the artifact is downloadable. Reading the two as
- * one falsy check is what left the quarantine banner unreachable (#650), so
- * the distinction is expressed explicitly in `quarantineKnowledge` and every
+ * - `"quarantined"` — held; downloads refused until `quarantine_until` lapses,
+ * - `"rejected"` — terminally blocked by an admin,
+ * - a scan-lifecycle state (`"clean"` / `"flagged"` / `"unscanned"` /
+ *   `"released"`),
+ * - `"not_quarantined"` — the explicit default, so a client never has to
+ *   treat a missing value as a state.
+ *
+ * `quarantine_until` travels only with a timed hold
+ * (`skip_serializing_if = "Option::is_none"`).
+ *
+ * Artifact payloads carry NO `is_blocked` and NO `quarantine_reason`: the
+ * reason is per-artifact security detail disclosed only by the authenticated,
+ * repository-visibility-checked `GET /api/v1/quarantine/{id}` (#2912), which
+ * is also the only surface that computes `is_blocked`.
+ *
+ * An absent `quarantine_status` is still meaningful: the response came from
+ * an older backend (or a surface that never loads quarantine state), i.e.
+ * "the server did not look". Absent must not read as "clear" — that collapse
+ * is what left the quarantine banner unreachable (#650) — so
+ * `quarantineKnowledge` keeps `unknown` as a first-class answer and every
  * caller goes through it.
  */
 export interface QuarantineFields {
   /**
-   * Whether the download gate currently refuses this artifact's bytes. Covers
-   * both a live hold (409) and a rejection (403). Named `is_blocked` to match
-   * the backend; there is no `is_quarantined` field and there never was.
+   * Raw status. Absent only when the server never loaded quarantine state
+   * (older backend), or null from the status endpoint for an artifact with
+   * no recorded state.
    */
-  is_blocked?: boolean | null;
-  /** Raw status: `quarantined`, `rejected`, `released`, `clean`, ... */
   quarantine_status?: string | null;
-  /** When a live hold lapses. Null for an unconditional hold. */
+  /** When a timed hold lapses. Absent for permanent holds and clear rows. */
   quarantine_until?: string | null;
   /**
-   * Why the artifact is held. Redacted (absent) unless the caller can access
-   * the repository, because it carries internal policy names, finding counts
-   * and admin incident notes. A present status with an absent reason is
-   * normal, not an error.
+   * Why the artifact is held. Only ever present from
+   * `GET /api/v1/quarantine/{id}`, and only for callers who hold the
+   * repository, because it carries internal policy names, finding counts and
+   * admin incident notes. Never present on an artifact listing; a blocked
+   * status with an absent reason is normal, not an error.
    */
   quarantine_reason?: string | null;
 }
@@ -49,6 +61,12 @@ export const QUARANTINE_REJECTED_DOWNLOAD_REASON =
 /**
  * Classify what a response says about an artifact's quarantine state.
  *
+ * The verdict is derived from `quarantine_status` with the same semantics as
+ * the backend's download gate (`check_download_allowed` in
+ * quarantine_service.rs): `"quarantined"` (while any timed hold is live) and
+ * `"rejected"` are blocked; `"not_quarantined"` and the scan-lifecycle states
+ * are clear.
+ *
  * `unknown` is a first-class answer: it means this particular response never
  * carried quarantine state, so nothing about the artifact may be asserted from
  * it. Callers that need the verdict for such an artifact fetch
@@ -57,22 +75,29 @@ export const QUARANTINE_REJECTED_DOWNLOAD_REASON =
 export function quarantineKnowledge(
   source: QuarantineFields | null | undefined,
 ): QuarantineKnowledge {
-  // `null` as well as `undefined`: the contract omits the key, but a value of
-  // null still means "no verdict", never "not blocked".
-  if (source == null || source.is_blocked == null) return "unknown";
-  if (!source.is_blocked) return "clear";
+  if (source == null) return "unknown";
+  const status = source.quarantine_status;
+  // Absent, null or empty all mean "the server did not look" — never
+  // "not blocked".
+  if (!status) return "unknown";
 
-  // The server computed `is_blocked` when it rendered the response. A view
-  // left open past the end of a timed hold should stop claiming the artifact
-  // is held. An unparseable timestamp compares false here, so it stays
-  // blocked rather than being waved through.
-  if (
-    source.quarantine_until &&
-    new Date(source.quarantine_until).getTime() <= Date.now()
-  ) {
-    return "clear";
+  if (status === "quarantined") {
+    // A timed hold whose window has lapsed no longer blocks downloads, even
+    // though the row keeps the "quarantined" label until the background job
+    // transitions it. A view left open past the end of a hold should stop
+    // claiming the artifact is held. An unparseable timestamp compares false
+    // here, so it stays blocked rather than being waved through.
+    if (
+      source.quarantine_until &&
+      new Date(source.quarantine_until).getTime() <= Date.now()
+    ) {
+      return "clear";
+    }
+    return "blocked";
   }
-  return "blocked";
+  if (status === "rejected") return "blocked";
+  // "not_quarantined" and the scan-lifecycle states are all downloadable.
+  return "clear";
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -230,18 +230,19 @@ export interface Artifact {
   content_type: string;
   download_count: number;
   /**
-   * Quarantine state, carried by every row of the repository artifacts
-   * listing (artifact-keeper#2940) and absent everywhere else. All four keys
-   * travel together and are omitted rather than nulled on surfaces that do
-   * not load quarantine state, so `undefined` means "the server did not
-   * look" while `is_blocked: false` means "it looked and this is
-   * downloadable". Read them through `@/lib/quarantine` rather than testing
-   * them directly, so the two never collapse into one falsy check (#650).
+   * Quarantine state, serialized on every artifact payload from a current
+   * backend (artifact-keeper#2966): the repository artifacts listing, the
+   * by-id and the by-path responses all carry `quarantine_status`
+   * ("quarantined", "rejected", a scan-lifecycle state, or
+   * "not_quarantined"), with `quarantine_until` present only for timed
+   * holds. Optional here only so an older backend that serializes neither
+   * degrades to "unknown" instead of crashing. The listing never carries
+   * `is_blocked` or the reason — the reason is disclosed only by
+   * `GET /api/v1/quarantine/{id}`. Read these through `@/lib/quarantine`
+   * rather than testing them directly (#650, #697).
    */
-  is_blocked?: boolean;
   quarantine_status?: string | null;
   quarantine_until?: string | null;
-  quarantine_reason?: string | null;
   created_at: string;
   metadata?: Record<string, unknown>;
   /**


### PR DESCRIPTION
Fixes #697

## Summary

The quarantine listing badges were dead on main: the web code was written against backend PR artifact-keeper/artifact-keeper#2958 (never merged — `is_blocked` + `quarantine_reason` on artifact listings), but the backend shipped artifact-keeper/artifact-keeper#2966 instead. This PR realigns the frontend with the shipped contract, verified against the backend handlers:

- `ArtifactResponse.quarantine_status` is **always serialized** on the listing, by-id, and by-path artifact responses — `"quarantined"`, `"rejected"`, a scan-lifecycle state (`"clean"`/`"flagged"`/`"unscanned"`/`"released"`), or the explicit `"not_quarantined"` default (`backend/src/api/handlers/repositories.rs` `ArtifactResponse` + `quarantine_status_label`; `backend/src/api/handlers/artifacts.rs`).
- `quarantine_until` is present only for timed holds (`skip_serializing_if`).
- There is **no `is_blocked` and no `quarantine_reason` on listings** — the reason is disclosed only by the authenticated, repo-visibility-checked `GET /api/v1/quarantine/{id}` (`backend/src/api/handlers/quarantine.rs` `QuarantineStatusResponse`, #2912).
- Verdict semantics match the backend's download gate (`check_download_allowed` in `quarantine_service.rs`): `"quarantined"` blocks until any `quarantine_until` lapses, `"rejected"` blocks permanently, everything else is downloadable.

What changed:

- `src/lib/quarantine.ts` — `quarantineKnowledge()` now derives `unknown`/`clear`/`blocked` from the always-present `quarantine_status` instead of the never-sent `is_blocked`. A missing status (older backend) still degrades to `unknown`, never to `clear` — the collapse that made the banner unreachable in #650.
- `src/lib/api/artifacts.ts`, `src/types/index.ts` — `adaptArtifact` and the `Artifact` type drop `is_blocked`/`quarantine_reason` and copy `quarantine_status`/`quarantine_until` verbatim.
- `docker-tag-list.tsx` — the QuarantineBadge/OK/`-` tri-state now works off the listing's real verdict; the badge tooltip falls back to the hold expiry since listings carry no reason.
- `repo-detail-content.tsx` — the dialog's `GET /api/v1/quarantine/{id}` lookup now fires only when there is something to gain from it: the artifact is held (the reason is worth showing) or the payload carried no verdict (older backend). A clear artifact costs no extra request — previously it fired on every dialog open because `is_blocked` was always absent. The release/reject optimistic update now patches `quarantine_status` (`released`/`rejected`) instead of the unshipped `is_blocked`.
- `src/lib/api/quarantine.ts` — doc comments corrected (the by-path endpoint no longer "omits all four keys"; `reasonBody` rationale).
- Tests — all fixtures that mocked the unshipped #2958 shape now encode the shipped #2966 contract: listing rows carry `quarantine_status` only; the reason arrives via the status-endpoint mock. These tests fail against the old shape (e.g. `is_blocked: true` without a status now reads `unknown`, not blocked).

Out of scope (follow-ups from the #654 post-merge review): zod validation of `apiFetch` responses in `src/lib/api/quarantine.ts`; the search-results badge, whose backend surface (`SearchResultItem`) serializes no quarantine fields at all.

## Test Checklist

- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

`npm run test`: 167 files / 3075 tests pass. `npx eslint` on changed files: clean. `npx tsc --noEmit`: 23 pre-existing baseline errors in unrelated test files, no new ones. `npm run build`: succeeds.

## UI Changes

- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader)

Badge/banner rendering logic only; no layout or styling changes. The components rendered (`QuarantineBadge`, `QuarantineBanner`, OK badge, dialog) are unchanged.
