### PR TITLE
feat(groups): read-only UI for SSO-synced groups (adopts #629)

### DIFF
--- a/src/app/(app)/(admin)/groups/page.tsx
+++ b/src/app/(app)/(admin)/groups/page.tsx
@@ -122,7 +122,7 @@ export default function GroupsPage() {
   });
 
   const updateMutation = useMutation({
-    mutationFn: ({ id, data }: { id: string; data: Partial<GroupForm> }) =>
+    mutationFn: ({ id, data }: { id: string; data: GroupForm }) =>
       // PUT is a full replacement: backend requires `name`, so resend the
       // (unchanged, non-editable) name alongside the new description.
       groupsApi.update(id, { name: data.name, description: data.description }),

--- a/src/app/(app)/(admin)/groups/page.tsx
+++ b/src/app/(app)/(admin)/groups/page.tsx
@@ -64,6 +64,10 @@ interface GroupForm {
 
 const EMPTY_FORM: GroupForm = { name: "", description: "" };
 
+// SSO-synced groups (is_external) are owned by the IdP; the backend blocks edits (#2874).
+const SSO_DISABLED_LABEL = "Editing not permitted (synced via SSO)";
+const SSO_READONLY_LABEL = "Read-only, editing not permitted (synced via SSO)";
+
 // -- page --
 
 export default function GroupsPage() {
@@ -186,6 +190,9 @@ export default function GroupsPage() {
     setMembersOpen(true);
   }, []);
 
+  // SSO-synced groups: membership is read-only in the dialog (backend rejects edits).
+  const selectedIsExternal = !!selectedGroup?.is_external;
+
   // Compute members with type safety
   const members: GroupMember[] = groupDetail?.members ?? [];
 
@@ -255,15 +262,21 @@ export default function GroupsPage() {
         >
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                onClick={() => handleEdit(g)}
-              >
-                <Pencil className="size-3.5" />
-              </Button>
+              {/* span wrapper: disabled Button has pointer-events-none, so the tooltip fires on the span. */}
+              <span className="inline-flex">
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  disabled={g.is_external}
+                  onClick={() => handleEdit(g)}
+                >
+                  <Pencil className="size-3.5" />
+                </Button>
+              </span>
             </TooltipTrigger>
-            <TooltipContent>Edit</TooltipContent>
+            <TooltipContent>
+              {g.is_external ? SSO_DISABLED_LABEL : "Edit"}
+            </TooltipContent>
           </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -275,7 +288,9 @@ export default function GroupsPage() {
                 <Users2 className="size-3.5" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Manage Members</TooltipContent>
+            <TooltipContent>
+              {g.is_external ? SSO_READONLY_LABEL : "Manage Members"}
+            </TooltipContent>
           </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -490,7 +505,9 @@ export default function GroupsPage() {
               Manage Members: {selectedGroup?.name}
             </DialogTitle>
             <DialogDescription>
-              Add or remove users from this group.
+              {selectedIsExternal
+                ? SSO_READONLY_LABEL
+                : "Add or remove users from this group."}
             </DialogDescription>
           </DialogHeader>
 
@@ -498,7 +515,11 @@ export default function GroupsPage() {
           <div className="flex items-end gap-2">
             <div className="flex-1 space-y-2">
               <Label>Add Member</Label>
-              <Select value={addUserId} onValueChange={setAddUserId}>
+              <Select
+                value={addUserId}
+                onValueChange={setAddUserId}
+                disabled={selectedIsExternal}
+              >
                 <SelectTrigger>
                   <SelectValue placeholder="Select a user..." />
                 </SelectTrigger>
@@ -516,21 +537,35 @@ export default function GroupsPage() {
                 </SelectContent>
               </Select>
             </div>
-            <Button
-              size="sm"
-              disabled={!addUserId || addMemberMutation.isPending}
-              onClick={() => {
-                if (selectedGroup && addUserId) {
-                  addMemberMutation.mutate({
-                    groupId: selectedGroup.id,
-                    userId: addUserId,
-                  });
-                }
-              }}
-            >
-              <UserPlus className="size-3.5 mr-1" />
-              Add
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                {/* span wrapper so the tooltip fires on the disabled button */}
+                <span className="inline-flex">
+                  <Button
+                    size="sm"
+                    disabled={
+                      selectedIsExternal ||
+                      !addUserId ||
+                      addMemberMutation.isPending
+                    }
+                    onClick={() => {
+                      if (selectedGroup && addUserId) {
+                        addMemberMutation.mutate({
+                          groupId: selectedGroup.id,
+                          userId: addUserId,
+                        });
+                      }
+                    }}
+                  >
+                    <UserPlus className="size-3.5 mr-1" />
+                    Add
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              {selectedIsExternal && (
+                <TooltipContent>{SSO_DISABLED_LABEL}</TooltipContent>
+              )}
+            </Tooltip>
           </div>
 
           <Separator />
@@ -582,24 +617,31 @@ export default function GroupsPage() {
                       </div>
                       <Tooltip>
                         <TooltipTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="icon-xs"
-                            className="text-destructive hover:text-destructive"
-                            onClick={() => {
-                              if (selectedGroup) {
-                                removeMemberMutation.mutate({
-                                  groupId: selectedGroup.id,
-                                  userId: m.user_id,
-                                });
+                          <span className="inline-flex">
+                            <Button
+                              variant="ghost"
+                              size="icon-xs"
+                              className="text-destructive hover:text-destructive"
+                              onClick={() => {
+                                if (selectedGroup) {
+                                  removeMemberMutation.mutate({
+                                    groupId: selectedGroup.id,
+                                    userId: m.user_id,
+                                  });
+                                }
+                              }}
+                              disabled={
+                                selectedIsExternal ||
+                                removeMemberMutation.isPending
                               }
-                            }}
-                            disabled={removeMemberMutation.isPending}
-                          >
-                            <UserMinus className="size-3.5" />
-                          </Button>
+                            >
+                              <UserMinus className="size-3.5" />
+                            </Button>
+                          </span>
                         </TooltipTrigger>
-                        <TooltipContent>Remove</TooltipContent>
+                        <TooltipContent>
+                          {selectedIsExternal ? SSO_DISABLED_LABEL : "Remove"}
+                        </TooltipContent>
                       </Tooltip>
                     </div>
                   ))}

--- a/src/app/(app)/(admin)/groups/page.tsx
+++ b/src/app/(app)/(admin)/groups/page.tsx
@@ -123,7 +123,9 @@ export default function GroupsPage() {
 
   const updateMutation = useMutation({
     mutationFn: ({ id, data }: { id: string; data: Partial<GroupForm> }) =>
-      groupsApi.update(id, { description: data.description }),
+      // PUT is a full replacement: backend requires `name`, so resend the
+      // (unchanged, non-editable) name alongside the new description.
+      groupsApi.update(id, { name: data.name, description: data.description }),
     onSuccess: () => {
       toast.success("Group updated successfully");
       invalidateGroup(queryClient, "groups");
@@ -448,7 +450,7 @@ export default function GroupsPage() {
               if (selectedGroup) {
                 updateMutation.mutate({
                   id: selectedGroup.id,
-                  data: { description: form.description },
+                  data: { name: form.name, description: form.description },
                 });
               }
             }}

--- a/src/lib/api/__tests__/groups.test.ts
+++ b/src/lib/api/__tests__/groups.test.ts
@@ -57,6 +57,7 @@ function adaptedGroupFixture(overrides: Record<string, unknown> = {}) {
     auto_join: false,
     member_count: 5,
     is_external: false,
+    external_source: null,
     created_at: "2025-01-01",
     updated_at: "2025-01-01",
     ...overrides,
@@ -119,8 +120,27 @@ describe("groupsApi", () => {
     await expect(groupsApi.getDetail("g1")).rejects.toBe("not found");
   });
 
+  it("derives is_external / external_source from the SDK external_source field", async () => {
+    mockListGroups.mockResolvedValue({
+      data: {
+        items: [
+          sdkGroupFixture({ id: "oidc", external_source: "oidc" }),
+          sdkGroupFixture({ id: "saml", external_source: "saml" }),
+          sdkGroupFixture({ id: "ldap", external_source: "ldap" }),
+          sdkGroupFixture({ id: "local", external_source: null }),
+        ],
+        pagination: { total: 4 },
+      },
+      error: undefined,
+    });
+    const { groupsApi } = await import("../groups");
+    const { items } = await groupsApi.list();
+    expect(items.map((g) => g.is_external)).toEqual([true, true, true, false]);
+    expect(items.map((g) => g.external_source)).toEqual(["oidc", "saml", "ldap", null]);
+  });
+
   it("create returns created group", async () => {
-    // CreatedGroupRow shape — no member_count.
+    // CreatedGroupRow shape, no member_count.
     mockCreateGroup.mockResolvedValue({
       data: { id: "g2", name: "ops", description: null, created_at: "x", updated_at: "x" },
       error: undefined,
@@ -133,6 +153,7 @@ describe("groupsApi", () => {
       auto_join: false,
       member_count: 0,
       is_external: false,
+      external_source: null,
       created_at: "x",
       updated_at: "x",
     });

--- a/src/lib/api/__tests__/groups.test.ts
+++ b/src/lib/api/__tests__/groups.test.ts
@@ -165,15 +165,19 @@ describe("groupsApi", () => {
     await expect(groupsApi.create({ name: "ops" } as any)).rejects.toBe("dup");
   });
 
-  it("update returns updated group", async () => {
+  it("update resends name with the PUT body (backend requires it)", async () => {
     mockUpdateGroup.mockResolvedValue({
       data: sdkGroupFixture({ name: "devs-updated" }),
       error: undefined,
     });
     const { groupsApi } = await import("../groups");
-    expect(await groupsApi.update("g1", { name: "devs-updated" } as any)).toEqual(
-      adaptedGroupFixture({ name: "devs-updated" })
-    );
+    expect(
+      await groupsApi.update("g1", { name: "devs", description: "new desc" })
+    ).toEqual(adaptedGroupFixture({ name: "devs-updated" }));
+    expect(mockUpdateGroup).toHaveBeenCalledWith({
+      path: { id: "g1" },
+      body: { name: "devs", description: "new desc" },
+    });
   });
 
   it("update throws on error", async () => {

--- a/src/lib/api/groups.ts
+++ b/src/lib/api/groups.ts
@@ -28,32 +28,36 @@ export interface ListGroupsParams {
   search?: string;
 }
 
-// SDK GroupResponse / CreatedGroupRow don't surface auto_join or is_external.
-// Default them to false so the local Group contract is satisfied; pages that
-// rely on real values for these will need a backend/SDK update.
-// CreatedGroupRow (returned from createGroup) lacks member_count — default 0.
+// external_source ("oidc"|"saml"|"ldap"; null=local) drives is_external, read defensively since the 1.5.x SDK type lacks the field.
+// auto_join defaults false; CreatedGroupRow lacks member_count so default 0.
 function adaptGroup(sdk: GroupResponse | CreatedGroupRow): Group {
   const memberCount = 'member_count' in sdk ? sdk.member_count : 0;
+  const externalSource =
+    (sdk as { external_source?: string | null }).external_source ?? null;
   return {
     id: sdk.id,
     name: sdk.name,
     description: sdk.description ?? undefined,
     auto_join: false,
     member_count: memberCount,
-    is_external: false,
+    is_external: externalSource != null,
+    external_source: externalSource,
     created_at: sdk.created_at,
     updated_at: sdk.updated_at,
   };
 }
 
 function adaptGroupDetail(sdk: GroupDetailResponse): GroupDetail {
+  const externalSource =
+    (sdk as { external_source?: string | null }).external_source ?? null;
   return {
     id: sdk.id,
     name: sdk.name,
     description: sdk.description ?? undefined,
     auto_join: false,
     member_count: sdk.member_count,
-    is_external: false,
+    is_external: externalSource != null,
+    external_source: externalSource,
     created_at: sdk.created_at,
     updated_at: sdk.updated_at,
     members: sdk.members.map((m) => ({
@@ -96,15 +100,15 @@ export const groupsApi = {
   update: async (groupId: string, input: Partial<CreateGroupRequest>): Promise<Group> => {
     // SDK updateGroup requires the full CreateGroupRequest (with `name`); the
     // existing API exposes Partial<> for description-only updates. Build a
-    // body type that allows omitting `name` — sending '' would overwrite the
-    // group name to blank — then cast at the SDK boundary.
+    // body type that allows omitting `name` (sending '' would blank the group
+    // name), then cast at the SDK boundary.
     type UpdateGroupBodyPartial = Omit<CreateGroupRequest, 'name'> & { name?: string };
     const body: UpdateGroupBodyPartial = {
       ...(input.name !== undefined ? { name: input.name } : {}),
       ...(input.description !== undefined ? { description: input.description } : {}),
     };
     // SDK marks `name` required for PUT, but the backend treats omission as
-    // "leave unchanged" — we want that semantic for description-only edits.
+    // "leave unchanged", which we want for description-only edits.
     const data = await unwrap(updateGroup({
       path: { id: groupId },
       body: body as CreateGroupRequest,

--- a/src/lib/api/groups.ts
+++ b/src/lib/api/groups.ts
@@ -28,12 +28,13 @@ export interface ListGroupsParams {
   search?: string;
 }
 
-// external_source ("oidc"|"saml"|"ldap"; null=local) drives is_external, read defensively since the 1.5.x SDK type lacks the field.
-// auto_join defaults false; CreatedGroupRow lacks member_count so default 0.
+// external_source ("oidc"|"saml"|"ldap"; null/absent=local) drives is_external.
+// Typed optional in the SDK; `?? null` also covers backends predating #2874
+// that omit the field entirely. auto_join defaults false; CreatedGroupRow
+// lacks member_count so default 0.
 function adaptGroup(sdk: GroupResponse | CreatedGroupRow): Group {
   const memberCount = 'member_count' in sdk ? sdk.member_count : 0;
-  const externalSource =
-    (sdk as { external_source?: string | null }).external_source ?? null;
+  const externalSource = sdk.external_source ?? null;
   return {
     id: sdk.id,
     name: sdk.name,
@@ -48,8 +49,7 @@ function adaptGroup(sdk: GroupResponse | CreatedGroupRow): Group {
 }
 
 function adaptGroupDetail(sdk: GroupDetailResponse): GroupDetail {
-  const externalSource =
-    (sdk as { external_source?: string | null }).external_source ?? null;
+  const externalSource = sdk.external_source ?? null;
   return {
     id: sdk.id,
     name: sdk.name,
@@ -97,21 +97,14 @@ export const groupsApi = {
     return adaptGroup(assertData(data, 'groupsApi.create'));
   },
 
-  update: async (groupId: string, input: Partial<CreateGroupRequest>): Promise<Group> => {
-    // SDK updateGroup requires the full CreateGroupRequest (with `name`); the
-    // existing API exposes Partial<> for description-only updates. Build a
-    // body type that allows omitting `name` (sending '' would blank the group
-    // name), then cast at the SDK boundary.
-    type UpdateGroupBodyPartial = Omit<CreateGroupRequest, 'name'> & { name?: string };
-    const body: UpdateGroupBodyPartial = {
-      ...(input.name !== undefined ? { name: input.name } : {}),
-      ...(input.description !== undefined ? { description: input.description } : {}),
-    };
-    // SDK marks `name` required for PUT, but the backend treats omission as
-    // "leave unchanged", which we want for description-only edits.
+  update: async (groupId: string, input: CreateGroupRequest): Promise<Group> => {
+    // PUT is a full replacement: the backend's CreateGroupRequest requires
+    // `name` (omitting it fails body deserialization with 422, it is not
+    // treated as "leave unchanged"). Callers editing only the description
+    // must resend the current name.
     const data = await unwrap(updateGroup({
       path: { id: groupId },
-      body: body as CreateGroupRequest,
+      body: { name: input.name, description: input.description },
     }));
     return adaptGroup(assertData(data, 'groupsApi.update'));
   },

--- a/src/types/groups.ts
+++ b/src/types/groups.ts
@@ -5,6 +5,8 @@ export interface Group {
   auto_join: boolean;
   member_count: number;
   is_external: boolean;
+  /** Federated SSO provider that owns the group: "oidc" | "saml" | "ldap"; null/absent for local groups. */
+  external_source?: string | null;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary

Fixes #628
Supersedes #629

Adopts @nicola-preda's #629 for the 1.7.0 cut — original commits are preserved with authorship intact (`d8d1e4a`, `ad0f3ec`), rebased onto current `main`. Adoption fixes are separate commits on top (`7d778a2`, `d2acc6f`).

SSO-synced groups (`external_source` = `oidc`/`saml`/`ldap`, returned by the backend since artifact-keeper/artifact-keeper#2885) are now treated as read-only in Administration → Groups:

- Row **Edit** is disabled with an explanatory tooltip.
- **Manage Members** opens read-only: member list visible, Add/Remove disabled, tooltip explains the IdP owns membership.
- **Delete** stays enabled, per the issue spec.
- Description edits on local groups resend the (non-editable) `name` so the backend PUT body deserializes.

## Review notes (verified during adoption)

Verified against the backend (`backend/src/api/handlers/groups.rs` @ 1.7.0-rc.3):

- **Correct:** `GroupResponse`/`CreatedGroupRow` return `external_source: Option<String>` on list, detail, create, and update — the frontend derivation `is_external = external_source != null` matches, and the `?? null` fallback covers pre-#2874 backends that omit the field.
- **Correct:** backend rejects membership add/remove on SSO groups with 409 Conflict (`ensure_membership_editable`, #2874) — the read-only members dialog matches server enforcement.
- **Correct:** backend PUT `/{id}` deserializes `CreateGroupRequest` with a **required** `name` and is a full replacement (`SET name = $2, description = $3`). The head commit's fix to resend `name` is required, not optional.
- **Stricter than backend (intentional, matches #628):** the backend does not block name/description edits or deletion of SSO groups; the UI disabling Edit implements the issue's spec. Server-side gating of those operations would be a backend follow-up if desired.

Fixed during adoption (separate commits):

- `7d778a2` — `groupsApi.update` claimed the backend treats an omitted `name` as "leave unchanged"; it actually fails deserialization with 422. Tightened the signature from `Partial<CreateGroupRequest>` to `CreateGroupRequest`, dropped the partial-body builder, corrected the comment, and added a test locking that `name` is resent. Also dropped the defensive `external_source` cast — `@artifact-keeper/sdk` 1.7.0 types the field as optional, so the "1.5.x SDK lacks the field" comment was stale.
- `d2acc6f` — typed the edit mutation's input as full `GroupForm` (the dialog always submits name + description) to satisfy the tightened `update` signature.

Rebase notes: resolved the `src/lib/api/groups.ts` conflict in favor of the #694 conventions (named exports + `unwrap()` from `src/lib/sdk-utils.ts`); kept the `ListTruncationNotice` from #688 on the groups page; `PageHeader` (with #687 `useDocumentTitle`) usage unchanged.

Nits (not changed, non-blocking): the `SSO_DISABLED_LABEL`/`SSO_READONLY_LABEL` copy could mention the specific IdP (`external_source`) rather than a generic "SSO"; `UpdateGroupRequest` in `src/types/groups.ts` is now unused and could be removed in a follow-up.

## Test Checklist

- [x] Unit tests added/updated (adapter derives `is_external`/`external_source` for oidc/saml/ldap/null; update() resends `name`)
- [ ] E2E Playwright tests added/updated
- [ ] Manually tested locally
- [x] No regressions in existing tests (`npm run test`: 168 files / 3097 tests passed; `npx eslint` on changed files clean; `npx tsc --noEmit` at the 23-error pre-existing baseline with no new errors; `npm run build` succeeds)

## UI Changes

- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader) — disabled buttons are wrapped in `<span>` so tooltips still fire on hover/focus; read-only state is conveyed via tooltip copy, not color alone
