### PR TITLE
fix(settings): remove SMTP save flow that 404s against the backend (#555)

### DIFF
--- a/src/app/(app)/(admin)/settings/__tests__/page.test.tsx
+++ b/src/app/(app)/(admin)/settings/__tests__/page.test.tsx
@@ -33,9 +33,9 @@ vi.mock("@/lib/api/admin", () => ({
 vi.mock("@/lib/api/settings", () => ({
   // useQuery is itself mocked above, so queryFns never actually run — but we
   // still expose the API surface the page imports so module resolution works.
+  // Note: no updateSmtpConfig — the backend has no SMTP save endpoint (#555).
   settingsApi: {
     getAllSettings: vi.fn(),
-    updateSmtpConfig: vi.fn(),
     sendTestEmail: vi.fn(),
   },
 }));
@@ -275,7 +275,7 @@ describe("SettingsPage", () => {
 
   // Mock useQuery's return value based on which queryKey it's called with,
   // instead of relying on a fragile call-order index. Keys in SettingsPage:
-  //   ["health"], ["admin-settings"]   — the latter is shared by SmtpSettingsTab.
+  //   ["health"], ["admin-settings"]
   function mockQueriesByKey(
     overrides: Record<string, ReturnType<typeof mockUseQuery>>
   ) {
@@ -463,42 +463,6 @@ describe("SettingsPage", () => {
     expect(inputs.find((i) => i.value === "/data/artifacts")).toBeUndefined();
   });
 
-  it("shows error alert in SMTP tab when admin-settings errors (#349)", () => {
-    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
-    mockQueriesByKey({
-      [ADMIN_SETTINGS_KEY]: {
-        data: undefined,
-        isLoading: false,
-        isError: true,
-        error: new Error("Failed to load admin settings: unauthorized"),
-      },
-    });
-
-    render(<SettingsPage />);
-
-    expect(screen.getByText("SMTP configuration unavailable")).toBeDefined();
-    // The thrown Error's message is rendered so an operator sees the
-    // actual cause (not a generic placeholder).
-    expect(
-      screen.getByText("Failed to load admin settings: unauthorized")
-    ).toBeDefined();
-    // The buggy default form placeholders must NOT render on error.
-    expect(screen.queryByTestId("smtp-host")).toBeNull();
-  });
-
-  it("shows loader in SMTP tab while admin-settings is loading (#349)", () => {
-    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
-    mockQueriesByKey({
-      [ADMIN_SETTINGS_KEY]: { data: undefined, isLoading: true, isError: false },
-    });
-
-    render(<SettingsPage />);
-
-    // Neither the form nor the error alert should render during loading.
-    expect(screen.queryByTestId("smtp-host")).toBeNull();
-    expect(screen.queryByText("SMTP configuration unavailable")).toBeNull();
-  });
-
   it("renders the Email tab trigger", () => {
     mockUseAuth.mockReturnValue({ user: { is_admin: true } });
 
@@ -538,199 +502,34 @@ describe("SettingsPage", () => {
     expect(elements.length).toBeGreaterThanOrEqual(2);
   });
 
-  it("renders SMTP form fields with placeholders", () => {
+  it("explains SMTP is configured via server environment variables (#555)", () => {
     mockUseAuth.mockReturnValue({ user: { is_admin: true } });
     mockAdminSettings();
 
     render(<SettingsPage />);
 
-    expect(screen.getByTestId("smtp-host")).toBeDefined();
-    expect(screen.getByTestId("smtp-port")).toBeDefined();
-    expect(screen.getByTestId("smtp-username")).toBeDefined();
-    expect(screen.getByTestId("smtp-password")).toBeDefined();
-    expect(screen.getByTestId("smtp-from")).toBeDefined();
-    expect(screen.getByTestId("smtp-tls")).toBeDefined();
+    expect(
+      screen.getByText("Configured via environment variables")
+    ).toBeDefined();
+    expect(screen.getByText(/SMTP_HOST/)).toBeDefined();
+    expect(screen.getByText(/SMTP_TLS_MODE/)).toBeDefined();
   });
 
-  it("populates SMTP fields from loaded config", () => {
-    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
-    mockAdminSettings({
-      ...DEFAULT_ADMIN_SETTINGS,
-      smtpConfig: {
-        host: "mail.example.com",
-        port: 465,
-        username: "sender",
-        password: "secret",
-        from_address: "no-reply@example.com",
-        tls_mode: "tls",
-      },
-    });
-
-    render(<SettingsPage />);
-
-    const hostInput = screen.getByTestId("smtp-host") as HTMLInputElement;
-    expect(hostInput.value).toBe("mail.example.com");
-
-    const portInput = screen.getByTestId("smtp-port") as HTMLInputElement;
-    expect(portInput.value).toBe("465");
-
-    const usernameInput = screen.getByTestId("smtp-username") as HTMLInputElement;
-    expect(usernameInput.value).toBe("sender");
-
-    const fromInput = screen.getByTestId("smtp-from") as HTMLInputElement;
-    expect(fromInput.value).toBe("no-reply@example.com");
-
-    // Password should not be populated from server response
-    const passwordInput = screen.getByTestId("smtp-password") as HTMLInputElement;
-    expect(passwordInput.value).toBe("");
-  });
-
-  it("disables Save button when form is not dirty", () => {
+  it("does not render a Save SMTP Settings button or edit form (#555)", () => {
+    // Regression: the backend has no SMTP save endpoint — PUT
+    // /api/v1/admin/smtp returns 404. The UI must not offer a save flow.
     mockUseAuth.mockReturnValue({ user: { is_admin: true } });
     mockAdminSettings();
 
     render(<SettingsPage />);
 
-    const saveButton = screen.getByText("Save SMTP Settings");
-    expect(saveButton.closest("button")?.disabled).toBe(true);
-  });
-
-  it("enables Save button after editing a field", () => {
-    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
-    mockAdminSettings();
-
-    render(<SettingsPage />);
-
-    const hostInput = screen.getByTestId("smtp-host");
-    fireEvent.change(hostInput, { target: { value: "smtp.test.com" } });
-
-    const saveButton = screen.getByText("Save SMTP Settings");
-    expect(saveButton.closest("button")?.disabled).toBe(false);
-  });
-
-  it("calls save mutation with form values on Save click", () => {
-    const mutateFn = vi.fn();
-    mockUseMutation.mockReturnValue(createMutationMock({ mutate: mutateFn }));
-    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
-    mockAdminSettings();
-
-    render(<SettingsPage />);
-
-    // Fill required fields
-    fireEvent.change(screen.getByTestId("smtp-host"), {
-      target: { value: "smtp.test.com" },
-    });
-    fireEvent.change(screen.getByTestId("smtp-from"), {
-      target: { value: "test@test.com" },
-    });
-
-    fireEvent.click(screen.getByText("Save SMTP Settings"));
-
-    expect(mutateFn).toHaveBeenCalledWith({
-      host: "smtp.test.com",
-      port: 587,
-      username: "",
-      from_address: "test@test.com",
-      tls_mode: "starttls",
-    });
-  });
-
-  it("includes password in save payload only when modified", () => {
-    const mutateFn = vi.fn();
-    mockUseMutation.mockReturnValue(createMutationMock({ mutate: mutateFn }));
-    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
-    mockAdminSettings();
-
-    render(<SettingsPage />);
-
-    // Fill required fields
-    fireEvent.change(screen.getByTestId("smtp-host"), {
-      target: { value: "smtp.test.com" },
-    });
-    fireEvent.change(screen.getByTestId("smtp-from"), {
-      target: { value: "test@test.com" },
-    });
-    // Modify the password field
-    fireEvent.change(screen.getByTestId("smtp-password"), {
-      target: { value: "new-secret" },
-    });
-
-    fireEvent.click(screen.getByText("Save SMTP Settings"));
-
-    expect(mutateFn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        host: "smtp.test.com",
-        password: "new-secret",
-      })
-    );
-  });
-
-  it("shows validation error for empty host on save", () => {
-    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
-    mockAdminSettings();
-
-    render(<SettingsPage />);
-
-    // Make form dirty by setting from address, but leave host blank
-    fireEvent.change(screen.getByTestId("smtp-from"), {
-      target: { value: "test@test.com" },
-    });
-    fireEvent.click(screen.getByText("Save SMTP Settings"));
-
-    expect(mockToast.error).toHaveBeenCalledWith("SMTP host is required");
-  });
-
-  it("shows validation error for empty from address on save", () => {
-    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
-    mockAdminSettings();
-
-    render(<SettingsPage />);
-
-    // Make form dirty with a host but no from address
-    fireEvent.change(screen.getByTestId("smtp-host"), {
-      target: { value: "smtp.test.com" },
-    });
-    fireEvent.click(screen.getByText("Save SMTP Settings"));
-
-    expect(mockToast.error).toHaveBeenCalledWith("From address is required");
-  });
-
-  it("shows validation error for invalid port on save", () => {
-    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
-    mockAdminSettings();
-
-    render(<SettingsPage />);
-
-    fireEvent.change(screen.getByTestId("smtp-host"), {
-      target: { value: "smtp.test.com" },
-    });
-    fireEvent.change(screen.getByTestId("smtp-port"), {
-      target: { value: "99999" },
-    });
-    fireEvent.click(screen.getByText("Save SMTP Settings"));
-
-    expect(mockToast.error).toHaveBeenCalledWith(
-      "Port must be a number between 1 and 65535"
-    );
-  });
-
-  it("shows validation error for non-numeric port on save", () => {
-    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
-    mockAdminSettings();
-
-    render(<SettingsPage />);
-
-    fireEvent.change(screen.getByTestId("smtp-host"), {
-      target: { value: "smtp.test.com" },
-    });
-    fireEvent.change(screen.getByTestId("smtp-port"), {
-      target: { value: "abc" },
-    });
-    fireEvent.click(screen.getByText("Save SMTP Settings"));
-
-    expect(mockToast.error).toHaveBeenCalledWith(
-      "Port must be a number between 1 and 65535"
-    );
+    expect(screen.queryByText("Save SMTP Settings")).toBeNull();
+    expect(screen.queryByTestId("smtp-host")).toBeNull();
+    expect(screen.queryByTestId("smtp-port")).toBeNull();
+    expect(screen.queryByTestId("smtp-username")).toBeNull();
+    expect(screen.queryByTestId("smtp-password")).toBeNull();
+    expect(screen.queryByTestId("smtp-from")).toBeNull();
+    expect(screen.queryByTestId("smtp-tls")).toBeNull();
   });
 
   it("calls test email mutation with recipient", () => {
@@ -770,20 +569,6 @@ describe("SettingsPage", () => {
     );
   });
 
-  it("renders SMTP field labels", () => {
-    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
-    mockAdminSettings();
-
-    render(<SettingsPage />);
-
-    expect(screen.getByText("Host")).toBeDefined();
-    expect(screen.getByText("Port")).toBeDefined();
-    expect(screen.getByText("Username")).toBeDefined();
-    expect(screen.getByText("Password")).toBeDefined();
-    expect(screen.getByText("From Address")).toBeDefined();
-    expect(screen.getByText("TLS Mode")).toBeDefined();
-  });
-
   it("renders the test recipient input", () => {
     mockUseAuth.mockReturnValue({ user: { is_admin: true } });
     mockAdminSettings();
@@ -795,75 +580,14 @@ describe("SettingsPage", () => {
     expect(recipientInput.type).toBe("email");
   });
 
-  it("trims whitespace from fields before saving", () => {
-    const mutateFn = vi.fn();
-    mockUseMutation.mockReturnValue(createMutationMock({ mutate: mutateFn }));
-    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
-    mockAdminSettings();
-
-    render(<SettingsPage />);
-
-    fireEvent.change(screen.getByTestId("smtp-host"), {
-      target: { value: "  smtp.test.com  " },
-    });
-    fireEvent.change(screen.getByTestId("smtp-from"), {
-      target: { value: "  test@test.com  " },
-    });
-    fireEvent.change(screen.getByTestId("smtp-username"), {
-      target: { value: "  user  " },
-    });
-
-    fireEvent.click(screen.getByText("Save SMTP Settings"));
-
-    expect(mutateFn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        host: "smtp.test.com",
-        from_address: "test@test.com",
-        username: "user",
-      })
-    );
-  });
-
-  it("password field is type=password", () => {
-    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
-    mockAdminSettings();
-
-    render(<SettingsPage />);
-
-    const pwInput = screen.getByTestId("smtp-password") as HTMLInputElement;
-    expect(pwInput.type).toBe("password");
-  });
-
-  it("renders TLS mode options", () => {
-    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
-    mockAdminSettings();
-
-    render(<SettingsPage />);
-
-    expect(screen.getByText("None")).toBeDefined();
-    expect(screen.getByText("STARTTLS")).toBeDefined();
-    expect(screen.getByText("TLS")).toBeDefined();
-  });
-
-  it("disables Save button when mutation is pending", () => {
-    mockUseMutation.mockReturnValue(createMutationMock({ isPending: true }));
-    mockUseAuth.mockReturnValue({ user: { is_admin: true } });
-    mockAdminSettings();
-
-    render(<SettingsPage />);
-
-    const saveButton = screen.getByText("Save SMTP Settings");
-    expect(saveButton.closest("button")?.disabled).toBe(true);
-  });
-
   it("disables Send Test Email button when test mutation is pending", () => {
     // useMutation call order is: [1] upload-size save (storage tab, #189),
-    // [2] SMTP save, [3] send-test-email. The test-email mutation is the
-    // third call, so mark only that one pending.
+    // [2] send-test-email (Email tab). The test-email mutation is the second
+    // call, so mark only that one pending.
     let mutationCallIndex = 0;
     mockUseMutation.mockImplementation(() => {
       mutationCallIndex++;
-      if (mutationCallIndex === 3) {
+      if (mutationCallIndex === 2) {
         return createMutationMock({ isPending: true });
       }
       return createMutationMock();

--- a/src/app/(app)/(admin)/settings/page.tsx
+++ b/src/app/(app)/(admin)/settings/page.tsx
@@ -28,7 +28,7 @@ import {
 
 import { PageHeader } from "@/components/common/page-header";
 import { NpmUpstreamFeedCard } from "@/components/settings/npm-upstream-feed-card";
-import type { PasswordPolicy, SmtpConfig, SmtpTlsMode, StorageSettings } from "@/lib/api/settings";
+import type { PasswordPolicy, StorageSettings } from "@/lib/api/settings";
 
 // -- helpers --
 
@@ -215,78 +215,7 @@ function UploadSizeSetting({
 // -- SMTP settings tab --
 
 function SmtpSettingsTab() {
-  // Shares one in-flight request and cache entry with SettingsPage's
-  // top-level call (#349). The shared hook is the dedup invariant.
-  const { data: settings, isLoading, isError, error, dataUpdatedAt } =
-    useAdminSettings();
-  const smtpConfig = settings?.smtpConfig;
-
-  if (isLoading) {
-    return (
-      <Card>
-        <CardContent className="flex items-center justify-center py-12">
-          <Loader2 className="size-6 animate-spin text-muted-foreground" />
-        </CardContent>
-      </Card>
-    );
-  }
-
-  if (isError || !smtpConfig) {
-    // `!smtpConfig` is logically dead once isLoading and isError are
-    // handled (the success path always returns an object), but stating
-    // it makes the invariant load-bearing for the type narrowing below
-    // and for any future maintainer reading the render flow (R3, #347).
-    return (
-      <Card>
-        <CardContent className="py-6">
-          <Alert variant="destructive">
-            <AlertTitle>SMTP configuration unavailable</AlertTitle>
-            <AlertDescription>
-              {error instanceof Error
-                ? error.message
-                : "Unable to load SMTP configuration from the server."}
-            </AlertDescription>
-          </Alert>
-        </CardContent>
-      </Card>
-    );
-  }
-
-  // Remount the form when query data changes so initial state resets
-  // without needing setState inside an effect.
-  return <SmtpSettingsForm key={dataUpdatedAt} initialConfig={smtpConfig} />;
-}
-
-function SmtpSettingsForm({
-  initialConfig,
-}: {
-  initialConfig: SmtpConfig | undefined;
-}) {
-  const queryClient = useQueryClient();
-
-  const [host, setHost] = useState(initialConfig?.host ?? "");
-  const [port, setPort] = useState(String(initialConfig?.port ?? 587));
-  const [username, setUsername] = useState(initialConfig?.username ?? "");
-  const [password, setPassword] = useState("");
-  const [passwordDirty, setPasswordDirty] = useState(false);
-  const [fromAddress, setFromAddress] = useState(
-    initialConfig?.from_address ?? ""
-  );
-  const [tlsMode, setTlsMode] = useState<SmtpTlsMode>(
-    initialConfig?.tls_mode ?? "starttls"
-  );
   const [testRecipient, setTestRecipient] = useState("");
-  const [formDirty, setFormDirty] = useState(false);
-
-  const saveMutation = useMutation({
-    mutationFn: (config: SmtpConfig) => settingsApi.updateSmtpConfig(config),
-    onSuccess: () => {
-      toast.success("SMTP configuration saved");
-      queryClient.invalidateQueries({ queryKey: ADMIN_SETTINGS_QUERY_KEY });
-      setFormDirty(false);
-    },
-    onError: mutationErrorToast("Failed to save SMTP configuration"),
-  });
 
   const testMutation = useMutation({
     mutationFn: (recipient: string) => settingsApi.sendTestEmail(recipient),
@@ -299,40 +228,6 @@ function SmtpSettingsForm({
     },
     onError: mutationErrorToast("Failed to send test email"),
   });
-
-  function handleFieldChange<T>(setter: (v: T) => void) {
-    return (value: T) => {
-      setter(value);
-      setFormDirty(true);
-    };
-  }
-
-  function handleSave() {
-    const portNum = parseInt(port, 10);
-    if (isNaN(portNum) || portNum < 1 || portNum > 65535) {
-      toast.error("Port must be a number between 1 and 65535");
-      return;
-    }
-    if (!host.trim()) {
-      toast.error("SMTP host is required");
-      return;
-    }
-    if (!fromAddress.trim()) {
-      toast.error("From address is required");
-      return;
-    }
-    const payload: Record<string, unknown> = {
-      host: host.trim(),
-      port: portNum,
-      username: username.trim(),
-      from_address: fromAddress.trim(),
-      tls_mode: tlsMode,
-    };
-    if (passwordDirty) {
-      payload.password = password;
-    }
-    saveMutation.mutate(payload as unknown as SmtpConfig);
-  }
 
   function handleSendTest() {
     if (!testRecipient.trim()) {
@@ -348,127 +243,26 @@ function SmtpSettingsForm({
         <CardHeader>
           <CardTitle className="text-base">SMTP Configuration</CardTitle>
           <CardDescription>
-            Configure the outbound email server used for notifications, password
-            resets, and other system emails.
+            Outbound email server used for notifications, password resets, and
+            other system emails.
           </CardDescription>
         </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="smtp-host">Host</Label>
-              <Input
-                id="smtp-host"
-                placeholder="smtp.example.com"
-                value={host}
-                onChange={(e) => handleFieldChange(setHost)(e.target.value)}
-              />
-              <p className="text-xs text-muted-foreground">
-                Hostname or IP address of the SMTP server.
-              </p>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="smtp-port">Port</Label>
-              <Input
-                id="smtp-port"
-                type="number"
-                min={1}
-                max={65535}
-                placeholder="587"
-                value={port}
-                onChange={(e) => handleFieldChange(setPort)(e.target.value)}
-              />
-              <p className="text-xs text-muted-foreground">
-                Common ports: 25 (SMTP), 465 (SMTPS), 587 (Submission).
-              </p>
-            </div>
-          </div>
-
-          <Separator />
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="smtp-username">Username</Label>
-              <Input
-                id="smtp-username"
-                placeholder="user@example.com"
-                autoComplete="off"
-                value={username}
-                onChange={(e) => handleFieldChange(setUsername)(e.target.value)}
-              />
-              <p className="text-xs text-muted-foreground">
-                Leave blank if the server does not require authentication.
-              </p>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="smtp-password">Password</Label>
-              <Input
-                id="smtp-password"
-                type="password"
-                placeholder="********"
-                autoComplete="new-password"
-                value={password}
-                onChange={(e) => {
-                  setPassword(e.target.value);
-                  setPasswordDirty(true);
-                  setFormDirty(true);
-                }}
-              />
-              <p className="text-xs text-muted-foreground">
-                Stored encrypted on the server. Leave blank to keep the existing value.
-              </p>
-            </div>
-          </div>
-
-          <Separator />
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="smtp-from">From Address</Label>
-              <Input
-                id="smtp-from"
-                type="email"
-                placeholder="noreply@example.com"
-                value={fromAddress}
-                onChange={(e) => handleFieldChange(setFromAddress)(e.target.value)}
-              />
-              <p className="text-xs text-muted-foreground">
-                The sender address used in outgoing emails.
-              </p>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="smtp-tls">TLS Mode</Label>
-              <Select
-                value={tlsMode}
-                onValueChange={(v) => handleFieldChange(setTlsMode)(v as SmtpTlsMode)}
-              >
-                <SelectTrigger id="smtp-tls">
-                  <SelectValue placeholder="Select TLS mode" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="none">None</SelectItem>
-                  <SelectItem value="starttls">STARTTLS</SelectItem>
-                  <SelectItem value="tls">TLS</SelectItem>
-                </SelectContent>
-              </Select>
-              <p className="text-xs text-muted-foreground">
-                STARTTLS upgrades an unencrypted connection. TLS connects with encryption from the start.
-              </p>
-            </div>
-          </div>
-
-          <Separator />
-
-          <div className="flex justify-end">
-            <Button
-              onClick={handleSave}
-              disabled={saveMutation.isPending || !formDirty}
-            >
-              {saveMutation.isPending && (
-                <Loader2 className="size-4 mr-2 animate-spin" />
-              )}
-              Save SMTP Settings
-            </Button>
-          </div>
+        <CardContent>
+          {/* The backend exposes no SMTP save endpoint — PUT
+              /api/v1/admin/smtp does not exist and the old editable form's
+              Save button 404'd (issue #555). SMTP is server-side
+              configuration only, so this tab is informational. */}
+          <Alert>
+            <Info className="size-4" />
+            <AlertTitle>Configured via environment variables</AlertTitle>
+            <AlertDescription>
+              SMTP is configured on the server with the SMTP_HOST, SMTP_PORT,
+              SMTP_USERNAME, SMTP_PASSWORD, SMTP_FROM_ADDRESS, and
+              SMTP_TLS_MODE environment variables; changes take effect on
+              server restart. When SMTP_HOST is not set, email delivery is
+              disabled.
+            </AlertDescription>
+          </Alert>
         </CardContent>
       </Card>
 
@@ -476,8 +270,8 @@ function SmtpSettingsForm({
         <CardHeader>
           <CardTitle className="text-base">Send Test Email</CardTitle>
           <CardDescription>
-            Verify the SMTP configuration by sending a test message. Save any
-            pending changes before testing.
+            Verify the server-side SMTP configuration by sending a test
+            message.
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/src/hooks/use-admin-settings.ts
+++ b/src/hooks/use-admin-settings.ts
@@ -4,11 +4,11 @@ import { settingsApi, type AdminSettings } from "@/lib/api/settings";
 /**
  * Shared query for the bundled `/api/v1/admin/settings` response.
  *
- * The admin Settings page and its SmtpSettingsTab both need this data. They
- * used to declare two `useQuery` calls with hand-matched options; react-query
- * deduplicates by serialized `queryKey`, so any drift between the two call
- * sites silently doubled the network traffic. Routing both through this hook
- * makes the dedup invariant impossible to violate. See #349.
+ * The admin Settings page fetches all settings slices (password policy,
+ * storage, SMTP, environment) through this one query. Always go through this
+ * hook rather than declaring a separate `useQuery` with hand-matched options:
+ * react-query deduplicates by serialized `queryKey`, so any drift between
+ * call sites silently doubles the network traffic. See #349.
  */
 export function useAdminSettings(): UseQueryResult<AdminSettings, Error> {
   return useQuery({

--- a/src/lib/api/__tests__/settings.test.ts
+++ b/src/lib/api/__tests__/settings.test.ts
@@ -355,43 +355,6 @@ describe("settingsApi", () => {
   });
 
   // -------------------------------------------------------------------------
-  // updateSmtpConfig tests
-  // -------------------------------------------------------------------------
-
-  it("updateSmtpConfig calls PUT /api/v1/admin/smtp", async () => {
-    mockApiFetch.mockResolvedValue(undefined);
-    const mod = await import("../settings");
-    const config = {
-      host: "smtp.test.com",
-      port: 587,
-      username: "user",
-      password: "pass",
-      from_address: "test@test.com",
-      tls_mode: "starttls" as const,
-    };
-    await mod.settingsApi.updateSmtpConfig(config);
-    expect(mockApiFetch).toHaveBeenCalledWith("/api/v1/admin/smtp", {
-      method: "PUT",
-      body: JSON.stringify(config),
-    });
-  });
-
-  it("updateSmtpConfig propagates errors", async () => {
-    mockApiFetch.mockRejectedValue(new Error("API error 500: server error"));
-    const mod = await import("../settings");
-    await expect(
-      mod.settingsApi.updateSmtpConfig({
-        host: "smtp.test.com",
-        port: 587,
-        username: "",
-        password: "",
-        from_address: "test@test.com",
-        tls_mode: "starttls",
-      })
-    ).rejects.toThrow("API error 500");
-  });
-
-  // -------------------------------------------------------------------------
   // sendTestEmail tests
   // -------------------------------------------------------------------------
 
@@ -413,6 +376,17 @@ describe("settingsApi", () => {
     await expect(
       mod.settingsApi.sendTestEmail("admin@test.com")
     ).rejects.toThrow("API error 502");
+  });
+
+  it("exposes no SMTP save method — the backend has no save endpoint (#555)", async () => {
+    // Regression guard: the backend has never exposed PUT/POST
+    // /api/v1/admin/smtp (only /api/v1/admin/smtp/test). SMTP is configured
+    // via server env vars (SMTP_HOST et al.), so re-adding an
+    // `updateSmtpConfig` here would re-introduce the 404 from issue #555.
+    const mod = await import("../settings");
+    expect(
+      (mod.settingsApi as Record<string, unknown>).updateSmtpConfig
+    ).toBeUndefined();
   });
 
   // -------------------------------------------------------------------------

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -337,18 +337,14 @@ export const settingsApi = {
   },
 
   /**
-   * Save SMTP configuration. Uses the /api/v1/admin/smtp endpoint which
-   * is not yet in the generated SDK.
-   */
-  updateSmtpConfig: async (config: SmtpConfig): Promise<void> => {
-    await apiFetch<void>("/api/v1/admin/smtp", {
-      method: "PUT",
-      body: JSON.stringify(config),
-    });
-  },
-
-  /**
    * Send a test email through the configured SMTP server.
+   *
+   * Note: there is deliberately no `updateSmtpConfig` here. The backend has
+   * never exposed a save endpoint — `PUT /api/v1/admin/smtp` does not exist
+   * and calling it returns 404 (issue #555). SMTP is configured exclusively
+   * via server environment variables (SMTP_HOST, SMTP_PORT, SMTP_USERNAME,
+   * SMTP_PASSWORD, SMTP_FROM_ADDRESS, SMTP_TLS_MODE); only the test-email
+   * endpoint below exists under /api/v1/admin/smtp.
    */
   sendTestEmail: async (recipient: string): Promise<SendTestEmailResponse> => {
     return apiFetch<SendTestEmailResponse>("/api/v1/admin/smtp/test", {


### PR DESCRIPTION
## Summary

Fixes #555

**Root cause:** the Email tab's "Save SMTP Settings" button called `PUT /api/v1/admin/smtp`, an endpoint the backend has never exposed. Verified against the backend repo (`backend/src/api/handlers/smtp.rs`): under `/api/v1/admin/smtp` only `POST /test` exists, and SMTP is configured exclusively via server environment variables (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_FROM_ADDRESS`, `SMTP_TLS_MODE`, parsed in `backend/src/config.rs`). Since the SMTP service was introduced (backend #681/#718) there has been no runtime-persistence path, so every save attempt 404'd — matching the issue's screenshot.

**Fix (web side):** stop pretending SMTP is UI-editable.
- Removed `settingsApi.updateSmtpConfig` (the dead `PUT /api/v1/admin/smtp` call).
- Replaced the editable SMTP form on Settings → Email with an informational notice explaining SMTP is server-configured via env vars, consistent with the page's existing "Read-only Configuration" banner.
- Kept the Send Test Email card — `POST /api/v1/admin/smtp/test` is a real endpoint and still works.
- Added regression tests pinning the contract: no save method on the settings API surface, and no save button/edit form rendered on the Email tab.

If runtime-editable SMTP is ever desired, it needs a backend feature (persist config + reconfigure `SmtpService`); the UI form can be restored against that endpoint then.

## Test Checklist
- [x] Unit tests added/updated (regression tests for #555; removed tests covering the deleted save flow)
- [ ] E2E Playwright tests added/updated (N/A — no Playwright specs cover the SMTP tab)
- [ ] Manually tested locally
- [x] No regressions in existing tests (full suite: 170 files / 3136 tests passing)

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes

UI change is a like-for-like swap of the form for an Alert inside the existing card layout, using the same `Alert`/`Info` pattern already used at the top of the Settings page.