### PR TITLE
fix(permissions): support service account principals

### DIFF
--- a/e2e/suites/interactions/admin/permissions.spec.ts
+++ b/e2e/suites/interactions/admin/permissions.spec.ts
@@ -42,6 +42,32 @@ test.describe('Permissions Management', () => {
     await dialog.getByRole('button', { name: /cancel/i }).click();
   });
 
+  test('can select a service account as the permission principal', async ({ page }) => {
+    await page.getByRole('button', { name: /create permission/i }).first().click();
+    const dialog = page.getByRole('dialog', { name: 'Create Permission', exact: true });
+    await expect(dialog).toBeVisible({ timeout: 10000 });
+
+    const principalType = dialog.locator('[role="combobox"]').filter({ hasText: /^User$/ });
+    await expect(principalType).toHaveCount(1);
+    await principalType.click();
+    await page.getByRole('option', { name: 'Service Account', exact: true }).click();
+
+    const principalPicker = dialog.getByRole('combobox', { name: 'Principal', exact: true });
+    await expect(principalPicker).toBeVisible();
+    await principalPicker.click();
+
+    const principalSearch = page.getByRole('combobox', { name: 'Search principals' });
+    await principalSearch.fill('e2e-ci-bot');
+
+    const seededServiceAccount = page.getByRole('option', { name: 'Service account for E2E tests' });
+    await expect(seededServiceAccount).toBeVisible({ timeout: 10000 });
+    await seededServiceAccount.click();
+    await expect(principalPicker).toContainText('Service account for E2E tests');
+
+    await dialog.getByRole('button', { name: /cancel/i }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 10000 });
+  });
+
   test('dialog has action checkboxes for Read, Write, Delete, Admin', async ({ page }) => {
     await page.getByRole('button', { name: /create permission/i }).first().click();
     const dialog = page.getByRole('dialog');

--- a/src/app/(app)/(admin)/permissions/page.test.tsx
+++ b/src/app/(app)/(admin)/permissions/page.test.tsx
@@ -416,19 +416,20 @@ describe("PermissionsPage", () => {
     expect(screen.getAllByText("npm-local").length).toBeGreaterThan(0);
   });
 
-  it("renders service account principal type with a human-readable label", async () => {
+  it("uses the loaded service account name when a permission row omits principal_name", async () => {
     mockPermissionsApi.list.mockResolvedValue({
       items: [{
         ...PERM_1,
         principal_type: "service_account" as const,
         principal_id: "service-account-1",
-        principal_name: "Release Bot",
+        principal_name: undefined,
       }],
       pagination: { page: 1, per_page: 1000, total: 1, total_pages: 1 },
     });
     renderPage();
     await waitFor(() => {
       expect(screen.getByText("Service Account")).toBeTruthy();
+      expect(screen.getByText("Release Bot")).toBeTruthy();
     });
     expect(screen.queryByText("Service_account")).toBeNull();
   });

--- a/src/app/(app)/(admin)/permissions/page.test.tsx
+++ b/src/app/(app)/(admin)/permissions/page.test.tsx
@@ -416,6 +416,23 @@ describe("PermissionsPage", () => {
     expect(screen.getAllByText("npm-local").length).toBeGreaterThan(0);
   });
 
+  it("renders service account principal type with a human-readable label", async () => {
+    mockPermissionsApi.list.mockResolvedValue({
+      items: [{
+        ...PERM_1,
+        principal_type: "service_account" as const,
+        principal_id: "service-account-1",
+        principal_name: "Release Bot",
+      }],
+      pagination: { page: 1, per_page: 1000, total: 1, total_pages: 1 },
+    });
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Service Account")).toBeTruthy();
+    });
+    expect(screen.queryByText("Service_account")).toBeNull();
+  });
+
   it("shows empty state when no permissions exist", async () => {
     mockPermissionsApi.list.mockResolvedValue({
       items: [],
@@ -527,7 +544,7 @@ describe("PermissionsPage", () => {
       const principalPicker = screen.getByRole("combobox", { name: "Principal" });
       expect(principalPicker.textContent).toContain("Select...");
       await user.click(principalPicker);
-      await user.type(screen.getByRole("textbox", { name: "Search principals" }), "release");
+      await user.type(screen.getByRole("textbox", { name: "Search principals" }), "svc-release");
       expect(screen.getByRole("button", { name: "Release Bot" })).toBeTruthy();
       expect(screen.queryByRole("button", { name: "Alice" })).toBeNull();
       expect(screen.queryByRole("button", { name: "Developers" })).toBeNull();

--- a/src/app/(app)/(admin)/permissions/page.test.tsx
+++ b/src/app/(app)/(admin)/permissions/page.test.tsx
@@ -41,6 +41,11 @@ vi.mock("@/lib/api/admin", () => ({
   adminApi: mockAdminApi,
 }));
 
+const mockServiceAccountsApi = { list: vi.fn() };
+vi.mock("@/lib/api/service-accounts", () => ({
+  serviceAccountsApi: mockServiceAccountsApi,
+}));
+
 const mockToast = { success: vi.fn(), error: vi.fn() };
 vi.mock("sonner", () => ({ toast: mockToast }));
 
@@ -92,6 +97,45 @@ vi.mock("@/components/ui/select", () => {
   }
   return { Select, SelectTrigger, SelectValue, SelectContent, SelectItem };
 });
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode; asChild?: boolean }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/command", () => ({
+  Command: ({ children }: { children: React.ReactNode; shouldFilter?: boolean }) => <div>{children}</div>,
+  CommandInput: ({
+    value,
+    onValueChange,
+    ...props
+  }: {
+    value?: string;
+    onValueChange?: (value: string) => void;
+  } & React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input
+      {...props}
+      value={value ?? ""}
+      onChange={(event) => onValueChange?.(event.target.value)}
+    />
+  ),
+  CommandList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CommandEmpty: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CommandGroup: ({ children }: { children: React.ReactNode; heading?: string }) => <div>{children}</div>,
+  CommandItem: ({
+    children,
+    onSelect,
+  }: {
+    children: React.ReactNode;
+    value: string;
+    onSelect?: () => void;
+  }) => (
+    <button type="button" onClick={onSelect}>
+      {children}
+    </button>
+  ),
+}));
 
 // -- Radix UI Checkbox replaced with native <input type="checkbox"> ---------
 vi.mock("@/components/ui/checkbox", () => ({
@@ -203,6 +247,18 @@ const MOCK_GROUPS = [
   { id: "grp-2", name: "QA Team", description: "", auto_join: false, member_count: 2, is_external: false, created_at: "2025-01-01T00:00:00Z", updated_at: "2025-01-01T00:00:00Z" },
 ];
 
+const MOCK_SERVICE_ACCOUNTS = [
+  {
+    id: "service-account-1",
+    username: "svc-release-bot",
+    display_name: "Release Bot",
+    is_active: true,
+    token_count: 1,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  },
+];
+
 const MOCK_REPOS = [
   { id: "repo-1", key: "npm-local", name: "NPM Local", format: "npm" as const, repo_type: "local" as const, is_public: false, storage_used_bytes: 0, created_at: "2025-01-01T00:00:00Z", updated_at: "2025-01-01T00:00:00Z" },
   { id: "repo-2", key: "maven-remote", name: "", format: "maven" as const, repo_type: "remote" as const, is_public: true, storage_used_bytes: 0, created_at: "2025-01-01T00:00:00Z", updated_at: "2025-01-01T00:00:00Z" },
@@ -261,7 +317,7 @@ async function openCreateDialog(user: ReturnType<typeof userEvent.setup>) {
   await user.click(buttons[0]);
   await waitFor(() => {
     expect(
-      screen.getByText("Grant a user or group access to a target resource."),
+      screen.getByText("Grant a user, service account, or group access to a target resource."),
     ).toBeTruthy();
   });
 }
@@ -269,12 +325,20 @@ async function openCreateDialog(user: ReturnType<typeof userEvent.setup>) {
 /**
  * Return all native <select> elements inside a dialog.
  * In the create/edit form the order is:
- *   [0] principal_type   [1] principal_id
- *   [2] target_type      [3] target_id (absent when target_type=artifact)
+ *   [0] principal_type   [1] target_type
+ *   [2] target_id (absent when target_type=artifact)
  */
 function getFormSelects(): HTMLSelectElement[] {
   const dialog = screen.getByRole("dialog");
   return Array.from(dialog.querySelectorAll("select"));
+}
+
+async function selectPrincipal(
+  user: ReturnType<typeof userEvent.setup>,
+  label: string,
+) {
+  await user.click(screen.getByRole("combobox", { name: "Principal" }));
+  await user.click(screen.getByRole("button", { name: label }));
 }
 
 /**
@@ -310,6 +374,7 @@ beforeEach(async () => {
     items: MOCK_GROUPS,
     pagination: { page: 1, per_page: 1000, total: 2, total_pages: 1 },
   });
+  mockServiceAccountsApi.list.mockResolvedValue(MOCK_SERVICE_ACCOUNTS);
   mockRepositoriesApi.list.mockResolvedValue({
     items: MOCK_REPOS,
     pagination: { page: 1, per_page: 1000, total: 2, total_pages: 1 },
@@ -378,7 +443,7 @@ describe("PermissionsPage", () => {
 
       // The target_type select should have value "repository"
       const selects = getFormSelects();
-      expect(selects[2].value).toBe("repository");
+      expect(selects[1].value).toBe("repository");
     });
 
     it("shows text input with placeholder Artifact UUID for artifact target type", async () => {
@@ -388,14 +453,14 @@ describe("PermissionsPage", () => {
       await openCreateDialog(user);
 
       const selects = getFormSelects();
-      await user.selectOptions(selects[2], "artifact");
+      await user.selectOptions(selects[1], "artifact");
 
       // Label should change to "Artifact ID"
       expect(screen.getByText("Artifact ID")).toBeTruthy();
       // A text input with the UUID placeholder should appear
       expect(screen.getByPlaceholderText("Artifact UUID")).toBeTruthy();
-      // The target_id select should be replaced by the input, so only 3 selects remain
-      expect(getFormSelects().length).toBe(3);
+      // The target_id select should be replaced by the input, so only 2 selects remain
+      expect(getFormSelects().length).toBe(2);
     });
 
     it("shows Target Group label and group select for group target type", async () => {
@@ -405,13 +470,13 @@ describe("PermissionsPage", () => {
       await openCreateDialog(user);
 
       const selects = getFormSelects();
-      await user.selectOptions(selects[2], "group");
+      await user.selectOptions(selects[1], "group");
 
       expect(screen.getByText("Target Group")).toBeTruthy();
 
       // The target_id select should contain group options
       const updatedSelects = getFormSelects();
-      const targetIdSelect = updatedSelects[3];
+      const targetIdSelect = updatedSelects[2];
       const options = Array.from(targetIdSelect.querySelectorAll("option"));
       expect(options.some((o) => o.value === "grp-1")).toBe(true);
       expect(options.some((o) => o.textContent === "Developers")).toBe(true);
@@ -424,8 +489,8 @@ describe("PermissionsPage", () => {
       await openCreateDialog(user);
 
       const selects = getFormSelects();
-      const targetTypeSelect = selects[2];
-      const targetIdSelect = selects[3];
+      const targetTypeSelect = selects[1];
+      const targetIdSelect = selects[2];
 
       // Pick a repository
       await user.selectOptions(targetIdSelect, "repo-1");
@@ -435,7 +500,52 @@ describe("PermissionsPage", () => {
       await user.selectOptions(targetTypeSelect, "group");
 
       const refreshed = getFormSelects();
-      expect(refreshed[3].value).toBe("");
+      expect(refreshed[2].value).toBe("");
+    });
+  });
+
+  describe("service account principals", () => {
+    it("filters principals by type and sends service_account in the create payload", async () => {
+      const user = userEvent.setup();
+      mockPermissionsApi.create.mockResolvedValue({
+        ...PERM_1,
+        principal_type: "service_account",
+        principal_id: "service-account-1",
+        principal_name: "Release Bot",
+      });
+      renderPage();
+      await waitForTableLoaded();
+      await openCreateDialog(user);
+
+      await selectPrincipal(user, "Alice");
+      expect(screen.getByRole("combobox", { name: "Principal" }).textContent).toContain("Alice");
+
+      const selects = getFormSelects();
+
+      await user.selectOptions(selects[0], "service_account");
+
+      const principalPicker = screen.getByRole("combobox", { name: "Principal" });
+      expect(principalPicker.textContent).toContain("Select...");
+      await user.click(principalPicker);
+      await user.type(screen.getByRole("textbox", { name: "Search principals" }), "release");
+      expect(screen.getByRole("button", { name: "Release Bot" })).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Alice" })).toBeNull();
+      expect(screen.queryByRole("button", { name: "Developers" })).toBeNull();
+
+      await user.click(screen.getByRole("button", { name: "Release Bot" }));
+      await user.selectOptions(getFormSelects()[2], "repo-1");
+      const submitButtons = screen.getAllByText(/Create Permission/);
+      await user.click(submitButtons[submitButtons.length - 1]);
+
+      await waitFor(() => {
+        expect(mockPermissionsApi.create).toHaveBeenCalledWith({
+          principal_type: "service_account",
+          principal_id: "service-account-1",
+          target_type: "repository",
+          target_id: "repo-1",
+          actions: ["read"],
+        });
+      });
     });
   });
 
@@ -449,7 +559,7 @@ describe("PermissionsPage", () => {
       await openCreateDialog(user);
 
       const selects = getFormSelects();
-      const targetIdSelect = selects[3];
+      const targetIdSelect = selects[2];
       const options = Array.from(targetIdSelect.querySelectorAll("option"));
       expect(options.some((o) => o.value === "repo-1")).toBe(true);
       expect(options.some((o) => o.value === "repo-2")).toBe(true);
@@ -462,7 +572,7 @@ describe("PermissionsPage", () => {
       await openCreateDialog(user);
 
       const selects = getFormSelects();
-      const targetIdSelect = selects[3];
+      const targetIdSelect = selects[2];
       const options = Array.from(targetIdSelect.querySelectorAll("option"));
       const npmOpt = options.find((o) => o.value === "repo-1");
       expect(npmOpt?.textContent).toContain("npm-local");
@@ -511,10 +621,10 @@ describe("PermissionsPage", () => {
       await waitForTableLoaded();
       await openCreateDialog(user);
 
-      // Fill required fields via the native selects inside the dialog
+      // Pick the default user principal and target repository.
       const selects = getFormSelects();
-      await user.selectOptions(selects[1], "user-2"); // principal_id
-      await user.selectOptions(selects[3], "repo-1"); // target_id
+      await selectPrincipal(user, "Alice");
+      await user.selectOptions(selects[2], "repo-1");
 
       // Click submit -- the last "Create Permission" match is the form button
       const submitBtns = screen.getAllByText(/Create Permission/);
@@ -535,8 +645,8 @@ describe("PermissionsPage", () => {
       await openCreateDialog(user);
 
       const selects = getFormSelects();
-      await user.selectOptions(selects[1], "user-2");
-      await user.selectOptions(selects[3], "repo-1");
+      await selectPrincipal(user, "Alice");
+      await user.selectOptions(selects[2], "repo-1");
 
       const submitBtns = screen.getAllByText(/Create Permission/);
       await user.click(submitBtns[submitBtns.length - 1]);
@@ -554,8 +664,8 @@ describe("PermissionsPage", () => {
       await openCreateDialog(user);
 
       const selects = getFormSelects();
-      await user.selectOptions(selects[1], "user-2");
-      await user.selectOptions(selects[3], "repo-1");
+      await selectPrincipal(user, "Alice");
+      await user.selectOptions(selects[2], "repo-1");
 
       const submitBtns = screen.getAllByText(/Create Permission/);
       await user.click(submitBtns[submitBtns.length - 1]);

--- a/src/app/(app)/(admin)/permissions/page.test.tsx
+++ b/src/app/(app)/(admin)/permissions/page.test.tsx
@@ -98,11 +98,32 @@ vi.mock("@/components/ui/select", () => {
   return { Select, SelectTrigger, SelectValue, SelectContent, SelectItem };
 });
 
-vi.mock("@/components/ui/popover", () => ({
-  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  PopoverTrigger: ({ children }: { children: React.ReactNode; asChild?: boolean }) => <>{children}</>,
-  PopoverContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-}));
+vi.mock("@/components/ui/popover", () => {
+  // Minimal stateful stand-in: the trigger toggles through the page's
+  // onOpenChange so tests exercise the page's own open/close handling
+  // (search reset on close), while content still renders inline.
+  let currentOpen = false;
+  let currentOnOpenChange: ((open: boolean) => void) | undefined;
+  return {
+    Popover: ({
+      children,
+      open,
+      onOpenChange,
+    }: {
+      children: React.ReactNode;
+      open?: boolean;
+      onOpenChange?: (open: boolean) => void;
+    }) => {
+      currentOpen = open ?? false;
+      currentOnOpenChange = onOpenChange;
+      return <>{children}</>;
+    },
+    PopoverTrigger: ({ children }: { children: React.ReactNode; asChild?: boolean }) => (
+      <span onClick={() => currentOnOpenChange?.(!currentOpen)}>{children}</span>
+    ),
+    PopoverContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
 
 vi.mock("@/components/ui/command", () => ({
   Command: ({ children }: { children: React.ReactNode; shouldFilter?: boolean }) => <div>{children}</div>,
@@ -162,12 +183,23 @@ vi.mock("@/components/ui/dialog", () => ({
   Dialog({
     children,
     open,
+    onOpenChange,
   }: {
     children: React.ReactNode;
     open?: boolean;
     onOpenChange?: (o: boolean) => void;
   }) {
-    return open ? <div role="dialog">{children}</div> : null;
+    // Mirror Radix: Escape closes the dialog through onOpenChange.
+    return open ? (
+      <div
+        role="dialog"
+        onKeyDown={(e) => {
+          if (e.key === "Escape") onOpenChange?.(false);
+        }}
+      >
+        {children}
+      </div>
+    ) : null;
   },
   DialogContent({ children }: { children: React.ReactNode; className?: string }) {
     return <div>{children}</div>;
@@ -564,6 +596,80 @@ describe("PermissionsPage", () => {
           actions: ["read"],
         });
       });
+    });
+  });
+
+  describe("group principals", () => {
+    it("lists groups when the principal type is group", async () => {
+      const user = userEvent.setup();
+      renderPage();
+      await waitForTableLoaded();
+      await openCreateDialog(user);
+
+      await user.selectOptions(getFormSelects()[0], "group");
+
+      await user.click(screen.getByRole("combobox", { name: "Principal" }));
+      expect(screen.getByRole("button", { name: "Developers" })).toBeTruthy();
+      expect(screen.getByRole("button", { name: "QA Team" })).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Alice" })).toBeNull();
+      expect(screen.queryByRole("button", { name: "Release Bot" })).toBeNull();
+    });
+  });
+
+  describe("principal picker state", () => {
+    it("clears the principal search when the picker is closed", async () => {
+      const user = userEvent.setup();
+      renderPage();
+      await waitForTableLoaded();
+      await openCreateDialog(user);
+
+      await user.selectOptions(getFormSelects()[0], "service_account");
+
+      const picker = screen.getByRole("combobox", { name: "Principal" });
+      await user.click(picker);
+      const search = screen.getByRole("textbox", {
+        name: "Search principals",
+      }) as HTMLInputElement;
+      await user.type(search, "svc-release");
+      expect(search.value).toBe("svc-release");
+      expect(screen.getByRole("button", { name: "Release Bot" })).toBeTruthy();
+
+      // Toggling the picker closed resets the search filter.
+      await user.click(picker);
+      const reopened = screen.getByRole("textbox", {
+        name: "Search principals",
+      }) as HTMLInputElement;
+      expect(reopened.value).toBe("");
+    });
+
+    it("resets the principal picker and search when the create dialog is closed", async () => {
+      const user = userEvent.setup();
+      renderPage();
+      await waitForTableLoaded();
+      await openCreateDialog(user);
+
+      await user.selectOptions(getFormSelects()[0], "service_account");
+
+      await user.click(screen.getByRole("combobox", { name: "Principal" }));
+      const search = screen.getByRole("textbox", {
+        name: "Search principals",
+      }) as HTMLInputElement;
+      await user.type(search, "zzz");
+      expect(screen.queryByRole("button", { name: "Release Bot" })).toBeNull();
+
+      // Escape closes the dialog (Radix behavior), discarding picker state.
+      await user.keyboard("{Escape}");
+      await waitFor(() => {
+        expect(screen.queryByRole("dialog")).toBeNull();
+      });
+
+      await openCreateDialog(user);
+      await user.selectOptions(getFormSelects()[0], "service_account");
+      const reopenedSearch = screen.getByRole("textbox", {
+        name: "Search principals",
+      }) as HTMLInputElement;
+      expect(reopenedSearch.value).toBe("");
+      expect(screen.getByRole("button", { name: "Release Bot" })).toBeTruthy();
     });
   });
 

--- a/src/app/(app)/(admin)/permissions/page.tsx
+++ b/src/app/(app)/(admin)/permissions/page.tsx
@@ -189,15 +189,35 @@ export default function PermissionsPage() {
     [form.principal_id, principalOptions]
   );
 
+  const serviceAccountNames = useMemo(
+    () => new Map(
+      (serviceAccountsData ?? []).map((account: ServiceAccount) => [
+        account.id,
+        account.display_name || account.username,
+      ])
+    ),
+    [serviceAccountsData]
+  );
+
+  const getPrincipalLabel = useCallback(
+    (permission: Permission) =>
+      permission.principal_name ??
+      (permission.principal_type === "service_account"
+        ? serviceAccountNames.get(permission.principal_id)
+        : undefined) ??
+      permission.principal_id,
+    [serviceAccountNames]
+  );
+
   const filteredPrincipalOptions = useMemo(() => {
     const search = principalSearch.trim().toLowerCase();
     if (!search) return principalOptions;
 
-    return principalOptions.filter((principal) => [
-      principal.label,
-      principal.searchText,
-      principal.value,
-    ].some((value) => value?.toLowerCase().includes(search)));
+    return principalOptions.filter((principal) =>
+      principal.label.toLowerCase().includes(search) ||
+      principal.searchText?.toLowerCase().includes(search) ||
+      principal.value.toLowerCase().startsWith(search)
+    );
   }, [principalOptions, principalSearch]);
 
   const repositoryOptions = useMemo(() =>
@@ -293,7 +313,7 @@ export default function PermissionsPage() {
     {
       id: "principal",
       header: "Principal",
-      accessor: (p) => p.principal_name ?? p.principal_id,
+      accessor: getPrincipalLabel,
       sortable: true,
       cell: (p) => (
         <div className="flex items-center gap-2">
@@ -301,7 +321,7 @@ export default function PermissionsPage() {
             {PRINCIPAL_TYPE_LABELS[p.principal_type]}
           </Badge>
           <span className="text-sm font-medium">
-            {p.principal_name ?? p.principal_id}
+            {getPrincipalLabel(p)}
           </span>
         </div>
       ),
@@ -440,7 +460,10 @@ export default function PermissionsPage() {
               >
                 {form.principal_type === "service_account" && serviceAccountsLoading
                   ? "Loading service accounts..."
-                  : selectedPrincipal?.label ?? "Select..."}
+                  : selectedPrincipal?.label ??
+                    (editOpen && selectedPermission
+                      ? getPrincipalLabel(selectedPermission)
+                      : "Select...")}
                 <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
               </Button>
             </PopoverTrigger>
@@ -457,7 +480,11 @@ export default function PermissionsPage() {
                 />
                 <CommandList>
                   {filteredPrincipalOptions.length === 0 && (
-                    <CommandEmpty>No principals match your search.</CommandEmpty>
+                    <CommandEmpty>
+                      {principalSearch
+                        ? "No principals match your search."
+                        : "No principals are available."}
+                    </CommandEmpty>
                   )}
                   {filteredPrincipalOptions.length > 0 && (
                     <CommandGroup heading="Principals">

--- a/src/app/(app)/(admin)/permissions/page.tsx
+++ b/src/app/(app)/(admin)/permissions/page.tsx
@@ -664,7 +664,11 @@ export default function PermissionsPage() {
         open={createOpen}
         onOpenChange={(o) => {
           setCreateOpen(o);
-          if (!o) setForm(EMPTY_FORM);
+          if (!o) {
+            setForm(EMPTY_FORM);
+            setPrincipalPickerOpen(false);
+            setPrincipalSearch("");
+          }
         }}
       >
         <DialogContent className="sm:max-w-lg">

--- a/src/app/(app)/(admin)/permissions/page.tsx
+++ b/src/app/(app)/(admin)/permissions/page.tsx
@@ -89,12 +89,24 @@ interface PermissionForm {
   actions: PermissionAction[];
 }
 
+interface PrincipalOption {
+  value: string;
+  label: string;
+  searchText?: string;
+}
+
 const EMPTY_FORM: PermissionForm = {
   principal_type: "user",
   principal_id: "",
   target_type: "repository",
   target_id: "",
   actions: ["read"],
+};
+
+const PRINCIPAL_TYPE_LABELS: Record<PermissionPrincipalType, string> = {
+  user: "User",
+  service_account: "Service Account",
+  group: "Group",
 };
 
 // -- page --
@@ -152,17 +164,20 @@ export default function PermissionsPage() {
   const principalOptions = useMemo(() => {
     switch (form.principal_type) {
       case "user":
-        return users.map((u: User) => ({
+        return users.map((u: User): PrincipalOption => ({
           value: u.id,
           label: u.display_name || u.username,
         }));
       case "service_account":
-        return (serviceAccountsData ?? []).map((account: ServiceAccount) => ({
+        return (serviceAccountsData ?? []).map((account: ServiceAccount): PrincipalOption => ({
           value: account.id,
           label: account.display_name || account.username,
+          // Display names often contain a description, while tokens and API
+          // clients refer to the account by its stable svc-* username.
+          searchText: account.username,
         }));
       case "group":
-        return groups.map((g: Group) => ({
+        return groups.map((g: Group): PrincipalOption => ({
           value: g.id,
           label: g.name,
         }));
@@ -178,10 +193,11 @@ export default function PermissionsPage() {
     const search = principalSearch.trim().toLowerCase();
     if (!search) return principalOptions;
 
-    return principalOptions.filter((principal) =>
-      principal.label.toLowerCase().includes(search) ||
-      principal.value.toLowerCase().includes(search)
-    );
+    return principalOptions.filter((principal) => [
+      principal.label,
+      principal.searchText,
+      principal.value,
+    ].some((value) => value?.toLowerCase().includes(search)));
   }, [principalOptions, principalSearch]);
 
   const repositoryOptions = useMemo(() =>
@@ -281,11 +297,8 @@ export default function PermissionsPage() {
       sortable: true,
       cell: (p) => (
         <div className="flex items-center gap-2">
-          <Badge
-            variant="outline"
-            className="text-xs capitalize"
-          >
-            {p.principal_type}
+          <Badge variant="outline" className="text-xs">
+            {PRINCIPAL_TYPE_LABELS[p.principal_type]}
           </Badge>
           <span className="text-sm font-medium">
             {p.principal_name ?? p.principal_id}
@@ -736,7 +749,7 @@ export default function PermissionsPage() {
           if (!o) setSelectedPermission(null);
         }}
         title="Delete Permission"
-        description="Deleting this permission will revoke the associated access. Users or groups will lose the granted actions on the target resource. This action cannot be undone."
+        description="Deleting this permission will revoke the associated access. Users, service accounts, or groups will lose the granted actions on the target resource. This action cannot be undone."
         confirmText="Delete Permission"
         danger
         loading={deleteMutation.isPending}

--- a/src/app/(app)/(admin)/permissions/page.tsx
+++ b/src/app/(app)/(admin)/permissions/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useMemo } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Plus, Pencil, Trash2, Shield } from "lucide-react";
+import { Check, ChevronsUpDown, Plus, Pencil, Trash2, Shield } from "lucide-react";
 import { toast } from "sonner";
 
 import { permissionsApi } from "@/lib/api/permissions";
@@ -16,10 +16,12 @@ import type {
 import { groupsApi } from "@/lib/api/groups";
 import { useRepositories } from "@/hooks/use-repositories";
 import { adminApi } from "@/lib/api/admin";
+import { serviceAccountsApi } from "@/lib/api/service-accounts";
 import { mutationErrorToast } from "@/lib/error-utils";
 import { useAuth } from "@/providers/auth-provider";
 import type { User, Repository } from "@/types";
 import type { Group } from "@/types/groups";
+import type { ServiceAccount } from "@/lib/api/service-accounts";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -41,6 +43,19 @@ import {
   SelectContent,
   SelectItem,
 } from "@/components/ui/select";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import {
   Tooltip,
   TooltipTrigger,
@@ -95,6 +110,8 @@ export default function PermissionsPage() {
   const [selectedPermission, setSelectedPermission] = useState<Permission | null>(null);
 
   const [form, setForm] = useState<PermissionForm>(EMPTY_FORM);
+  const [principalPickerOpen, setPrincipalPickerOpen] = useState(false);
+  const [principalSearch, setPrincipalSearch] = useState("");
 
   // -- queries --
   const { data: permissionsData, isLoading: permissionsLoading } = useQuery({
@@ -120,6 +137,12 @@ export default function PermissionsPage() {
     { enabled: !!currentUser?.is_admin },
   );
 
+  const { data: serviceAccountsData, isLoading: serviceAccountsLoading } = useQuery({
+    queryKey: ["service-accounts"],
+    queryFn: () => serviceAccountsApi.list(),
+    enabled: !!currentUser?.is_admin,
+  });
+
   const permissions = permissionsData?.items ?? [];
   const users = usersData ?? [];
   const groups = groupsData?.items ?? [];
@@ -127,17 +150,39 @@ export default function PermissionsPage() {
 
   // principal options based on selected type
   const principalOptions = useMemo(() => {
-    if (form.principal_type === "user") {
-      return users.map((u: User) => ({
-        value: u.id,
-        label: u.display_name || u.username,
-      }));
+    switch (form.principal_type) {
+      case "user":
+        return users.map((u: User) => ({
+          value: u.id,
+          label: u.display_name || u.username,
+        }));
+      case "service_account":
+        return (serviceAccountsData ?? []).map((account: ServiceAccount) => ({
+          value: account.id,
+          label: account.display_name || account.username,
+        }));
+      case "group":
+        return groups.map((g: Group) => ({
+          value: g.id,
+          label: g.name,
+        }));
     }
-    return groups.map((g: Group) => ({
-      value: g.id,
-      label: g.name,
-    }));
-  }, [form.principal_type, users, groups]);
+  }, [form.principal_type, users, serviceAccountsData, groups]);
+
+  const selectedPrincipal = useMemo(
+    () => principalOptions.find((principal) => principal.value === form.principal_id),
+    [form.principal_id, principalOptions]
+  );
+
+  const filteredPrincipalOptions = useMemo(() => {
+    const search = principalSearch.trim().toLowerCase();
+    if (!search) return principalOptions;
+
+    return principalOptions.filter((principal) =>
+      principal.label.toLowerCase().includes(search) ||
+      principal.value.toLowerCase().includes(search)
+    );
+  }, [principalOptions, principalSearch]);
 
   const repositoryOptions = useMemo(() =>
     repositories.map((r: Repository) => ({
@@ -337,13 +382,15 @@ export default function PermissionsPage() {
           <Label>Principal Type</Label>
           <Select
             value={form.principal_type}
-            onValueChange={(v) =>
+            onValueChange={(v) => {
               setForm((f) => ({
                 ...f,
                 principal_type: v as PermissionPrincipalType,
                 principal_id: "",
-              }))
-            }
+              }));
+              setPrincipalPickerOpen(false);
+              setPrincipalSearch("");
+            }}
             disabled={editOpen}
           >
             <SelectTrigger>
@@ -351,30 +398,82 @@ export default function PermissionsPage() {
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="user">User</SelectItem>
+              <SelectItem value="service_account">Service Account</SelectItem>
               <SelectItem value="group">Group</SelectItem>
             </SelectContent>
           </Select>
         </div>
         <div className="space-y-2">
           <Label>Principal</Label>
-          <Select
-            value={form.principal_id}
-            onValueChange={(v) =>
-              setForm((f) => ({ ...f, principal_id: v }))
-            }
-            disabled={editOpen}
+          <Popover
+            open={principalPickerOpen}
+            onOpenChange={(open) => {
+              setPrincipalPickerOpen(open);
+              if (!open) setPrincipalSearch("");
+            }}
           >
-            <SelectTrigger>
-              <SelectValue placeholder="Select..." />
-            </SelectTrigger>
-            <SelectContent>
-              {principalOptions.map((o) => (
-                <SelectItem key={o.value} value={o.value}>
-                  {o.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+            <PopoverTrigger asChild>
+              <Button
+                type="button"
+                variant="outline"
+                role="combobox"
+                aria-label="Principal"
+                aria-expanded={principalPickerOpen}
+                className="w-full justify-between font-normal"
+                disabled={
+                  editOpen ||
+                  (form.principal_type === "service_account" && serviceAccountsLoading)
+                }
+              >
+                {form.principal_type === "service_account" && serviceAccountsLoading
+                  ? "Loading service accounts..."
+                  : selectedPrincipal?.label ?? "Select..."}
+                <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent
+              className="w-[var(--radix-popover-trigger-width)] p-0"
+              align="start"
+            >
+              <Command shouldFilter={false}>
+                <CommandInput
+                  aria-label="Search principals"
+                  placeholder="Search principals..."
+                  value={principalSearch}
+                  onValueChange={setPrincipalSearch}
+                />
+                <CommandList>
+                  {filteredPrincipalOptions.length === 0 && (
+                    <CommandEmpty>No principals match your search.</CommandEmpty>
+                  )}
+                  {filteredPrincipalOptions.length > 0 && (
+                    <CommandGroup heading="Principals">
+                      {filteredPrincipalOptions.map((principal) => (
+                        <CommandItem
+                          key={principal.value}
+                          value={principal.value}
+                          onSelect={() => {
+                            setForm((f) => ({ ...f, principal_id: principal.value }));
+                            setPrincipalPickerOpen(false);
+                            setPrincipalSearch("");
+                          }}
+                        >
+                          <Check
+                            className={`size-4 ${
+                              form.principal_id === principal.value
+                                ? "opacity-100"
+                                : "opacity-0"
+                            }`}
+                          />
+                          <span className="min-w-0 flex-1 truncate">{principal.label}</span>
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  )}
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
         </div>
       </div>
 
@@ -532,7 +631,7 @@ export default function PermissionsPage() {
           <DialogHeader>
             <DialogTitle>Create Permission</DialogTitle>
             <DialogDescription>
-              Grant a user or group access to a target resource.
+              Grant a user, service account, or group access to a target resource.
             </DialogDescription>
           </DialogHeader>
           <form

--- a/src/lib/api/__tests__/permissions.test.ts
+++ b/src/lib/api/__tests__/permissions.test.ts
@@ -177,10 +177,20 @@ describe("permissionsApi", () => {
 
   // ---- Narrowing fallback warnings ----
 
+  it("preserves service_account principal_type", async () => {
+    mockGetPermission.mockResolvedValue({
+      data: sdkPermissionFixture({ principal_type: "service_account" }),
+      error: undefined,
+    });
+    const { permissionsApi } = await import("../permissions");
+    const result = await permissionsApi.get("perm1");
+    expect(result.principal_type).toBe("service_account");
+  });
+
   it("warns and defaults principal_type to 'user' on unknown variant", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     mockGetPermission.mockResolvedValue({
-      data: sdkPermissionFixture({ principal_type: "service_account" }),
+      data: sdkPermissionFixture({ principal_type: "api_key" }),
       error: undefined,
     });
     const { permissionsApi } = await import("../permissions");

--- a/src/lib/api/permissions.ts
+++ b/src/lib/api/permissions.ts
@@ -18,7 +18,7 @@ import { unwrap } from '@/lib/sdk-utils';
 
 export type PermissionAction = 'read' | 'write' | 'delete' | 'admin';
 export type PermissionTargetType = 'repository' | 'group' | 'artifact';
-export type PermissionPrincipalType = 'user' | 'group';
+export type PermissionPrincipalType = 'user' | 'service_account' | 'group';
 
 export interface Permission {
   id: string;
@@ -50,13 +50,17 @@ export interface ListPermissionsParams {
   target_id?: string;
 }
 
-const PRINCIPAL_TYPES = new Set<PermissionPrincipalType>(['user', 'group']);
+const PRINCIPAL_TYPES = new Set<PermissionPrincipalType>([
+  'user',
+  'service_account',
+  'group',
+]);
 const TARGET_TYPES = new Set<PermissionTargetType>(['repository', 'group', 'artifact']);
 const ACTIONS = new Set<PermissionAction>(['read', 'write', 'delete', 'admin']);
 
-// A new backend principal_type variant (e.g. 'service_account') would otherwise
-// silently flatten to 'user' and show up under the wrong ACL row — warn so the
-// regression is observable.
+// A new backend principal_type variant would otherwise silently flatten to
+// 'user' and show up under the wrong ACL row — warn so the regression is
+// observable.
 function narrowPrincipal(v: string): PermissionPrincipalType {
   return narrowEnum(
     v,


### PR DESCRIPTION
## Summary

Adds support for **service account principals** in the admin permissions UI and API adapter, aligning the frontend with the backend's existing `service_account` principal support.

Fixes #621
Supersedes #685

This branch adopts @ivolnistov's original implementation from #685 — their commits are preserved in this branch with authorship intact — rebased onto latest `main` with the maintainer review feedback applied:

- Rebased onto `main`; resolved the single conflict in the permissions page query block by keeping #692's shared `useRepositories({ per_page: 1000 })` hook and moving the new `service-accounts` query next to it (dropped the hand-rolled `["admin-repositories"]` query, which bypassed prefix invalidation under `QUERY_KEYS.REPOSITORIES`).
- `principalPickerOpen` / `principalSearch` are now reset when the create dialog closes, so reopening the dialog no longer restores a stale open popover or search filter.
- `src/lib/api/permissions.ts` auto-merged cleanly with #694's `unwrap()` refactor.

Changes (from the original PR):

- Extend `PermissionPrincipalType` with `service_account`, preserved through API adaptation with a regression test.
- Permissions admin page: searchable, type-filtered principal picker supporting service accounts.
- Resolve missing `principal_name` for service-account rows client-side from the loaded service accounts list (the backend list endpoint only resolves names for `user` and `group` principals).

Original implementation by @ivolnistov in #685; this branch applies the review feedback so the fix can land in the 1.7.0 cut.

## Test Checklist
- [x] Unit tests added/updated
- [x] E2E Playwright tests added/updated
- [ ] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [x] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes
