### PR TITLE
feat(settings): npm upstream feed configuration UI (#702)

### DIFF
--- a/src/app/(app)/(admin)/settings/__tests__/page.test.tsx
+++ b/src/app/(app)/(admin)/settings/__tests__/page.test.tsx
@@ -48,6 +48,8 @@ vi.mock("lucide-react", () => {
     Lock: icon,
     Info: icon,
     Mail: icon,
+    Rss: icon,
+    ExternalLink: icon,
     Loader2: icon,
   };
 });
@@ -503,6 +505,17 @@ describe("SettingsPage", () => {
     render(<SettingsPage />);
 
     expect(screen.getByText("Email")).toBeDefined();
+  });
+
+  it("renders the npm Upstream tab and its read-only feed card (#702)", () => {
+    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
+
+    render(<SettingsPage />);
+
+    expect(screen.getByText("npm Upstream")).toBeDefined();
+    expect(screen.getByText("npm Upstream Change-Feed")).toBeDefined();
+    expect(screen.getByText("NPM_UPSTREAM_FEED_ENABLED")).toBeDefined();
+    expect(screen.getByText("NPM_UPSTREAM_FEED_URL")).toBeDefined();
   });
 
   it("renders SMTP Configuration heading", () => {

--- a/src/app/(app)/(admin)/settings/page.tsx
+++ b/src/app/(app)/(admin)/settings/page.tsx
@@ -8,7 +8,7 @@ import { adminApi } from "@/lib/api/admin";
 import { settingsApi } from "@/lib/api/settings";
 import { ADMIN_SETTINGS_QUERY_KEY, useAdminSettings } from "@/hooks/use-admin-settings";
 import { mutationErrorToast } from "@/lib/error-utils";
-import { Server, HardDrive, Lock, Info, Mail, Loader2 } from "lucide-react";
+import { Server, HardDrive, Lock, Info, Mail, Rss, Loader2 } from "lucide-react";
 
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -27,6 +27,7 @@ import {
 } from "@/components/ui/select";
 
 import { PageHeader } from "@/components/common/page-header";
+import { NpmUpstreamFeedCard } from "@/components/settings/npm-upstream-feed-card";
 import type { PasswordPolicy, SmtpConfig, SmtpTlsMode, StorageSettings } from "@/lib/api/settings";
 
 // -- helpers --
@@ -605,6 +606,10 @@ export default function SettingsPage() {
             <Mail className="size-4 mr-1.5" />
             Email
           </TabsTrigger>
+          <TabsTrigger value="npm-upstream">
+            <Rss className="size-4 mr-1.5" />
+            npm Upstream
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent value="general" className="mt-4">
@@ -737,6 +742,10 @@ export default function SettingsPage() {
 
         <TabsContent value="email" className="mt-4">
           <SmtpSettingsTab />
+        </TabsContent>
+
+        <TabsContent value="npm-upstream" className="mt-4">
+          <NpmUpstreamFeedCard />
         </TabsContent>
       </Tabs>
     </div>

--- a/src/components/settings/__tests__/npm-upstream-feed-card.test.tsx
+++ b/src/components/settings/__tests__/npm-upstream-feed-card.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import {
+  NpmUpstreamFeedCard,
+  NPM_UPSTREAM_FEED_ENV_VARS,
+  NPM_REPLICATION_FEED_DEFAULT_URL,
+  BACKEND_ISSUE_URL,
+} from "../npm-upstream-feed-card";
+
+vi.mock("lucide-react", () => ({
+  Rss: () => null,
+  ExternalLink: () => null,
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("NpmUpstreamFeedCard (#702)", () => {
+  it("renders the title and environment-configured badge", () => {
+    render(<NpmUpstreamFeedCard />);
+
+    expect(screen.getByText("npm Upstream Change-Feed")).toBeInTheDocument();
+    expect(
+      screen.getByText("Configured via environment")
+    ).toBeInTheDocument();
+  });
+
+  it("documents both backend environment variables with their defaults", () => {
+    render(<NpmUpstreamFeedCard />);
+
+    expect(
+      screen.getByText("NPM_UPSTREAM_FEED_ENABLED")
+    ).toBeInTheDocument();
+    expect(screen.getByText("NPM_UPSTREAM_FEED_URL")).toBeInTheDocument();
+    expect(screen.getByText("false")).toBeInTheDocument();
+    expect(
+      screen.getByText(NPM_REPLICATION_FEED_DEFAULT_URL)
+    ).toBeInTheDocument();
+  });
+
+  it("states that runtime status depends on the backend API", () => {
+    render(<NpmUpstreamFeedCard />);
+
+    expect(screen.getByText("Runtime status")).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: /artifact-keeper#3069/ });
+    expect(link).toHaveAttribute("href", BACKEND_ISSUE_URL);
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+  });
+
+  it("mentions SSRF validation for the future URL field", () => {
+    render(<NpmUpstreamFeedCard />);
+
+    expect(screen.getByText(/SSRF validation/)).toBeInTheDocument();
+  });
+
+  it("is read-only: renders no inputs, switches, or save buttons", () => {
+    render(<NpmUpstreamFeedCard />);
+
+    expect(screen.queryByRole("textbox")).toBeNull();
+    expect(screen.queryByRole("switch")).toBeNull();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("renders one documentation row per documented env var", () => {
+    render(<NpmUpstreamFeedCard />);
+
+    for (const envVar of NPM_UPSTREAM_FEED_ENV_VARS) {
+      expect(screen.getByText(envVar.name)).toBeInTheDocument();
+    }
+    expect(NPM_UPSTREAM_FEED_ENV_VARS.length).toBe(2);
+  });
+});

--- a/src/components/settings/npm-upstream-feed-card.tsx
+++ b/src/components/settings/npm-upstream-feed-card.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { ExternalLink, Rss } from "lucide-react";
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+
+/**
+ * Read-only documentation surface for the npm upstream change-feed (#702).
+ *
+ * Backend 1.7.0 ships an opt-in consumer of npm's replication feed
+ * (`replicate.npmjs.com/_changes`) that proactively evicts stale cached
+ * packuments in remote/virtual npm repositories instead of waiting for the
+ * packument cache TTL. It is currently configurable only via environment
+ * variables, and the backend exposes no status or config endpoint for it —
+ * the API the UI needs is tracked as artifact-keeper#3069
+ * (BACKEND_ISSUE_URL below). Until that lands, this card is intentionally
+ * read-only: there is nothing to fetch and nothing to persist.
+ */
+
+export const NPM_REPLICATION_FEED_DEFAULT_URL =
+  "https://replicate.npmjs.com/_changes";
+
+/** Backend issue tracking the status/config API this UI depends on. */
+export const BACKEND_ISSUE_URL =
+  "https://github.com/artifact-keeper/artifact-keeper/issues/3069";
+
+interface EnvVarDoc {
+  name: string;
+  defaultValue: string;
+  description: string;
+}
+
+/** Environment variables that configure the feed, shown read-only. */
+export const NPM_UPSTREAM_FEED_ENV_VARS: EnvVarDoc[] = [
+  {
+    name: "NPM_UPSTREAM_FEED_ENABLED",
+    defaultValue: "false",
+    description:
+      "Set to true to subscribe to the upstream change-feed. One replica consumes cluster-wide via an advisory lock; leadership fails over automatically (300s terms).",
+  },
+  {
+    name: "NPM_UPSTREAM_FEED_URL",
+    defaultValue: NPM_REPLICATION_FEED_DEFAULT_URL,
+    description:
+      "Endpoint of the npm replication feed. Only needs changing when mirroring the feed through an internal relay.",
+  },
+];
+
+export function NpmUpstreamFeedCard() {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <Rss className="size-4 text-muted-foreground" />
+          <CardTitle className="text-base">npm Upstream Change-Feed</CardTitle>
+          <Badge variant="secondary">Configured via environment</Badge>
+        </div>
+        <CardDescription>
+          Subscribes to npm&apos;s replication feed and proactively evicts stale
+          cached packuments in remote and virtual npm repositories, instead of
+          waiting for the packument cache TTL. Requires backend 1.7.0+.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {NPM_UPSTREAM_FEED_ENV_VARS.map((envVar, index) => (
+          <div key={envVar.name}>
+            {index > 0 && <Separator className="mb-4" />}
+            <div className="space-y-2">
+              <p className="text-sm font-medium">
+                <code>{envVar.name}</code>
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Default: <code>{envVar.defaultValue}</code>
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {envVar.description}
+              </p>
+            </div>
+          </div>
+        ))}
+        <Separator />
+        <div className="space-y-2">
+          <p className="text-sm font-medium">Runtime status</p>
+          <p className="text-xs text-muted-foreground">
+            Consumption status (feed cursor, last poll, cluster leadership) and
+            in-UI enable/URL configuration require a backend admin API that is
+            not implemented yet. When the feed URL becomes configurable through
+            the API it will be subject to the same SSRF validation as remote
+            repository upstreams (http/https only). Track{" "}
+            <a
+              href={BACKEND_ISSUE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-0.5 underline underline-offset-2 hover:text-foreground"
+            >
+              artifact-keeper#3069
+              <ExternalLink className="size-3" />
+            </a>
+            .
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #702.

Adds an admin settings surface for the npm upstream change-feed shipped in backend 1.7.0 (`NPM_UPSTREAM_FEED_ENABLED` / `NPM_UPSTREAM_FEED_URL`, backend issue artifact-keeper#2249).

**Depends on backend issue https://github.com/artifact-keeper/artifact-keeper/issues/3069** — the backend currently exposes **no** admin API for the feed: no status endpoint and no config-update endpoint (verified: config is env-only at `backend/src/config.rs:724-728`, consumer state lives in the `upstream_feed_state` table per `backend/migrations/156_upstream_feed_state.sql` but is not routed anywhere in `backend/src/api`). The issue asks for the exact response shape the UI needs (enabled, feed_url, cursor, last_poll_at, is_leader, leader_term_secs, last_error) plus an optional runtime config-update endpoint with SSRF validation.

Because there is nothing to fetch or persist, this PR ships the read-only tier only:

- New **npm Upstream** tab on the admin Settings page (`/settings`), rendering a `NpmUpstreamFeedCard` that documents the feature, both env vars and their defaults, the cluster-wide advisory-lock/leadership behavior, and the SSRF validation that will apply to the feed URL once configurable via API. The card explicitly states runtime status (cursor / last poll / leadership) is pending the backend endpoint and links artifact-keeper#3069.
- Deliberately **no** enable/disable toggle or URL field: the backend cannot persist them, and inventing client-side state for settings the server ignores would be worse than documenting the env vars.

Follow-up once artifact-keeper#3069 lands: swap the documentation rows for the real toggle, URL field (with SSRF-aware error display), and a status card.

## Test Checklist

- [x] Unit tests added/updated
  - `src/components/settings/__tests__/npm-upstream-feed-card.test.tsx` (6 tests: env-var docs, defaults, backend-issue link, SSRF note, read-only invariant)
  - `src/app/(app)/(admin)/settings/__tests__/page.test.tsx` (tab trigger + card render; lucide mock extended)
- [ ] E2E Playwright tests added/updated (read-only documentation card; existing settings-page coverage applies)
- [x] Manually tested locally
- [x] No regressions in existing tests (`npm run test`: 168 files / 3088 tests pass; `npx eslint` clean on changed files; `npx tsc --noEmit` unchanged at the 23 pre-existing baseline errors, none in changed files; `npm run build` succeeds)

## UI Changes

- [ ] Playwright E2E spec covers the change
- [x] Responsive layout verified (mobile + desktop)
- [x] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes
