### PR TITLE
fix(repositories): select and display WASM plugin layouts in the UI (#591, #592)

### DIFF
--- a/src/app/(app)/(admin)/format-handlers/page.tsx
+++ b/src/app/(app)/(admin)/format-handlers/page.tsx
@@ -12,6 +12,7 @@ import {
   type FormatHandler,
   type FormatTestResult,
 } from "@/lib/api/format-handlers";
+import { FORMAT_HANDLERS_QUERY_KEY } from "@/hooks/use-format-handlers";
 import { mutationErrorToast, toUserMessage } from "@/lib/error-utils";
 import { useAuth } from "@/providers/auth-provider";
 
@@ -31,7 +32,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 
-const QUERY_KEY = ["format-handlers"];
+const QUERY_KEY = FORMAT_HANDLERS_QUERY_KEY;
 
 export default function FormatHandlersPage() {
   useDocumentTitle("Format Handlers");

--- a/src/app/(app)/repositories/_components/repo-detail-content.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.tsx
@@ -33,6 +33,8 @@ import { artifactsApi } from "@/lib/api/artifacts";
 import { securityApi } from "@/lib/api/security";
 import { quarantineApi } from "@/lib/api/quarantine";
 import { mutationErrorToast } from "@/lib/error-utils";
+import { useFormatHandlers } from "@/hooks/use-format-handlers";
+import { isPluginBackedRepo, repoFormatLabel } from "@/lib/repo-format";
 import {
   isActivelyQuarantined,
   isQuarantineRejected,
@@ -191,6 +193,10 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
     queryFn: () => repositoriesApi.get(repoKey),
     enabled: !!repoKey,
   });
+
+  // Installed format handlers — resolves the custom layout name for repos
+  // backed by a WASM plugin (#592), which report `format: "generic"`.
+  const { data: formatHandlers } = useFormatHandlers();
 
   const repoFormat = repository?.format;
   // Derive effective view mode: explicit user choice wins; otherwise default
@@ -725,8 +731,13 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
 
             <div className="flex flex-wrap items-center gap-2">
               <Badge variant="secondary" className="text-xs">
-                {repository.format.toUpperCase()}
+                {repoFormatLabel(repository, formatHandlers).toUpperCase()}
               </Badge>
+              {isPluginBackedRepo(repository) && (
+                <Badge variant="outline" className="text-xs font-normal">
+                  WASM plugin
+                </Badge>
+              )}
               <span
                 className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${REPO_TYPE_COLORS[repository.repo_type] ?? ""}`}
               >
@@ -767,8 +778,13 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
           </div>
           <div className="flex flex-wrap items-center gap-2">
             <Badge variant="secondary" className="text-xs">
-              {repository.format.toUpperCase()}
+              {repoFormatLabel(repository, formatHandlers).toUpperCase()}
             </Badge>
+            {isPluginBackedRepo(repository) && (
+              <Badge variant="outline" className="text-xs font-normal">
+                WASM plugin
+              </Badge>
+            )}
             <span
               className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${REPO_TYPE_COLORS[repository.repo_type] ?? ""}`}
             >

