### PR TITLE
feat(age-gate): per-repo settings panel and webhook event wiring (#701)

### DIFF
--- a/src/app/(app)/(admin)/age-gate/page.test.tsx
+++ b/src/app/(app)/(admin)/age-gate/page.test.tsx
@@ -222,6 +222,13 @@ describe("AgeGatePage", () => {
     expect(screen.getByText(/5d old \(min 14d\)/)).toBeInTheDocument();
   });
 
+  it("links each repository badge to that repo's settings tab (#701)", () => {
+    reviewsData = { data: { items: [REVIEW], total: 1 }, isLoading: false };
+    render(<AgeGatePage />);
+    const link = screen.getByRole("link", { name: "npm-remote" });
+    expect(link).toHaveAttribute("href", "/repositories/npm-remote?tab=settings");
+  });
+
   it("adds a status to the server-side filter when its checkbox is ticked", async () => {
     const user = userEvent.setup();
     render(<AgeGatePage />);

--- a/src/app/(app)/(admin)/age-gate/page.tsx
+++ b/src/app/(app)/(admin)/age-gate/page.tsx
@@ -3,6 +3,7 @@
 import { useDocumentTitle } from "@/hooks/use-document-title";
 
 import { useState, useMemo, useSyncExternalStore } from "react";
+import Link from "next/link";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Hourglass, RefreshCw, AlertCircle, AlertTriangle, Loader2 } from "lucide-react";
 import { toast } from "sonner";
@@ -311,7 +312,14 @@ export default function AgeGatePage() {
                   <td className="px-3 py-2 font-medium">{r.packageName}</td>
                   <td className="px-3 py-2 font-mono text-xs">{r.packageVersion}</td>
                   <td className="px-3 py-2">
-                    <Badge variant="outline">{r.repositoryKey}</Badge>
+                    {/* Deep-link to the repo's settings tab, where the same
+                        repository's age gate policy is configured (#701). */}
+                    <Link
+                      href={`/repositories/${encodeURIComponent(r.repositoryKey)}?tab=settings`}
+                      title={`Age gate settings for ${r.repositoryKey}`}
+                    >
+                      <Badge variant="outline">{r.repositoryKey}</Badge>
+                    </Link>
                   </td>
                   <td className="px-3 py-2 text-xs text-muted-foreground">
                     {formatAge(r, repoConfigs?.[r.repositoryKey]?.minAgeDays)}

--- a/src/app/(app)/(protected)/webhooks/__tests__/page.test.tsx
+++ b/src/app/(app)/(protected)/webhooks/__tests__/page.test.tsx
@@ -587,5 +587,86 @@ describe("WebhooksPage", () => {
     const started = screen.getByText("build started");
     expect(started.className).toContain("blue");
   });
+
+  it("colors age gate events like their outcomes", async () => {
+    setupQueryMock({
+      data: {
+        items: [
+          {
+            id: "w1",
+            name: "Gate Hook",
+            url: "https://ex.com",
+            events: [
+              "age_gate_queued",
+              "age_gate_approved",
+              "age_gate_rejected",
+            ],
+            is_enabled: true,
+            created_at: "2026-01-01",
+          },
+        ],
+        total: 1,
+      },
+    });
+    await renderPage();
+    expect(screen.getByText("age gate approved").className).toContain(
+      "emerald"
+    );
+    expect(screen.getByText("age gate rejected").className).toContain("red");
+    // Queued is neither a success nor a failure: neutral default styling.
+    expect(screen.getByText("age gate queued").className).toContain(
+      "secondary"
+    );
+  });
+
+  it("lists age gate events in the create dialog and submits them", async () => {
+    const { webhooksApi } = await import("@/lib/api/webhooks");
+    await renderPage();
+    await act(async () => {
+      fireEvent.click(screen.getAllByText("Create Webhook")[0]);
+    });
+    // The age gate group is offered alongside the other event groups.
+    expect(screen.getByText("Age Gate Queued")).toBeInTheDocument();
+    expect(screen.getByText("Age Gate Approved")).toBeInTheDocument();
+    expect(screen.getByText("Age Gate Rejected")).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.change(screen.getByPlaceholderText("e.g., Slack Notifications"), {
+        target: { value: "Age Gate Hook" },
+      });
+      fireEvent.change(
+        screen.getByPlaceholderText("https://example.com/webhook"),
+        { target: { value: "https://test.com/hook" } }
+      );
+    });
+
+    // Toggle the two decision events on.
+    const approved = screen
+      .getByText("Age Gate Approved")
+      .closest("label")!
+      .querySelector("input")!;
+    const rejected = screen
+      .getByText("Age Gate Rejected")
+      .closest("label")!
+      .querySelector("input")!;
+    await act(async () => {
+      fireEvent.click(approved);
+      fireEvent.click(rejected);
+    });
+
+    const form = screen.getByTestId("dialog-content").querySelector("form")!;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    expect(webhooksApi.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        events: expect.arrayContaining([
+          "age_gate_approved",
+          "age_gate_rejected",
+        ]),
+      })
+    );
+  });
 });
 