--- a/src/app/(app)/repositories/_components/repo-dialogs.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-dialogs.test.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import { render, screen, within, fireEvent, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { RepoDialogs } from './repo-dialogs';
+import type { FormatHandler } from '@/lib/api/format-handlers';
 
 // jsdom doesn't provide ResizeObserver
 beforeAll(() => {
@@ -1903,6 +1904,102 @@ describe('RepoDialogs - 1.6.0 format-specific config (#602)', () => {
         npm_allowed_scopes: ['@acme'],
         npm_allow_unscoped: true,
       })
+    );
+  });
+});
+
+describe('RepoDialogs - WASM plugin layouts (#591)', () => {
+  const UNITY_HANDLER: FormatHandler = {
+    id: 'h-unity',
+    format_key: 'unity',
+    display_name: 'Unity',
+    description: null,
+    extensions: ['.unitypackage'],
+    handler_type: 'Wasm',
+    is_enabled: true,
+    priority: 5,
+    plugin_id: 'p1',
+  };
+
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('offers installed WASM plugin layouts as labeled custom format options', () => {
+    render(<RepoDialogs {...defaultProps} pluginFormats={[UNITY_HANDLER]} />);
+
+    const dialog = screen.getByRole('dialog');
+    const formatSelect = within(dialog).getAllByTestId('mock-select')[0] as HTMLSelectElement;
+    const option = Array.from(formatSelect.options).find((o) => o.value === 'unity');
+
+    expect(option).toBeDefined();
+    expect(option?.textContent).toBe('Custom (plugin: Unity)');
+  });
+
+  it('omits the custom plugin options when no plugins are installed', () => {
+    render(<RepoDialogs {...defaultProps} />);
+
+    const dialog = screen.getByRole('dialog');
+    const formatSelect = within(dialog).getAllByTestId('mock-select')[0] as HTMLSelectElement;
+    const labels = Array.from(formatSelect.options).map((o) => o.textContent ?? '');
+
+    expect(labels.some((l) => l.startsWith('Custom (plugin:'))).toBe(false);
+  });
+
+  it('submits a selected plugin layout as format "generic" plus format_key', async () => {
+    const onCreateSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <RepoDialogs
+        {...defaultProps}
+        onCreateSubmit={onCreateSubmit}
+        pluginFormats={[UNITY_HANDLER]}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog');
+    await user.type(within(dialog).getByPlaceholderText('my-repo'), 'unity-local');
+    await user.type(within(dialog).getByPlaceholderText('My Repository'), 'Unity Local');
+
+    fireEvent.change(within(dialog).getAllByTestId('mock-select')[0], {
+      target: { value: 'unity' },
+    });
+
+    await user.click(within(dialog).getByRole('button', { name: /^create$/i }));
+
+    expect(onCreateSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: 'unity-local',
+        format: 'generic',
+        format_key: 'unity',
+      })
+    );
+  });
+
+  it('submits built-in formats without a format_key', async () => {
+    const onCreateSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <RepoDialogs
+        {...defaultProps}
+        onCreateSubmit={onCreateSubmit}
+        pluginFormats={[UNITY_HANDLER]}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog');
+    await user.type(within(dialog).getByPlaceholderText('my-repo'), 'npm-local');
+    await user.type(within(dialog).getByPlaceholderText('My Repository'), 'NPM Local');
+
+    fireEvent.change(within(dialog).getAllByTestId('mock-select')[0], {
+      target: { value: 'npm' },
+    });
+
+    await user.click(within(dialog).getByRole('button', { name: /^create$/i }));
+
+    expect(onCreateSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ format: 'npm', format_key: undefined })
     );
   });
 });

--- a/src/app/(app)/repositories/_components/repo-dialogs.tsx
+++ b/src/app/(app)/repositories/_components/repo-dialogs.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import type { Repository, CreateRepositoryRequest, RepositoryFormat, RepositoryType, VirtualRepoMemberInput } from "@/types";
+import type { FormatHandler } from "@/lib/api/format-handlers";
 import {
   FORMAT_OPTIONS,
   TYPE_OPTIONS,
@@ -103,6 +104,12 @@ interface RepoDialogsProps {
   deletePending: boolean;
   // Available repos for virtual repo member selection
   availableRepos?: Repository[];
+  /**
+   * Enabled WASM plugin format handlers offered as custom layouts in the
+   * create dialog's format selector (#591). Empty/omitted when no plugins
+   * are installed — the plugin options are simply absent then.
+   */
+  pluginFormats?: FormatHandler[];
 }
 
 export function RepoDialogs({
@@ -124,6 +131,7 @@ export function RepoDialogs({
   onDeleteConfirm,
   deletePending,
   availableRepos = [],
+  pluginFormats = [],
 }: RepoDialogsProps) {
   // Create form state
   const [createForm, setCreateForm] = useState<CreateRepositoryRequest>({
@@ -313,8 +321,16 @@ export function RepoDialogs({
             className="space-y-4"
             onSubmit={(e) => {
               e.preventDefault();
+              // #591: a selected WASM plugin layout is submitted as
+              // `format: "generic"` plus the plugin's `format_key` — the
+              // backend binds plugin-backed repos that way (migration 065).
+              const selectedPlugin = pluginFormats.find(
+                (h) => h.format_key === createForm.format,
+              );
               const submitData: CreateRepositoryRequest = {
                 ...createForm,
+                format: selectedPlugin ? "generic" : createForm.format,
+                format_key: selectedPlugin?.format_key,
                 quota_bytes: quotaToBytes(createQuotaValue, createQuotaUnit) ?? undefined,
                 upstream_url: createForm.repo_type === "remote" ? createForm.upstream_url : undefined,
                 member_repos: createForm.repo_type === "virtual" ? buildMemberRepos() : undefined,
@@ -409,6 +425,13 @@ export function RepoDialogs({
                     {SORTED_FORMAT_OPTIONS.map((o) => (
                       <SelectItem key={o.value} value={o.value}>
                         {o.label}
+                      </SelectItem>
+                    ))}
+                    {/* #591: custom layouts from installed WASM plugins,
+                        labeled as plugin-provided; absent when none. */}
+                    {pluginFormats.map((h) => (
+                      <SelectItem key={h.format_key} value={h.format_key}>
+                        {`Custom (plugin: ${h.display_name})`}
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/src/app/(app)/repositories/_components/repo-list-item.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-list-item.test.tsx
@@ -98,3 +98,43 @@ describe("RepoListItem", () => {
     ).not.toBeInTheDocument();
   });
 });
+
+describe("RepoListItem - WASM plugin layout label (#592)", () => {
+  const pluginRepo: Repository = {
+    ...repo,
+    id: "2",
+    key: "unity-local",
+    name: "Unity Local",
+    format: "generic",
+    format_key: "unity",
+    repo_type: "local",
+  };
+
+  it("renders the plugin layout label instead of bare GENERIC", () => {
+    render(
+      <RepoListItem
+        repo={pluginRepo}
+        isSelected={false}
+        onSelect={vi.fn()}
+        formatLabel="Unity"
+      />
+    );
+
+    expect(screen.getByText("Unity")).toBeInTheDocument();
+    expect(screen.queryByText("generic")).not.toBeInTheDocument();
+  });
+
+  it("still renders GENERIC for a plain generic repo without a layout label", () => {
+    const plainGeneric: Repository = {
+      ...repo,
+      id: "3",
+      key: "files",
+      name: "Files",
+      format: "generic",
+      format_key: null,
+    };
+    render(<RepoListItem repo={plainGeneric} isSelected={false} onSelect={vi.fn()} />);
+
+    expect(screen.getByText("generic")).toBeInTheDocument();
+  });
+});

--- a/src/app/(app)/repositories/_components/repo-list-item.tsx
+++ b/src/app/(app)/repositories/_components/repo-list-item.tsx
@@ -18,9 +18,15 @@ interface RepoListItemProps {
   onEdit?: (repo: Repository) => void;
   onDelete?: (repo: Repository) => void;
   artifactMatchCount?: number;
+  /**
+   * Resolved format label (#592). For repos backed by a WASM plugin layout
+   * (`format: "generic"` + `format_key`) the parent passes the plugin layout
+   * name so the row does not show a bare "GENERIC"; defaults to `repo.format`.
+   */
+  formatLabel?: string;
 }
 
-export function RepoListItem({ repo, isSelected, onSelect, onEdit, onDelete, artifactMatchCount }: RepoListItemProps) {
+export function RepoListItem({ repo, isSelected, onSelect, onEdit, onDelete, artifactMatchCount, formatLabel }: RepoListItemProps) {
   // #672: the row's primary action is a real <button> that is a SIBLING of the
   // actions dropdown trigger — never an ancestor — so no interactive element
   // nests inside another and the row's accessible name stays clean (it no
@@ -49,7 +55,7 @@ export function RepoListItem({ repo, isSelected, onSelect, onEdit, onDelete, art
             </p>
             <div className="flex items-center gap-1.5 mt-0.5">
               <span className="text-[11px] font-medium uppercase text-muted-foreground">
-                {repo.format}
+                {formatLabel ?? repo.format}
               </span>
               <span className="text-muted-foreground">·</span>
               <span className={cn("text-[11px] font-medium", REPO_TYPE_COLORS[repo.repo_type] ? "" : "text-muted-foreground")}>

--- a/src/app/(app)/repositories/_components/repo-settings-tab.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-settings-tab.test.tsx
@@ -62,6 +62,16 @@ vi.mock("@/providers/auth-provider", () => ({
   useAuth: () => mockUseAuth(),
 }));
 
+// Mock the format-handlers hook (resolves WASM plugin layout names, #592).
+const mockUseFormatHandlers = vi.fn(
+  (): { data: { format_key: string; display_name: string }[] | undefined } => ({
+    data: undefined,
+  })
+);
+vi.mock("@/hooks/use-format-handlers", () => ({
+  useFormatHandlers: () => mockUseFormatHandlers(),
+}));
+
 // Mock the scan-config API (apiFetch-based client for the security endpoint).
 const mockGetScanConfig = vi.fn();
 const mockUpdateScanConfig = vi.fn();
@@ -1678,5 +1688,49 @@ describe("RepoSettingsTab - Scanning & enforcement (#2954/#3003)", () => {
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith("Failed to save scanning settings");
     });
+  });
+});
+
+describe("RepoSettingsTab - WASM plugin layout display (#592)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListPolicies.mockResolvedValue([]);
+  });
+
+  it("shows the plugin layout name and annotation for a plugin-backed repo", () => {
+    mockUseFormatHandlers.mockReturnValue({
+      data: [{ format_key: "unity", display_name: "Unity" }],
+    });
+    const pluginRepo: Repository = {
+      ...baseRepo,
+      format: "generic",
+      format_key: "unity",
+    };
+
+    render(<RepoSettingsTab repository={pluginRepo} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByText("UNITY")).toBeTruthy();
+    expect(
+      screen.getByText(/custom layout provided by a wasm plugin/i)
+    ).toBeTruthy();
+  });
+
+  it("still shows GENERIC without annotation for a plain generic repo", () => {
+    const plainGeneric: Repository = {
+      ...baseRepo,
+      format: "generic",
+      format_key: null,
+    };
+
+    render(<RepoSettingsTab repository={plainGeneric} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByText("GENERIC")).toBeTruthy();
+    expect(
+      screen.queryByText(/custom layout provided by a wasm plugin/i)
+    ).toBeNull();
   });
 });

--- a/src/app/(app)/repositories/_components/repo-settings-tab.tsx
+++ b/src/app/(app)/repositories/_components/repo-settings-tab.tsx
@@ -19,6 +19,8 @@ import {
 } from "@/lib/api/scan-config";
 import { mutationErrorToast } from "@/lib/error-utils";
 import { formatBytes } from "@/lib/utils";
+import { useFormatHandlers } from "@/hooks/use-format-handlers";
+import { isPluginBackedRepo, repoFormatLabel } from "@/lib/repo-format";
 import type {
   Repository,
   DebianRepoConfig,
@@ -165,6 +167,10 @@ interface RepoSettingsTabProps {
 
 export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
   const queryClient = useQueryClient();
+
+  // Installed format handlers — resolves the custom layout name when the
+  // repo is backed by a WASM plugin (#592).
+  const { data: formatHandlers } = useFormatHandlers();
 
   // -- General settings form state (override-based, like the edit dialog) --
   const defaults = useMemo(
@@ -1319,10 +1325,15 @@ export function RepoSettingsTab({ repository }: RepoSettingsTabProps) {
         </h3>
         <dl className="grid grid-cols-[140px_1fr] gap-x-4 gap-y-2 text-sm">
           <dt className="text-muted-foreground">Format</dt>
-          <dd>
+          <dd className="flex items-center gap-2">
             <Badge variant="secondary" className="text-xs">
-              {repository.format.toUpperCase()}
+              {repoFormatLabel(repository, formatHandlers).toUpperCase()}
             </Badge>
+            {isPluginBackedRepo(repository) && (
+              <span className="text-xs text-muted-foreground">
+                Custom layout provided by a WASM plugin (generic family)
+              </span>
+            )}
           </dd>
           <dt className="text-muted-foreground">Type</dt>
           <dd className="capitalize">{repository.repo_type}</dd>

--- a/src/app/(app)/repositories/_components/repositories-content.tsx
+++ b/src/app/(app)/repositories/_components/repositories-content.tsx
@@ -12,6 +12,8 @@ import type { Repository, CreateRepositoryRequest } from "@/types";
 import { useAuth } from "@/providers/auth-provider";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useRepositories } from "@/hooks/use-repositories";
+import { useFormatHandlers, wasmPluginFormats } from "@/hooks/use-format-handlers";
+import { repoFormatLabel } from "@/lib/repo-format";
 import { useDocumentTitle } from "@/hooks/use-document-title";
 
 import { Button } from "@/components/ui/button";
@@ -85,6 +87,11 @@ export function RepositoriesContent() {
     format: formatFilter === "__all__" ? undefined : formatFilter,
     repo_type: typeFilter === "__all__" ? undefined : typeFilter,
   });
+
+  // Installed format handlers — drives the create dialog's custom WASM
+  // plugin layouts (#591) and the plugin layout labels in the list (#592).
+  const { data: formatHandlers } = useFormatHandlers();
+  const pluginFormats = useMemo(() => wasmPluginFormats(formatHandlers), [formatHandlers]);
 
   // --- mutations ---
 
@@ -371,6 +378,7 @@ export function RepositoriesContent() {
                 onEdit={isAdmin ? handleEdit : undefined}
                 onDelete={isAdmin ? handleDelete : undefined}
                 artifactMatchCount={searchQuery ? artifactMatchMap.get(repo.key) : undefined}
+                formatLabel={repoFormatLabel(repo, formatHandlers)}
               />
             ))}
           </div>
@@ -504,6 +512,7 @@ export function RepositoriesContent() {
         onDeleteConfirm={(key) => deleteMutation.mutate(key)}
         deletePending={deleteMutation.isPending}
         availableRepos={items}
+        pluginFormats={pluginFormats}
       />
     </div>
   );

--- a/src/hooks/use-format-handlers.ts
+++ b/src/hooks/use-format-handlers.ts
@@ -1,0 +1,41 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import {
+  formatHandlersApi,
+  type FormatHandler,
+} from "@/lib/api/format-handlers";
+
+/**
+ * Shared query key for the format-handler list. Exported so the admin
+ * format-handlers page and repository surfaces share one cache entry.
+ * (Defined here rather than in `lib/query-keys.ts` so consumers that mock
+ * that module do not see an undefined key.)
+ */
+export const FORMAT_HANDLERS_QUERY_KEY = ["format-handlers"] as const;
+
+/**
+ * Installed package-format handlers (built-in `Core` and WASM plugins).
+ *
+ * The backend mounts `GET /api/v1/formats` behind optional auth, so this is
+ * safe for non-admin users — e.g. the repository create dialog listing
+ * selectable WASM plugin layouts (#591).
+ */
+export function useFormatHandlers(): UseQueryResult<FormatHandler[], Error> {
+  return useQuery({
+    queryKey: FORMAT_HANDLERS_QUERY_KEY,
+    queryFn: () => formatHandlersApi.list(),
+    staleTime: 60_000,
+  });
+}
+
+/**
+ * Enabled WASM plugin handlers — the custom layouts a user may select when
+ * creating a repository. Disabled plugins are excluded: the backend rejects
+ * repository creation against a disabled handler.
+ */
+export function wasmPluginFormats(
+  handlers: FormatHandler[] | undefined | null,
+): FormatHandler[] {
+  return (handlers ?? []).filter(
+    (h) => h.handler_type === "Wasm" && h.is_enabled,
+  );
+}

--- a/src/lib/__tests__/repo-format.test.ts
+++ b/src/lib/__tests__/repo-format.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+
+import { isPluginBackedRepo, repoFormatLabel } from "@/lib/repo-format";
+
+const HANDLERS = [
+  { format_key: "unity", display_name: "Unity" },
+  { format_key: "pypi", display_name: "PyPI" },
+];
+
+describe("isPluginBackedRepo", () => {
+  it("is true for a generic repo with a format_key", () => {
+    expect(isPluginBackedRepo({ format: "generic", format_key: "unity" })).toBe(true);
+  });
+
+  it("is false for a plain generic repo", () => {
+    expect(isPluginBackedRepo({ format: "generic", format_key: null })).toBe(false);
+    expect(isPluginBackedRepo({ format: "generic" })).toBe(false);
+  });
+
+  it("is false for built-in formats even if a format_key leaks through", () => {
+    expect(isPluginBackedRepo({ format: "npm", format_key: "unity" })).toBe(false);
+  });
+});
+
+describe("repoFormatLabel", () => {
+  it("resolves the plugin display name for a plugin-backed repo (#592)", () => {
+    expect(
+      repoFormatLabel({ format: "generic", format_key: "unity" }, HANDLERS)
+    ).toBe("Unity");
+  });
+
+  it("falls back to the raw format_key for an unknown plugin id", () => {
+    expect(
+      repoFormatLabel({ format: "generic", format_key: "acme-layout" }, HANDLERS)
+    ).toBe("acme-layout");
+    expect(
+      repoFormatLabel({ format: "generic", format_key: "acme-layout" }, undefined)
+    ).toBe("acme-layout");
+  });
+
+  it("returns the format id for a plain generic repo", () => {
+    expect(repoFormatLabel({ format: "generic", format_key: null }, HANDLERS)).toBe(
+      "generic"
+    );
+  });
+
+  it("returns the format id for built-in formats", () => {
+    expect(repoFormatLabel({ format: "npm", format_key: null }, HANDLERS)).toBe("npm");
+  });
+});

--- a/src/lib/api/__tests__/repositories.test.ts
+++ b/src/lib/api/__tests__/repositories.test.ts
@@ -924,3 +924,52 @@ describe("repositoriesApi.updateAgePolicy", () => {
     ).rejects.toThrow("age policy boom");
   });
 });
+
+describe("repositoriesApi — WASM plugin format_key (#591/#592)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("adapts format_key from the SDK response for plugin-backed repos", async () => {
+    mockListRepositories.mockResolvedValue({
+      data: {
+        items: [sdkRepo({ format: "generic", format_key: "unity" })],
+        pagination: { page: 1, per_page: 20, total: 1, total_pages: 1 },
+      },
+      error: undefined,
+    });
+
+    const result = await repositoriesApi.list();
+    expect(result.items[0].format).toBe("generic");
+    expect(result.items[0].format_key).toBe("unity");
+  });
+
+  it("defaults format_key to null when the backend omits it", async () => {
+    mockListRepositories.mockResolvedValue({
+      data: {
+        items: [sdkRepo()],
+        pagination: { page: 1, per_page: 20, total: 1, total_pages: 1 },
+      },
+      error: undefined,
+    });
+
+    const result = await repositoriesApi.list();
+    expect(result.items[0].format_key).toBeNull();
+  });
+
+  it("forwards format_key in the create body for plugin layouts", async () => {
+    mockCreateRepository.mockResolvedValue({
+      data: sdkRepo({ format: "generic", format_key: "unity" }),
+      error: undefined,
+    });
+
+    await repositoriesApi.create({
+      key: "unity-local",
+      name: "Unity Local",
+      format: "generic",
+      format_key: "unity",
+      repo_type: "local",
+    });
+
+    const call = mockCreateRepository.mock.calls[0]?.[0] as { body: Record<string, unknown> };
+    expect(call.body).toMatchObject({ format: "generic", format_key: "unity" });
+  });
+});

--- a/src/lib/api/repositories.ts
+++ b/src/lib/api/repositories.ts
@@ -160,6 +160,12 @@ function adaptRepository(sdk: RepositoryResponse): Repository {
         `This likely means the backend added a format the SDK hasn't picked up yet.`,
     ),
     repo_type: narrowEnum(sdk.repo_type, REPO_TYPES, 'local'),
+    // `format_key` (backend migration 065) links a Generic-format repository
+    // to the WASM plugin format handler providing its custom layout. The
+    // generated SDK `RepositoryResponse` type does not declare it yet, so it
+    // is read defensively; backends that omit it yield `null`.
+    format_key:
+      (sdk as RepositoryResponse & { format_key?: string | null }).format_key ?? null,
     is_public: sdk.is_public,
     // `versioning_enabled` (artifact-keeper#2367) is now carried on the
     // generated SDK type; `?? false` stays defensive against a backend that
@@ -232,6 +238,10 @@ export const repositoriesApi = {
       name: input.name,
       description: input.description,
       format: input.format,
+      // #591: WASM plugin layouts are created as `format: "generic"` plus the
+      // plugin's `format_key` (backend migration 065). Undefined for built-in
+      // formats and dropped by JSON serialization.
+      format_key: input.format_key,
       repo_type: input.repo_type,
       is_public: input.is_public,
       quota_bytes: input.quota_bytes,

--- a/src/lib/repo-format.ts
+++ b/src/lib/repo-format.ts
@@ -1,0 +1,41 @@
+import type { FormatHandler } from "@/lib/api/format-handlers";
+import type { Repository } from "@/types";
+
+/**
+ * Display helpers for repository formats, including custom layouts provided
+ * by WASM plugin format handlers (#591/#592).
+ *
+ * Backend contract (migration 065): a plugin-backed repository is stored as
+ * `format = "generic"` plus `format_key = <plugin format key>`. Rendering
+ * `format` alone therefore shows a bare "GENERIC" for plugin repos — these
+ * helpers resolve the plugin layout identity instead.
+ */
+
+type RepoFormatFields = Pick<Repository, "format" | "format_key">;
+
+type FormatHandlerLike = Pick<FormatHandler, "format_key" | "display_name">;
+
+/** True when the repository is backed by a WASM plugin layout. */
+export function isPluginBackedRepo(repo: RepoFormatFields): boolean {
+  return repo.format === "generic" && !!repo.format_key;
+}
+
+/**
+ * Human-readable label for a repository's format.
+ *
+ * Plugin-backed repos resolve to the handler's `display_name` when the
+ * installed format handlers are known, falling back to the raw `format_key`
+ * (the layout id) so an unknown or uninstalled plugin id still renders
+ * something meaningful. Built-in formats return the format id unchanged, so
+ * callers can keep their existing uppercasing.
+ */
+export function repoFormatLabel(
+  repo: RepoFormatFields,
+  handlers?: FormatHandlerLike[] | null,
+): string {
+  if (isPluginBackedRepo(repo)) {
+    const handler = handlers?.find((h) => h.format_key === repo.format_key);
+    return handler?.display_name ?? (repo.format_key as string);
+  }
+  return repo.format;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,6 +58,13 @@ export interface Repository {
   name: string;
   description?: string;
   format: RepositoryFormat;
+  /**
+   * Custom layout key of the WASM plugin format handler backing this
+   * repository (backend migration 065, `repositories.format_key`). Set only
+   * for plugin-backed repos, which report `format: "generic"`; `null` /
+   * absent for built-in formats.
+   */
+  format_key?: string | null;
   repo_type: RepositoryType;
   is_public: boolean;
   /**
@@ -169,6 +176,12 @@ export interface CreateRepositoryRequest {
   name: string;
   description?: string;
   format: RepositoryFormat;
+  /**
+   * WASM plugin layout to back this repository with (backend migration 065).
+   * When set, `format` must be `"generic"`; the backend binds the repo to the
+   * plugin format handler with this key. Omit for built-in formats.
+   */
+  format_key?: string;
   repo_type: RepositoryType;
   is_public?: boolean;
   /** Opt a Generic/Mlmodel repository into first-class versioning (#571). */


### PR DESCRIPTION
## Summary

Fixes #591
Fixes #592

Custom layouts provided by installed WASM plugin format handlers were selectable via the API but invisible in the UI: the repository create dialog only offered the static built-in format list, and after creating a plugin-backed repo every surface showed its type as a bare `GENERIC`.

Backend contract (migration 065): a plugin-backed repository is stored as `format = "generic"` plus `format_key = <plugin format key>` (`repositories.format_key`). `POST /repositories` accepts that `format_key` on create, and `GET /api/v1/formats` (mounted behind optional auth, so non-admins can read it) lists the installed handlers with `handler_type: "Wasm"`.

**#591 — select a custom layout in the create dialog**
- New `useFormatHandlers()` hook (`src/hooks/use-format-handlers.ts`) sharing one `["format-handlers"]` cache entry with the admin format-handlers page.
- The create dialog's format selector now appends enabled WASM plugin handlers as clearly-labeled options — `Custom (plugin: <display name>)` — fetched live. With no plugins installed the options are simply absent.
- Submitting a plugin layout sends `format: "generic"` + `format_key: <plugin key>`, matching the API path that already worked.

**#592 — reflect the custom layout everywhere a repo type is shown**
- `Repository.format_key` is adapted from the repository response (read defensively — the generated SDK type does not declare it yet; backends that omit it yield `null`).
- New `repoFormatLabel()` / `isPluginBackedRepo()` helpers (`src/lib/repo-format.ts`): a plugin-backed repo resolves to the handler's display name, falling back to the raw `format_key` for unknown/uninstalled plugin ids. Plain generic repos still render `GENERIC`.
- Updated surfaces: repositories list row, repo detail header (both layouts, plus a `WASM plugin` badge), and the settings tab's Repository Info Format row (plus a "Custom layout provided by a WASM plugin (generic family)" note).

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

Added coverage: plugin layout options appear in the create dialog when plugins exist and are absent when none; submit maps a plugin selection to `format: "generic"` + `format_key`; built-in formats submit no `format_key`; `repoFormatLabel` resolves display name / raw-key fallback / plain-generic; list item renders the plugin label and still renders `GENERIC`; settings tab shows the plugin annotation; API adaptation of `format_key` (list + create body). Full suite: 168 files / 3099 tests passing; `tsc --noEmit` unchanged vs baseline (23 pre-existing errors in unrelated test files); ESLint clean on changed files; `next build` passes.

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes

The new select options are native `SelectItem`s inside the existing format dropdown, inheriting its keyboard/screen-reader behavior; the display changes are text/badge-only.