--- a/src/app/(app)/(protected)/webhooks/page.tsx
+++ b/src/app/(app)/(protected)/webhooks/page.tsx
@@ -75,14 +75,23 @@ const WEBHOOK_EVENTS: { value: WebhookEvent; label: string }[] = [
   { value: "build_started", label: "Build Started" },
   { value: "build_completed", label: "Build Completed" },
   { value: "build_failed", label: "Build Failed" },
+  { value: "age_gate_queued", label: "Age Gate Queued" },
+  { value: "age_gate_approved", label: "Age Gate Approved" },
+  { value: "age_gate_rejected", label: "Age Gate Rejected" },
 ];
 
 function eventColor(event: string): "green" | "red" | "blue" | "default" {
-  if (event.includes("deleted") || event.includes("failed")) return "red";
+  if (
+    event.includes("deleted") ||
+    event.includes("failed") ||
+    event.includes("rejected")
+  )
+    return "red";
   if (
     event.includes("created") ||
     event.includes("uploaded") ||
-    event.includes("completed")
+    event.includes("completed") ||
+    event.includes("approved")
   )
     return "green";
   if (event.includes("started")) return "blue";

--- a/src/app/(app)/repositories/_components/notifications-tab-content.test.tsx
+++ b/src/app/(app)/repositories/_components/notifications-tab-content.test.tsx
@@ -672,11 +672,19 @@ describe("NotificationsTabContent", () => {
   // WEBHOOK_EVENTS constant
   // -----------------------------------------------------------------------
 
-  it("exports WEBHOOK_EVENTS with 9 event types", () => {
-    expect(WEBHOOK_EVENTS).toHaveLength(9);
+  it("exports WEBHOOK_EVENTS with 12 event types", () => {
+    expect(WEBHOOK_EVENTS).toHaveLength(12);
     expect(WEBHOOK_EVENTS.map((e) => e.value)).toContain("artifact_uploaded");
     expect(WEBHOOK_EVENTS.map((e) => e.value)).toContain("build_completed");
     expect(WEBHOOK_EVENTS.map((e) => e.value)).toContain("repository_deleted");
+    // Age gate group (#701).
+    expect(WEBHOOK_EVENTS.map((e) => e.value)).toEqual(
+      expect.arrayContaining([
+        "age_gate_queued",
+        "age_gate_approved",
+        "age_gate_rejected",
+      ])
+    );
   });
 
   // -----------------------------------------------------------------------

--- a/src/app/(app)/repositories/_components/notifications-tab-content.tsx
+++ b/src/app/(app)/repositories/_components/notifications-tab-content.tsx
@@ -94,6 +94,21 @@ export const WEBHOOK_EVENTS: { value: WebhookEvent; label: string; description: 
     label: "User Deleted",
     description: "Triggered when a user account is removed",
   },
+  {
+    value: "age_gate_queued",
+    label: "Age Gate Queued",
+    description: "Triggered when a too-new upstream release enters the age gate review queue",
+  },
+  {
+    value: "age_gate_approved",
+    label: "Age Gate Approved",
+    description: "Triggered when an age-gated release is approved for download",
+  },
+  {
+    value: "age_gate_rejected",
+    label: "Age Gate Rejected",
+    description: "Triggered when an age-gated release is rejected",
+  },
 ];
 
 // ---------------------------------------------------------------------------

--- a/src/app/(app)/repositories/_components/repo-settings-tab.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-settings-tab.test.tsx
@@ -84,6 +84,18 @@ vi.mock("@/lib/api/scan-config", () => ({
   SEVERITY_THRESHOLDS: ["critical", "high", "medium", "low"],
 }));
 
+// Mock the age-gate API (#701 per-repo settings panel).
+const mockGetAgeGateConfig = vi.fn();
+const mockUpdateAgeGateConfig = vi.fn();
+vi.mock("@/lib/api/age-gate", () => ({
+  __esModule: true,
+  ageGateApi: {
+    getRepoConfig: (...args: unknown[]) => mockGetAgeGateConfig(...args),
+    updateRepoConfig: (...args: unknown[]) =>
+      mockUpdateAgeGateConfig(...args),
+  },
+}));
+
 // Mock lifecycle API
 const mockListPolicies = vi.fn();
 const mockDeletePolicy = vi.fn();
@@ -273,6 +285,14 @@ const defaultScanConfig = {
   proxy_scan_action: "fail_open" as const,
 };
 mockGetScanConfig.mockResolvedValue(defaultScanConfig);
+
+// Default age-gate config (#701): enabled with a 7-day minimum. Individual
+// tests override with mockResolvedValue/mockResolvedValueOnce.
+mockGetAgeGateConfig.mockResolvedValue({
+  repositoryKey: "npm-remote",
+  enabled: true,
+  minAgeDays: 7,
+});
 
 function createWrapper() {
   const client = new QueryClient({
@@ -1823,5 +1843,190 @@ describe("RepoSettingsTab - WASM plugin layout display (#592)", () => {
     expect(
       screen.queryByText(/custom layout provided by a wasm plugin/i)
     ).toBeNull();
+  });
+});
+
+describe("RepoSettingsTab - Age Gate (#701)", () => {
+  const remoteRepo: Repository = {
+    ...baseRepo,
+    key: "npm-remote",
+    repo_type: "remote" as const,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListPolicies.mockResolvedValue([]);
+    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
+    // Remote repos also run the cache-TTL query; give it a quiet default.
+    mockGetCacheTtl.mockResolvedValue({ cache_ttl_seconds: 86400 });
+    mockGetAgeGateConfig.mockResolvedValue({
+      repositoryKey: "npm-remote",
+      enabled: true,
+      minAgeDays: 7,
+    });
+  });
+
+  it("hides the section for non-admin users and does not run the GET", () => {
+    mockUseAuth.mockReturnValue({ user: { is_admin: false } });
+    render(<RepoSettingsTab repository={remoteRepo} />, {
+      wrapper: createWrapper(),
+    });
+    expect(screen.queryByRole("heading", { name: "Age Gate" })).toBeNull();
+    expect(mockGetAgeGateConfig).not.toHaveBeenCalled();
+  });
+
+  it("hides the section for local repositories even for admins", () => {
+    render(<RepoSettingsTab repository={baseRepo} />, {
+      wrapper: createWrapper(),
+    });
+    expect(screen.queryByRole("heading", { name: "Age Gate" })).toBeNull();
+    expect(mockGetAgeGateConfig).not.toHaveBeenCalled();
+  });
+
+  it("renders the section for remote repos and loads the config via GET", async () => {
+    render(<RepoSettingsTab repository={remoteRepo} />, {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText("Enable age gate")).toBeTruthy();
+    });
+    expect(mockGetAgeGateConfig).toHaveBeenCalledWith("npm-remote");
+    // The loaded config seeds the controls: gate on, 7-day minimum.
+    expect(
+      screen.getByLabelText("Enable age gate").getAttribute("aria-checked")
+    ).toBe("true");
+    expect(screen.getByLabelText("Minimum age (days)")).toHaveProperty(
+      "value",
+      "7"
+    );
+  });
+
+  it("keeps Save disabled until an edit is made", async () => {
+    render(<RepoSettingsTab repository={remoteRepo} />, {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText("Enable age gate")).toBeTruthy();
+    });
+    const saveBtn = screen.getByRole("button", {
+      name: /save age gate settings/i,
+    });
+    expect(saveBtn).toHaveProperty("disabled", true);
+  });
+
+  it("rejects out-of-range and non-integer day values inline", async () => {
+    const user = userEvent.setup();
+    render(<RepoSettingsTab repository={remoteRepo} />, {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText("Minimum age (days)")).toBeTruthy();
+    });
+    const daysInput = screen.getByLabelText("Minimum age (days)");
+
+    await user.clear(daysInput);
+    await user.type(daysInput, "5000");
+    expect(
+      screen.getByText(/Must be a whole number between 0 and 3,650/)
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /save age gate settings/i })
+    ).toHaveProperty("disabled", true);
+
+    await user.clear(daysInput);
+    await user.type(daysInput, "2.5");
+    expect(
+      screen.getByText(/Must be a whole number between 0 and 3,650/)
+    ).toBeTruthy();
+
+    // Back in range: error clears and Save becomes available.
+    await user.clear(daysInput);
+    await user.type(daysInput, "30");
+    expect(
+      screen.queryByText(/Must be a whole number between 0 and 3,650/)
+    ).toBeNull();
+    expect(
+      screen.getByRole("button", { name: /save age gate settings/i })
+    ).toHaveProperty("disabled", false);
+  });
+
+  it("saves the edited config and toasts success", async () => {
+    mockUpdateAgeGateConfig.mockResolvedValue({
+      repositoryKey: "npm-remote",
+      enabled: true,
+      minAgeDays: 30,
+    });
+    const { toast } = await import("sonner");
+    const user = userEvent.setup();
+    render(<RepoSettingsTab repository={remoteRepo} />, {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText("Minimum age (days)")).toBeTruthy();
+    });
+    const daysInput = screen.getByLabelText("Minimum age (days)");
+    await user.clear(daysInput);
+    await user.type(daysInput, "30");
+
+    await user.click(
+      screen.getByRole("button", { name: /save age gate settings/i })
+    );
+
+    await waitFor(() => {
+      expect(mockUpdateAgeGateConfig).toHaveBeenCalledWith("npm-remote", {
+        enabled: true,
+        minAgeDays: 30,
+      });
+    });
+    expect(toast.success).toHaveBeenCalledWith("Age gate enabled");
+  });
+
+  it("saves a disabled gate while keeping the loaded minimum age", async () => {
+    mockUpdateAgeGateConfig.mockResolvedValue({
+      repositoryKey: "npm-remote",
+      enabled: false,
+      minAgeDays: 7,
+    });
+    const { toast } = await import("sonner");
+    const user = userEvent.setup();
+    render(<RepoSettingsTab repository={remoteRepo} />, {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText("Enable age gate")).toBeTruthy();
+    });
+    await user.click(screen.getByLabelText("Enable age gate"));
+    await user.click(
+      screen.getByRole("button", { name: /save age gate settings/i })
+    );
+
+    await waitFor(() => {
+      expect(mockUpdateAgeGateConfig).toHaveBeenCalledWith("npm-remote", {
+        enabled: false,
+        minAgeDays: 7,
+      });
+    });
+    expect(toast.success).toHaveBeenCalledWith("Age gate settings saved");
+  });
+
+  it("toasts an error when the save fails", async () => {
+    mockUpdateAgeGateConfig.mockRejectedValue(new Error("403 Forbidden"));
+    const { toast } = await import("sonner");
+    const user = userEvent.setup();
+    render(<RepoSettingsTab repository={remoteRepo} />, {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText("Enable age gate")).toBeTruthy();
+    });
+    await user.click(screen.getByLabelText("Enable age gate"));
+    await user.click(
+      screen.getByRole("button", { name: /save age gate settings/i })
+    );
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "Failed to save age gate settings"
+      );
+    });
   });
 });

--- a/src/app/(app)/repositories/_components/repo-settings-tab.tsx
+++ b/src/app/(app)/repositories/_components/repo-settings-tab.tsx
@@ -6,6 +6,7 @@ import { Loader2, AlertTriangle, Trash2, Play, Eye } from "lucide-react";
 import { toast } from "sonner";
 
 import { repositoriesApi } from "@/lib/api/repositories";
+import { ageGateApi } from "@/lib/api/age-gate";
 import { supportsVersioning } from "@/lib/api/versions";
 import { useAdminSettings } from "@/hooks/use-admin-settings";
 import { useAuth } from "@/providers/auth-provider";
@@ -111,6 +112,14 @@ export function minutesToAge(minutes: number | undefined | null): { value: strin
 // a 400 + opaque message.
 const CACHE_TTL_MIN_SECONDS = 1;
 const CACHE_TTL_MAX_SECONDS = 30 * 24 * 60 * 60; // 2,592,000
+
+// Backend constraint from `validate_min_age_days` in age_gate_service.rs:
+// 0..=3650. 0 is meaningful — the "trusted remote" setting (#1558): no age
+// delay, but explicit rejections still block. The constants live here (not on
+// the SDK) so the UI can show a clear inline validation error before
+// submitting, mirroring the cache-TTL field above.
+const AGE_GATE_MIN_DAYS = 0;
+const AGE_GATE_MAX_DAYS = 3650;
 
 /**
  * Format a TTL in seconds as a short human-readable hint
@@ -625,6 +634,74 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
     });
   }, [scanForm, scanConfigMutation]);
 
+  // -- Age Gate (#701). Remote repos only: the backend PUT rejects other repo
+  // types with 400 (`require_remote_repo_for_age_gate`) and is admin-only, so
+  // the section mirrors the Scanning & enforcement gating above. --
+  const { data: ageGateConfig, isLoading: ageGateLoading } = useQuery({
+    queryKey: ["age-gate-config", repository.key],
+    queryFn: () => ageGateApi.getRepoConfig(repository.key),
+    enabled: isRemote && isRepoAdmin,
+  });
+
+  // Same override pattern as the cache-TTL field: a string-typed override for
+  // the days input so typing stays controlled mid-edit, and an optional
+  // boolean override for the toggle. A fresh load never counts as a change.
+  const [ageGateEnabledOverride, setAgeGateEnabledOverride] = useState<
+    boolean | undefined
+  >(undefined);
+  const [ageGateDaysOverride, setAgeGateDaysOverride] = useState<
+    string | undefined
+  >(undefined);
+  const ageGateEnabled =
+    ageGateEnabledOverride ?? ageGateConfig?.enabled ?? false;
+  const ageGateDaysInput =
+    ageGateDaysOverride ??
+    (ageGateConfig ? String(ageGateConfig.minAgeDays) : "");
+  const parsedAgeGateDays =
+    ageGateDaysInput.trim() === "" ? null : Number(ageGateDaysInput);
+  const ageGateDaysValid =
+    parsedAgeGateDays != null &&
+    Number.isInteger(parsedAgeGateDays) &&
+    parsedAgeGateDays >= AGE_GATE_MIN_DAYS &&
+    parsedAgeGateDays <= AGE_GATE_MAX_DAYS;
+  const ageGateChanged =
+    !!ageGateConfig &&
+    ((ageGateEnabledOverride !== undefined &&
+      ageGateEnabledOverride !== ageGateConfig.enabled) ||
+      (ageGateDaysOverride !== undefined &&
+        parsedAgeGateDays !== ageGateConfig.minAgeDays));
+
+  const ageGateMutation = useMutation({
+    mutationFn: (cfg: { enabled: boolean; minAgeDays: number }) =>
+      ageGateApi.updateRepoConfig(repository.key, cfg),
+    onSuccess: (updated) => {
+      // Seed the query cache with the server's echoed config and clear the
+      // local edits so the form re-baselines against what was persisted.
+      queryClient.setQueryData(["age-gate-config", repository.key], updated);
+      setAgeGateEnabledOverride(undefined);
+      setAgeGateDaysOverride(undefined);
+      toast.success(
+        updated.enabled ? "Age gate enabled" : "Age gate settings saved"
+      );
+    },
+    onError: mutationErrorToast("Failed to save age gate settings"),
+  });
+
+  const handleSaveAgeGate = useCallback(() => {
+    if (!ageGateConfig || !ageGateDaysValid || parsedAgeGateDays == null)
+      return;
+    ageGateMutation.mutate({
+      enabled: ageGateEnabled,
+      minAgeDays: parsedAgeGateDays,
+    });
+  }, [
+    ageGateConfig,
+    ageGateDaysValid,
+    parsedAgeGateDays,
+    ageGateEnabled,
+    ageGateMutation,
+  ]);
+
   return (
     <div className="max-w-2xl space-y-8">
       {/* -- General Settings Section -- */}
@@ -1012,6 +1089,113 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
       </section>
 
       <Separator />
+
+      {/* -- Age Gate Section (#701, remote repos, repo-admin only) -- */}
+      {isRemote && isRepoAdmin && (
+        <>
+          <section aria-labelledby="settings-age-gate-heading">
+            <div className="mb-4">
+              <h3
+                id="settings-age-gate-heading"
+                className="text-base font-semibold"
+              >
+                Age Gate
+              </h3>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Withhold upstream releases younger than a minimum age until
+                they mature or an admin approves them from the age gate review
+                queue.
+              </p>
+            </div>
+
+            {ageGateLoading || !ageGateConfig ? (
+              <div className="space-y-3">
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+            ) : (
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <div className="space-y-0.5">
+                    <Label htmlFor="settings-age-gate-enabled">
+                      Enable age gate
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Queue too-new releases for admin review instead of
+                      serving them to clients.
+                    </p>
+                  </div>
+                  <Switch
+                    id="settings-age-gate-enabled"
+                    checked={ageGateEnabled}
+                    onCheckedChange={setAgeGateEnabledOverride}
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="settings-age-gate-days">
+                    Minimum age (days)
+                  </Label>
+                  <Input
+                    id="settings-age-gate-days"
+                    type="number"
+                    min={AGE_GATE_MIN_DAYS}
+                    max={AGE_GATE_MAX_DAYS}
+                    step={1}
+                    value={ageGateDaysInput}
+                    onChange={(e) => setAgeGateDaysOverride(e.target.value)}
+                    disabled={!ageGateEnabled}
+                    aria-invalid={
+                      ageGateDaysOverride !== undefined && !ageGateDaysValid
+                    }
+                    aria-describedby="settings-age-gate-days-error"
+                  />
+                  {/* Persistent live region, mirroring the age-policy and
+                      cache-TTL fields. */}
+                  <p
+                    id="settings-age-gate-days-error"
+                    role="alert"
+                    className="text-sm text-destructive empty:hidden"
+                  >
+                    {ageGateDaysOverride !== undefined && !ageGateDaysValid
+                      ? `Must be a whole number between ${AGE_GATE_MIN_DAYS} and ${AGE_GATE_MAX_DAYS.toLocaleString()}.`
+                      : ""}
+                  </p>
+                  {ageGateDaysValid && (
+                    <p className="text-xs text-muted-foreground">
+                      Releases published fewer than this many days ago are
+                      withheld. 0 disables the age delay but keeps admin
+                      rejections enforced.
+                    </p>
+                  )}
+                </div>
+
+                <div className="flex justify-end">
+                  <Button
+                    onClick={handleSaveAgeGate}
+                    disabled={
+                      ageGateMutation.isPending ||
+                      !ageGateChanged ||
+                      !ageGateDaysValid
+                    }
+                  >
+                    {ageGateMutation.isPending ? (
+                      <>
+                        <Loader2 className="size-4 animate-spin" />
+                        Saving...
+                      </>
+                    ) : (
+                      "Save Age Gate Settings"
+                    )}
+                  </Button>
+                </div>
+              </div>
+            )}
+          </section>
+
+          <Separator />
+        </>
+      )}
 
       {/* -- Release Target Section (staging promotion, #260) -- */}
       {repository.repo_type === "staging" && (

--- a/src/lib/api/__tests__/age-gate.test.ts
+++ b/src/lib/api/__tests__/age-gate.test.ts
@@ -19,6 +19,7 @@ const m = {
   approveReview: vi.fn(),
   rejectReview: vi.fn(),
   getRepoAgeGate: vi.fn(),
+  updateRepoAgeGate: vi.fn(),
 };
 vi.mock("@artifact-keeper/sdk", () => ({
   listReviews: (...a: unknown[]) => m.listReviews(...a),
@@ -26,6 +27,7 @@ vi.mock("@artifact-keeper/sdk", () => ({
   approveReview: (...a: unknown[]) => m.approveReview(...a),
   rejectReview: (...a: unknown[]) => m.rejectReview(...a),
   getRepoAgeGate: (...a: unknown[]) => m.getRepoAgeGate(...a),
+  updateRepoAgeGate: (...a: unknown[]) => m.updateRepoAgeGate(...a),
 }));
 
 import { ApiError } from "../fetch";
@@ -351,5 +353,33 @@ describe("ageGateApi", () => {
     m.getRepoAgeGate.mockResolvedValue({ data: undefined, error: { status: 404 } });
     const out = await ageGateApi.getRepoConfigs(["no-policy-repo"]);
     expect(out).toEqual({});
+  });
+
+  it("getRepoConfig fetches one repository's policy and adapts it to camelCase", async () => {
+    m.getRepoAgeGate.mockResolvedValue({
+      data: { repository_key: "npm-remote", enabled: true, min_age_days: 14 },
+      error: undefined,
+    });
+    const out = await ageGateApi.getRepoConfig("npm-remote");
+    expect(m.getRepoAgeGate).toHaveBeenCalledWith({ path: { key: "npm-remote" } });
+    expect(out).toEqual({ repositoryKey: "npm-remote", enabled: true, minAgeDays: 14 });
+  });
+
+  it("getRepoConfig throws the SDK error instead of swallowing it", async () => {
+    m.getRepoAgeGate.mockResolvedValue({ data: undefined, error: { status: 500 } });
+    await expect(ageGateApi.getRepoConfig("npm-remote")).rejects.toEqual({ status: 500 });
+  });
+
+  it("updateRepoConfig PUTs the snake_case body and adapts the echoed config", async () => {
+    m.updateRepoAgeGate.mockResolvedValue({
+      data: { repository_key: "npm-remote", enabled: false, min_age_days: 0 },
+      error: undefined,
+    });
+    const out = await ageGateApi.updateRepoConfig("npm-remote", { enabled: false, minAgeDays: 0 });
+    expect(m.updateRepoAgeGate).toHaveBeenCalledWith({
+      path: { key: "npm-remote" },
+      body: { enabled: false, min_age_days: 0 },
+    });
+    expect(out).toEqual({ repositoryKey: "npm-remote", enabled: false, minAgeDays: 0 });
   });
 });

--- a/src/lib/api/__tests__/webhooks.test.ts
+++ b/src/lib/api/__tests__/webhooks.test.ts
@@ -119,6 +119,31 @@ describe("webhooksApi", () => {
     warn.mockRestore();
   });
 
+  it("list keeps age gate events without narrowing (#701)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockListWebhooks.mockResolvedValue({
+      data: {
+        items: [
+          {
+            ...SDK_WEBHOOK,
+            events: ["age_gate_queued", "age_gate_approved", "age_gate_rejected"],
+          },
+        ],
+        total: 1,
+      },
+      error: undefined,
+    });
+    const { webhooksApi } = await import("../webhooks");
+    const out = await webhooksApi.list();
+    expect(out.items[0].events).toEqual([
+      "age_gate_queued",
+      "age_gate_approved",
+      "age_gate_rejected",
+    ]);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   it("list throws on error", async () => {
     mockListWebhooks.mockResolvedValue({ data: undefined, error: "fail" });
     const { webhooksApi } = await import("../webhooks");

--- a/src/lib/api/age-gate.ts
+++ b/src/lib/api/age-gate.ts
@@ -5,6 +5,7 @@ import {
   approveReview,
   rejectReview,
   getRepoAgeGate,
+  updateRepoAgeGate,
 } from '@artifact-keeper/sdk';
 import type { AgeGateReviewResponse, AgeGateConfigResponse } from '@artifact-keeper/sdk';
 import { ApiError, apiFetch, assertData } from '@/lib/api/fetch';
@@ -283,6 +284,34 @@ export const ageGateApi = {
     return target === 'approved'
       ? ageGateApi.approveReview(review.id, why || undefined)
       : ageGateApi.rejectReview(review.id, why || undefined);
+  },
+
+  /**
+   * Fetch the age gate policy for one repository. Unlike `getRepoConfigs`
+   * (which swallows a failed lookup as "no policy" for the review queue),
+   * this throws so the repository settings panel can surface the error.
+   */
+  getRepoConfig: async (repositoryKey: string): Promise<AgeGateRepoConfig> => {
+    const data = await unwrap(getRepoAgeGate({ path: { key: repositoryKey } }));
+    return adaptConfig(assertData(data, 'ageGateApi.getRepoConfig'));
+  },
+
+  /**
+   * Replace a repository's age gate policy. The backend PUT is admin-only
+   * and rejects non-remote repositories with 400
+   * (`require_remote_repo_for_age_gate`), so callers gate the UI the same
+   * way. `minAgeDays` must be within 0..=3650 (`validate_min_age_days`); 0 is
+   * the "trusted remote" setting — no age delay, but rejections still block.
+   */
+  updateRepoConfig: async (
+    repositoryKey: string,
+    config: { enabled: boolean; minAgeDays: number },
+  ): Promise<AgeGateRepoConfig> => {
+    const data = await unwrap(updateRepoAgeGate({
+      path: { key: repositoryKey },
+      body: { enabled: config.enabled, min_age_days: config.minAgeDays },
+    }));
+    return adaptConfig(assertData(data, 'ageGateApi.updateRepoConfig'));
   },
 
   /**

--- a/src/lib/api/webhooks.ts
+++ b/src/lib/api/webhooks.ts
@@ -35,7 +35,10 @@ export type WebhookEvent =
   | 'user_deleted'
   | 'build_started'
   | 'build_completed'
-  | 'build_failed';
+  | 'build_failed'
+  | 'age_gate_queued'
+  | 'age_gate_approved'
+  | 'age_gate_rejected';
 
 const WEBHOOK_EVENTS = new Set<WebhookEvent>([
   'artifact_uploaded',
@@ -47,6 +50,9 @@ const WEBHOOK_EVENTS = new Set<WebhookEvent>([
   'build_started',
   'build_completed',
   'build_failed',
+  'age_gate_queued',
+  'age_gate_approved',
+  'age_gate_rejected',
 ]);
 
 export interface Webhook {


### PR DESCRIPTION
## Summary

Fixes #701

Ships the two remaining pieces of the age-gate UI that #452 never landed (review-queue half shipped via #635/#655/#698):

1. **Per-repo age-gate settings panel** — a new "Age Gate" section in the repository Settings tab (remote repos, admins only), editing `enabled` + `min_age_days` against the shipped backend endpoints:
   - `GET /api/v1/repositories/{key}/age-gate` → `{ repository_key, enabled, min_age_days }`
   - `PUT /api/v1/repositories/{key}/age-gate` (admin-only; rejects non-remote repos with 400; `min_age_days` validated 0–3650)
2. **`age_gate_*` webhook event wiring** — `age_gate_queued` / `age_gate_approved` / `age_gate_rejected` are now selectable in both webhook creation pickers (admin Webhooks page and the repo Notifications tab) and no longer narrow to the `artifact_uploaded` fallback in `webhooksApi`. Badge colors: approved → green, rejected → red, queued → neutral.

Implementation notes:

- The panel follows the local repo-settings patterns: named exports from `lib/api`, `unwrap()` from `sdk-utils`, `mutationErrorToast`, override-based dirty tracking with its own Save button (like the Scanning & enforcement section), inline range validation with an `aria-describedby` live region (like the cache-TTL field). No react-hook-form/zod — neighboring panels don't use them.
- Gating mirrors the backend contract: the section renders only for remote repos (the PUT 400s otherwise) and only for admins (the PUT is admin-only).
- The review-queue page's repository badge now deep-links to `/repositories/{key}?tab=settings` so an admin can jump from a held release to the repo's age-gate config.
- 0 days is presented as the backend defines it (#1558 "trusted remote"): no age delay, but rejections still block.

**Known backend gap (not faked):** the backend emits `age_gate.reopened` internally (`age_gate_service.rs`) but `webhook_producer.rs` maps only `queued`/`approved`/`rejected` to subscribable `WebhookEvent` variants — there is no `age_gate_reopened` event to subscribe to, so it is intentionally absent from the pickers. If that event should be subscribable, it needs a backend change first.

## Test Checklist

- [x] Unit tests added/updated
  - `lib/api/__tests__/age-gate.test.ts`: `getRepoConfig` / `updateRepoConfig` request + adaptation
  - `repo-settings-tab.test.tsx`: section gating (non-admin, non-remote), GET load, dirty-state Save, 0–3650 inline validation, success/error toasts
  - `webhooks/__tests__/page.test.tsx`: age-gate events offered + submitted in the create dialog, badge colors
  - `lib/api/__tests__/webhooks.test.ts`: age-gate events pass through without fallback narrowing
  - `notifications-tab-content.test.tsx`: event list now 12 incl. age-gate group
  - `age-gate/page.test.tsx`: repository badge links to repo settings tab
- [ ] E2E Playwright tests added/updated (N/A — covered by unit tests)
- [ ] Manually tested locally
- [x] No regressions in existing tests — full suite 167 files / 3096 tests green; `eslint` clean on changed files; `tsc --noEmit` at the 23-error pre-existing baseline (no new); `next build` passes

## UI Changes

- [ ] Playwright E2E spec covers the change
- [x] Responsive layout verified (mobile + desktop) — section reuses existing settings-tab layout primitives
- [x] Dark mode verified — only existing themed components used
- [x] Accessibility checked (keyboard navigation, screen reader) — labelled switch/input, `role="alert"` validation live region, aria-invalid wiring mirroring neighboring sections
