### PR TITLE
fix(admin): paginate users list and group member picker (#564)

### DIFF
--- a/src/app/(app)/(admin)/groups/__tests__/page.test.tsx
+++ b/src/app/(app)/(admin)/groups/__tests__/page.test.tsx
@@ -1,0 +1,439 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+} from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("lucide-react", () => {
+  const stub = (name: string) => {
+    const Icon = (props: any) => (
+      <span data-testid={`icon-${name}`} {...props} />
+    );
+    Icon.displayName = name;
+    return Icon;
+  };
+  return {
+    Plus: stub("Plus"),
+    Pencil: stub("Pencil"),
+    Trash2: stub("Trash2"),
+    Users2: stub("Users2"),
+    UserPlus: stub("UserPlus"),
+    UserMinus: stub("UserMinus"),
+    Search: stub("Search"),
+  };
+});
+
+const {
+  mockUseAuth,
+  mockUseQuery,
+  mockUseMutation,
+  mockInvalidateQueries,
+  mockGroupsList,
+  mockGroupsGetDetail,
+  mockGroupsCreate,
+  mockGroupsUpdate,
+  mockGroupsDelete,
+  mockGroupsAddMembers,
+  mockGroupsRemoveMembers,
+  mockAdminListUsersPage,
+} = vi.hoisted(() => ({
+  mockUseAuth: vi.fn(),
+  mockUseQuery: vi.fn(),
+  mockUseMutation: vi.fn(),
+  mockInvalidateQueries: vi.fn(),
+  mockGroupsList: vi.fn(),
+  mockGroupsGetDetail: vi.fn(),
+  mockGroupsCreate: vi.fn(),
+  mockGroupsUpdate: vi.fn(),
+  mockGroupsDelete: vi.fn(),
+  mockGroupsAddMembers: vi.fn(),
+  mockGroupsRemoveMembers: vi.fn(),
+  mockAdminListUsersPage: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/providers/auth-provider", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (opts: any) => mockUseQuery(opts),
+  useMutation: (opts: any) => mockUseMutation(opts),
+  useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
+}));
+
+vi.mock("@/lib/api/groups", () => ({
+  groupsApi: {
+    list: (...args: any[]) => mockGroupsList(...args),
+    getDetail: (...args: any[]) => mockGroupsGetDetail(...args),
+    create: (...args: any[]) => mockGroupsCreate(...args),
+    update: (...args: any[]) => mockGroupsUpdate(...args),
+    delete: (...args: any[]) => mockGroupsDelete(...args),
+    addMembers: (...args: any[]) => mockGroupsAddMembers(...args),
+    removeMembers: (...args: any[]) => mockGroupsRemoveMembers(...args),
+  },
+}));
+
+vi.mock("@/lib/api/admin", () => ({
+  adminApi: {
+    listUsersPage: (...args: any[]) => mockAdminListUsersPage(...args),
+  },
+}));
+
+vi.mock("@/lib/query-keys", () => ({
+  invalidateGroup: vi.fn(),
+}));
+
+// UI components
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: any) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("@/components/ui/input", () => ({
+  Input: (props: any) => <input {...props} />,
+}));
+
+vi.mock("@/components/ui/label", () => ({
+  Label: ({ children, ...props }: any) => <label {...props}>{children}</label>,
+}));
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: any) => <span data-testid="badge">{children}</span>,
+}));
+
+vi.mock("@/components/ui/textarea", () => ({
+  Textarea: (props: any) => <textarea {...props} />,
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children, open }: any) =>
+    open ? <div data-testid="dialog">{children}</div> : null,
+  DialogContent: ({ children }: any) => (
+    <div data-testid="dialog-content">{children}</div>
+  ),
+  DialogHeader: ({ children }: any) => <div>{children}</div>,
+  DialogTitle: ({ children }: any) => (
+    <h2 data-testid="dialog-title">{children}</h2>
+  ),
+  DialogDescription: ({ children }: any) => <p>{children}</p>,
+  DialogFooter: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({ children }: any) => <div data-testid="select">{children}</div>,
+  SelectTrigger: ({ children }: any) => <div>{children}</div>,
+  SelectValue: ({ placeholder }: any) => <span>{placeholder}</span>,
+  SelectContent: ({ children }: any) => (
+    <div data-testid="select-content">{children}</div>
+  ),
+  SelectItem: ({ children, value }: any) => (
+    <div data-testid={`select-item-${value}`}>{children}</div>
+  ),
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: any) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: any) => <div>{children}</div>,
+  TooltipContent: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/scroll-area", () => ({
+  ScrollArea: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/separator", () => ({
+  Separator: () => <hr />,
+}));
+
+vi.mock("@/components/common/page-header", () => ({
+  PageHeader: ({ title, description, actions }: any) => (
+    <div data-testid="page-header">
+      <h1>{title}</h1>
+      {description && <p>{description}</p>}
+      {actions}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/common/data-table", () => ({
+  DataTable: ({ data, columns, loading, emptyMessage, rowKey }: any) => {
+    if (loading) return <div data-testid="data-table-loading">Loading...</div>;
+    if (!data || data.length === 0)
+      return <div data-testid="data-table-empty">{emptyMessage}</div>;
+    return (
+      <table data-testid="data-table">
+        <tbody>
+          {data.map((row: any, i: number) => (
+            <tr key={rowKey ? rowKey(row) : i}>
+              {columns.map((c: any) => (
+                <td key={c.id}>{c.cell ? c.cell(row) : null}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  },
+}));
+
+vi.mock("@/components/common/confirm-dialog", () => ({
+  ConfirmDialog: ({ open, title, onConfirm }: any) =>
+    open ? (
+      <div data-testid="confirm-dialog">
+        <span>{title}</span>
+        <button data-testid="confirm-btn" onClick={onConfirm}>
+          Confirm
+        </button>
+      </div>
+    ) : null,
+}));
+
+vi.mock("@/components/common/empty-state", () => ({
+  EmptyState: ({ title, description, action }: any) => (
+    <div data-testid="empty-state">
+      <p>{title}</p>
+      <p>{description}</p>
+      {action}
+    </div>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const adminUser = {
+  id: "admin-1",
+  username: "admin",
+  email: "admin@test.com",
+  is_admin: true,
+  is_active: true,
+};
+
+const mockGroup = {
+  id: "grp-1",
+  name: "engineering",
+  description: "Engineers",
+  auto_join: false,
+  member_count: 1,
+  is_external: false,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+const memberUser = {
+  id: "user-1",
+  username: "alice",
+  email: "alice@test.com",
+  display_name: "Alice A",
+  is_admin: false,
+  is_active: true,
+};
+
+const nonMemberUser = {
+  id: "user-2",
+  username: "bob",
+  email: "bob@test.com",
+  display_name: "Bob B",
+  is_admin: false,
+  is_active: true,
+};
+
+const groupDetail = {
+  ...mockGroup,
+  members: [
+    {
+      user_id: "user-1",
+      username: "alice",
+      display_name: "Alice A",
+      joined_at: "2026-01-02T00:00:00Z",
+    },
+  ],
+};
+
+let capturedQueryConfigs: any[] = [];
+
+function setupMocks(
+  opts: {
+    user?: any;
+    groups?: any[];
+    groupsTotal?: number;
+    pickerUsers?: any[];
+    pickerTotal?: number;
+  } = {}
+) {
+  const {
+    user = adminUser,
+    groups = [mockGroup],
+    groupsTotal,
+    pickerUsers = [memberUser, nonMemberUser],
+    pickerTotal,
+  } = opts;
+
+  mockUseAuth.mockReturnValue({ user });
+  capturedQueryConfigs = [];
+
+  mockUseQuery.mockImplementation((q: any) => {
+    capturedQueryConfigs.push(q);
+    if (q.queryKey[0] === "admin-groups") {
+      return {
+        data: {
+          items: groups,
+          pagination: { total: groupsTotal ?? groups.length },
+        },
+        isLoading: false,
+      };
+    }
+    if (q.queryKey[0] === "admin-group-detail") {
+      return { data: groupDetail, isLoading: false };
+    }
+    if (q.queryKey[0] === "admin-users") {
+      return {
+        data: {
+          items: pickerUsers,
+          total: pickerTotal ?? pickerUsers.length,
+        },
+        isLoading: false,
+      };
+    }
+    return { data: undefined, isLoading: false };
+  });
+
+  mockUseMutation.mockImplementation(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+  }));
+}
+
+function openMembersDialog() {
+  const manageButtons = screen.getAllByTestId("icon-Users2");
+  fireEvent.click(manageButtons[0]);
+}
+
+function pickerQueries() {
+  return capturedQueryConfigs.filter(
+    (c) => c.queryKey[0] === "admin-users" && c.queryKey[1] === "picker"
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+import GroupsPage from "../page";
+
+describe("GroupsPage", () => {
+  afterEach(() => cleanup());
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the groups table for admins", () => {
+    setupMocks();
+    render(<GroupsPage />);
+    expect(screen.getByTestId("data-table")).toBeInTheDocument();
+    expect(screen.getByText("engineering")).toBeInTheDocument();
+  });
+
+  describe("add member picker (#564)", () => {
+    it("queries users with perPage 100 and no search when the dialog opens", async () => {
+      mockAdminListUsersPage.mockResolvedValue({ items: [], total: 0 });
+      setupMocks();
+      render(<GroupsPage />);
+      openMembersDialog();
+
+      const picker = pickerQueries().at(-1);
+      expect(picker).toBeDefined();
+      expect(picker.queryKey).toEqual(["admin-users", "picker", ""]);
+      await picker.queryFn();
+      expect(mockAdminListUsersPage).toHaveBeenCalledWith({
+        search: undefined,
+        perPage: 100,
+      });
+    });
+
+    it("offers users who are not already members", () => {
+      setupMocks();
+      render(<GroupsPage />);
+      openMembersDialog();
+
+      expect(screen.getByTestId("select-item-user-2")).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("select-item-user-1")
+      ).not.toBeInTheDocument();
+    });
+
+    it("passes the search term to the server-side query", async () => {
+      mockAdminListUsersPage.mockResolvedValue({
+        items: [nonMemberUser],
+        total: 1,
+      });
+      setupMocks();
+      render(<GroupsPage />);
+      openMembersDialog();
+
+      fireEvent.change(screen.getByLabelText("Search users to add"), {
+        target: { value: "bob" },
+      });
+
+      const picker = pickerQueries().find((c) => c.queryKey[2] === "bob");
+      expect(picker).toBeDefined();
+      await picker.queryFn();
+      expect(mockAdminListUsersPage).toHaveBeenCalledWith({
+        search: "bob",
+        perPage: 100,
+      });
+    });
+
+    it("shows a match-specific empty message when a search finds nothing", () => {
+      setupMocks({ pickerUsers: [] });
+      render(<GroupsPage />);
+      openMembersDialog();
+
+      fireEvent.change(screen.getByLabelText("Search users to add"), {
+        target: { value: "zzz" },
+      });
+
+      expect(
+        screen.getByText("No users match your search")
+      ).toBeInTheDocument();
+    });
+
+    it("shows a truncation notice when the server total exceeds the fetched page", () => {
+      setupMocks({
+        pickerUsers: [memberUser, nonMemberUser],
+        pickerTotal: 150,
+      });
+      render(<GroupsPage />);
+      openMembersDialog();
+
+      expect(
+        screen.getByText(/Showing first 2 of 150/)
+      ).toBeInTheDocument();
+    });
+
+    it("does not show a truncation notice when all users fit in the page", () => {
+      setupMocks({
+        pickerUsers: [memberUser, nonMemberUser],
+        pickerTotal: 2,
+      });
+      render(<GroupsPage />);
+      openMembersDialog();
+
+      expect(screen.queryByText(/Showing first/)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/app/(app)/(admin)/groups/page.tsx
+++ b/src/app/(app)/(admin)/groups/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useDeferredValue } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   Plus,
@@ -83,6 +83,7 @@ export default function GroupsPage() {
   const [selectedGroup, setSelectedGroup] = useState<Group | null>(null);
   const [form, setForm] = useState<GroupForm>(EMPTY_FORM);
   const [memberSearch, setMemberSearch] = useState("");
+  const [addUserSearch, setAddUserSearch] = useState("");
   const [addUserId, setAddUserId] = useState<string>("");
 
   // -- queries --
@@ -101,12 +102,22 @@ export default function GroupsPage() {
     enabled: membersOpen && !!selectedGroup?.id,
   });
 
-  // all users for the add member dropdown
-  const { data: allUsers } = useQuery({
-    queryKey: ["admin-users"],
-    queryFn: () => adminApi.listUsers(),
+  // Users for the add member dropdown, filtered server-side so any user in
+  // the instance is reachable even beyond the first page (#564). The backend
+  // clamps per_page to 100, so a truncation notice covers the remainder.
+  const deferredAddUserSearch = useDeferredValue(addUserSearch);
+  const { data: pickerUsersData } = useQuery({
+    queryKey: ["admin-users", "picker", deferredAddUserSearch],
+    queryFn: () =>
+      adminApi.listUsersPage({
+        search: deferredAddUserSearch || undefined,
+        perPage: 100,
+      }),
     enabled: membersOpen && !!currentUser?.is_admin,
   });
+
+  const allUsers = pickerUsersData?.items ?? [];
+  const pickerTotal = pickerUsersData?.total ?? 0;
 
   // -- mutations --
   const createMutation = useMutation({
@@ -188,6 +199,7 @@ export default function GroupsPage() {
   const handleManageMembers = useCallback((g: Group) => {
     setSelectedGroup(g);
     setMemberSearch("");
+    setAddUserSearch("");
     setAddUserId("");
     setMembersOpen(true);
   }, []);
@@ -199,9 +211,7 @@ export default function GroupsPage() {
   const members: GroupMember[] = groupDetail?.members ?? [];
 
   const memberIds = new Set(members.map((m) => m.user_id));
-  const availableUsers = (allUsers ?? []).filter(
-    (u: User) => !memberIds.has(u.id)
-  );
+  const availableUsers = allUsers.filter((u: User) => !memberIds.has(u.id));
 
   const filteredMembers = memberSearch
     ? members.filter(
@@ -497,6 +507,7 @@ export default function GroupsPage() {
           if (!o) {
             setSelectedGroup(null);
             setMemberSearch("");
+            setAddUserSearch("");
             setAddUserId("");
           }
         }}
@@ -517,6 +528,20 @@ export default function GroupsPage() {
           <div className="flex items-end gap-2">
             <div className="flex-1 space-y-2">
               <Label>Add Member</Label>
+              <div className="relative">
+                <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground" />
+                <Input
+                  aria-label="Search users to add"
+                  placeholder="Search users..."
+                  className="pl-8"
+                  value={addUserSearch}
+                  disabled={selectedIsExternal}
+                  onChange={(e) => {
+                    setAddUserSearch(e.target.value);
+                    setAddUserId("");
+                  }}
+                />
+              </div>
               <Select
                 value={addUserId}
                 onValueChange={setAddUserId}
@@ -533,11 +558,17 @@ export default function GroupsPage() {
                   ))}
                   {availableUsers.length === 0 && (
                     <div className="px-2 py-4 text-center text-sm text-muted-foreground">
-                      No users available to add
+                      {addUserSearch
+                        ? "No users match your search"
+                        : "No users available to add"}
                     </div>
                   )}
                 </SelectContent>
               </Select>
+              <ListTruncationNotice
+                shown={allUsers.length}
+                total={pickerTotal}
+              />
             </div>
             <Tooltip>
               <TooltipTrigger asChild>

--- a/src/app/(app)/(admin)/users/__tests__/page.test.tsx
+++ b/src/app/(app)/(admin)/users/__tests__/page.test.tsx
@@ -49,6 +49,7 @@ const {
   mockSdkResetPassword,
   mockSdkDeleteUser,
   mockAdminListUsers,
+  mockAdminListUsersPage,
   mockAdminListUserTokens,
   mockAdminRevokeUserToken,
 } = vi.hoisted(() => ({
@@ -63,6 +64,7 @@ const {
   mockSdkResetPassword: vi.fn(),
   mockSdkDeleteUser: vi.fn(),
   mockAdminListUsers: vi.fn(),
+  mockAdminListUsersPage: vi.fn(),
   mockAdminListUserTokens: vi.fn(),
   mockAdminRevokeUserToken: vi.fn(),
 }));
@@ -93,6 +95,7 @@ vi.mock("@artifact-keeper/sdk", () => ({
 vi.mock("@/lib/api/admin", () => ({
   adminApi: {
     listUsers: (...args: any[]) => mockAdminListUsers(...args),
+    listUsersPage: (...args: any[]) => mockAdminListUsersPage(...args),
     listUserTokens: (...args: any[]) => mockAdminListUserTokens(...args),
     revokeUserToken: (...args: any[]) => mockAdminRevokeUserToken(...args),
   },
@@ -200,32 +203,64 @@ vi.mock("@/components/common/page-header", () => ({
 }));
 
 vi.mock("@/components/common/data-table", () => ({
-  DataTable: ({ data, columns, loading, emptyMessage, rowKey }: any) => {
+  DataTable: ({
+    data,
+    columns,
+    loading,
+    emptyMessage,
+    rowKey,
+    total,
+    page,
+    pageSize,
+    onPageChange,
+    onPageSizeChange,
+  }: any) => {
     if (loading) return <div data-testid="data-table-loading">Loading...</div>;
     if (!data || data.length === 0)
       return <div data-testid="data-table-empty">{emptyMessage}</div>;
     return (
-      <table data-testid="data-table">
-        <thead>
-          <tr>
-            {columns.map((c: any) => (
-              <th key={c.id}>{c.header}</th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {data.map((row: any, i: number) => (
-            <tr key={rowKey ? rowKey(row) : i}>
-              {columns.map((c: any) => {
-                if (c.accessor) c.accessor(row);
-                return (
-                  <td key={c.id}>{c.cell ? c.cell(row) : null}</td>
-                );
-              })}
+      <div>
+        <table data-testid="data-table">
+          <thead>
+            <tr>
+              {columns.map((c: any) => (
+                <th key={c.id}>{c.header}</th>
+              ))}
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {data.map((row: any, i: number) => (
+              <tr key={rowKey ? rowKey(row) : i}>
+                {columns.map((c: any) => {
+                  if (c.accessor) c.accessor(row);
+                  return (
+                    <td key={c.id}>{c.cell ? c.cell(row) : null}</td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {(onPageChange || onPageSizeChange) && (
+          <div data-testid="data-table-pagination">
+            <span data-testid="pagination-total">{total}</span>
+            <span data-testid="pagination-page">{page}</span>
+            <span data-testid="pagination-page-size">{pageSize}</span>
+            <button
+              data-testid="next-page"
+              onClick={() => onPageChange?.((page ?? 1) + 1)}
+            >
+              Next
+            </button>
+            <button
+              data-testid="page-size-50"
+              onClick={() => onPageSizeChange?.(50)}
+            >
+              50 per page
+            </button>
+          </div>
+        )}
+      </div>
     );
   },
 }));
@@ -352,6 +387,7 @@ function getMutationConfig(name: keyof typeof MUTATION_INDEX) {
 function setupMocks(opts: {
   user?: any;
   users?: any[];
+  usersTotal?: number;
   usersLoading?: boolean;
   tokens?: any[];
   tokensLoading?: boolean;
@@ -360,6 +396,7 @@ function setupMocks(opts: {
   const {
     user = adminUser,
     users = mockUsers,
+    usersTotal,
     usersLoading = false,
     tokens = [],
     tokensLoading = false,
@@ -375,7 +412,13 @@ function setupMocks(opts: {
   mockUseQuery.mockImplementation((opts: any) => {
     capturedQueryConfigs.push(opts);
     if (opts.queryKey[0] === "admin-users") {
-      return { data: users, isLoading: usersLoading };
+      return {
+        data:
+          users === undefined
+            ? undefined
+            : { items: users, total: usersTotal ?? users.length },
+        isLoading: usersLoading,
+      };
     }
     if (opts.queryKey[0] === "admin-user-tokens") {
       return { data: tokens, isLoading: tokensLoading };
@@ -390,7 +433,7 @@ function setupMocks(opts: {
     mutationCallIndex++;
     const overrides = mutationOverrides[idx] ?? {};
     return {
-      mutate: vi.fn((arg: any) => {
+      mutate: vi.fn(() => {
         // For tests that want to trigger the mutation flow synchronously,
         // they can call getMutationConfig(name).onSuccess / onError directly.
       }),
@@ -1243,20 +1286,97 @@ describe("UsersPage", () => {
     });
   });
 
-  // -- Query queryFn callbacks --
+  // -- Server-side pagination (#564) --
 
-  it("users query queryFn calls adminApi.listUsers", async () => {
-    mockAdminListUsers.mockResolvedValue([]);
-    setupMocks();
-    render(<UsersPage />);
+  describe("pagination", () => {
+    it("requests page 1 with the default page size", () => {
+      setupMocks();
+      render(<UsersPage />);
 
-    const usersQuery = capturedQueryConfigs.find(
-      (c) => c.queryKey[0] === "admin-users"
-    );
-    expect(usersQuery).toBeDefined();
-    await usersQuery.queryFn();
-    expect(mockAdminListUsers).toHaveBeenCalled();
+      const usersQuery = capturedQueryConfigs.find(
+        (c) => c.queryKey[0] === "admin-users"
+      );
+      expect(usersQuery.queryKey).toEqual(["admin-users", 1, 20]);
+    });
+
+    it("queryFn calls adminApi.listUsersPage with the current page", async () => {
+      mockAdminListUsersPage.mockResolvedValue({ items: [], total: 0 });
+      setupMocks();
+      render(<UsersPage />);
+
+      const usersQuery = capturedQueryConfigs.find(
+        (c) => c.queryKey[0] === "admin-users"
+      );
+      expect(usersQuery).toBeDefined();
+      await usersQuery.queryFn();
+      expect(mockAdminListUsersPage).toHaveBeenCalledWith({
+        page: 1,
+        perPage: 20,
+      });
+    });
+
+    it("passes the server-reported total to the table", () => {
+      setupMocks({ usersTotal: 57 });
+      render(<UsersPage />);
+
+      expect(screen.getByTestId("data-table-pagination")).toBeInTheDocument();
+      expect(screen.getByTestId("pagination-total")).toHaveTextContent("57");
+      expect(screen.getByTestId("pagination-page")).toHaveTextContent("1");
+      expect(screen.getByTestId("pagination-page-size")).toHaveTextContent(
+        "20"
+      );
+    });
+
+    it("navigating to the next page re-queries with page 2", async () => {
+      mockAdminListUsersPage.mockResolvedValue({ items: mockUsers, total: 57 });
+      setupMocks({ usersTotal: 57 });
+      render(<UsersPage />);
+
+      fireEvent.click(screen.getByTestId("next-page"));
+
+      const pageTwoQuery = capturedQueryConfigs.find(
+        (c) => c.queryKey[0] === "admin-users" && c.queryKey[1] === 2
+      );
+      expect(pageTwoQuery).toBeDefined();
+      expect(pageTwoQuery.queryKey).toEqual(["admin-users", 2, 20]);
+      await pageTwoQuery.queryFn();
+      expect(mockAdminListUsersPage).toHaveBeenCalledWith({
+        page: 2,
+        perPage: 20,
+      });
+    });
+
+    it("changing the page size re-queries with the new size and resets to page 1", async () => {
+      mockAdminListUsersPage.mockResolvedValue({ items: mockUsers, total: 57 });
+      setupMocks({ usersTotal: 57 });
+      render(<UsersPage />);
+
+      // Move to page 2 first so the reset back to page 1 is observable.
+      fireEvent.click(screen.getByTestId("next-page"));
+      fireEvent.click(screen.getByTestId("page-size-50"));
+
+      const resizedQuery = capturedQueryConfigs.find(
+        (c) =>
+          c.queryKey[0] === "admin-users" &&
+          c.queryKey[1] === 1 &&
+          c.queryKey[2] === 50
+      );
+      expect(resizedQuery).toBeDefined();
+      await resizedQuery.queryFn();
+      expect(mockAdminListUsersPage).toHaveBeenCalledWith({
+        page: 1,
+        perPage: 50,
+      });
+    });
+
+    it("shows the empty state only when the server total is zero", () => {
+      setupMocks({ users: [], usersTotal: 0 });
+      render(<UsersPage />);
+      expect(screen.getByText("No users yet")).toBeInTheDocument();
+    });
   });
+
+  // -- Query queryFn callbacks --
 
   it("token query queryFn calls adminApi.listUserTokens", async () => {
     mockAdminListUserTokens.mockResolvedValue([]);

--- a/src/app/(app)/(admin)/users/page.tsx
+++ b/src/app/(app)/(admin)/users/page.tsx
@@ -124,12 +124,19 @@ export default function UsersPage() {
     is_active: true,
   });
 
+  // server-side pagination (#564)
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+
   // -- queries --
-  const { data: users, isLoading } = useQuery({
-    queryKey: ["admin-users"],
-    queryFn: () => adminApi.listUsers(),
+  const { data: usersData, isLoading } = useQuery({
+    queryKey: ["admin-users", page, pageSize],
+    queryFn: () => adminApi.listUsersPage({ page, perPage: pageSize }),
     enabled: !!currentUser?.is_admin,
   });
+
+  const users = usersData?.items;
+  const totalUsers = usersData?.total ?? 0;
 
   // -- mutations --
   const createMutation = useMutation({
@@ -479,7 +486,7 @@ export default function UsersPage() {
         }
       />
 
-      {!isLoading && (users?.length ?? 0) === 0 ? (
+      {!isLoading && totalUsers === 0 ? (
         <EmptyState
           icon={Users}
           title="No users yet"
@@ -495,6 +502,15 @@ export default function UsersPage() {
         <DataTable
           columns={columns}
           data={users ?? []}
+          total={totalUsers}
+          page={page}
+          pageSize={pageSize}
+          onPageChange={setPage}
+          onPageSizeChange={(s) => {
+            setPageSize(s);
+            setPage(1);
+          }}
+          pageSizeOptions={[20, 50, 100]}
           loading={isLoading}
           emptyMessage="No users found."
           rowKey={(u) => u.id}

--- a/src/lib/api/__tests__/admin.test.ts
+++ b/src/lib/api/__tests__/admin.test.ts
@@ -84,13 +84,69 @@ describe("adminApi", () => {
     mockListUsers.mockResolvedValue({ data: { items: [], pagination: {} }, error: undefined });
     const { adminApi } = await import("../admin");
     await adminApi.listUsers({ perPage: 100 });
-    expect(mockListUsers).toHaveBeenCalledWith({ query: { page: undefined, per_page: 100 } });
+    expect(mockListUsers).toHaveBeenCalledWith({
+      query: { page: undefined, per_page: 100, search: undefined },
+    });
+  });
+
+  it("listUsers passes search through to the SDK query", async () => {
+    mockListUsers.mockResolvedValue({ data: { items: [], pagination: {} }, error: undefined });
+    const { adminApi } = await import("../admin");
+    await adminApi.listUsers({ search: "alice" });
+    expect(mockListUsers).toHaveBeenCalledWith({
+      query: { page: undefined, per_page: undefined, search: "alice" },
+    });
   });
 
   it("listUsers throws on error", async () => {
     mockListUsers.mockResolvedValue({ data: undefined, error: "unauthorized" });
     const { adminApi } = await import("../admin");
     await expect(adminApi.listUsers()).rejects.toBe("unauthorized");
+  });
+
+  it("listUsersPage returns items and total from the pagination envelope", async () => {
+    const sdkUser = {
+      id: "1",
+      username: "admin",
+      email: "admin@example.com",
+      is_admin: true,
+      is_active: true,
+      must_change_password: false,
+      auth_provider: "local",
+      created_at: "2025-01-01",
+      display_name: null,
+    };
+    mockListUsers.mockResolvedValue({
+      data: {
+        items: [sdkUser],
+        pagination: { page: 2, per_page: 20, total: 41, total_pages: 3 },
+      },
+      error: undefined,
+    });
+    const { adminApi } = await import("../admin");
+    const result = await adminApi.listUsersPage({ page: 2, perPage: 20 });
+    expect(mockListUsers).toHaveBeenCalledWith({
+      query: { page: 2, per_page: 20, search: undefined },
+    });
+    expect(result.total).toBe(41);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].username).toBe("admin");
+  });
+
+  it("listUsersPage sends a trimmed search and drops blank search", async () => {
+    mockListUsers.mockResolvedValue({
+      data: { items: [], pagination: { total: 0 } },
+      error: undefined,
+    });
+    const { adminApi } = await import("../admin");
+    await adminApi.listUsersPage({ search: "  bob  " });
+    expect(mockListUsers).toHaveBeenLastCalledWith({
+      query: { page: undefined, per_page: undefined, search: "bob" },
+    });
+    await adminApi.listUsersPage({ search: "   " });
+    expect(mockListUsers).toHaveBeenLastCalledWith({
+      query: { page: undefined, per_page: undefined, search: undefined },
+    });
   });
 
   it("getHealth returns health response", async () => {

--- a/src/lib/api/admin.ts
+++ b/src/lib/api/admin.ts
@@ -98,17 +98,43 @@ function adaptApiKey(sdk: ApiTokenResponse): ApiKey {
   };
 }
 
+export interface ListUsersParams {
+  page?: number;
+  perPage?: number;
+  /** Server-side filter on username, email, or display name (ILIKE). */
+  search?: string;
+}
+
+export interface ListUsersResult {
+  items: User[];
+  /** Total matching users across all pages, from the pagination envelope. */
+  total: number;
+}
+
 export const adminApi = {
   getStats: async (): Promise<AdminStats> => {
     const data = await unwrap(getSystemStats());
     return adaptStats(assertData(data, 'adminApi.getStats'));
   },
 
-  listUsers: async (params: { page?: number; perPage?: number } = {}): Promise<User[]> => {
+  listUsers: async (params: ListUsersParams = {}): Promise<User[]> => {
+    const result = await adminApi.listUsersPage(params);
+    return result.items;
+  },
+
+  listUsersPage: async (params: ListUsersParams = {}): Promise<ListUsersResult> => {
     const data = await unwrap(listUsers({
-      query: { page: params.page, per_page: params.perPage },
+      query: {
+        page: params.page,
+        per_page: params.perPage,
+        search: params.search?.trim() || undefined,
+      },
     }));
-    return assertData(data, 'adminApi.listUsers').items.map(adaptUser);
+    const response = assertData(data, 'adminApi.listUsersPage');
+    return {
+      items: response.items.map(adaptUser),
+      total: response.pagination.total,
+    };
   },
 
   getHealth: async (): Promise<HealthResponse> => {


### PR DESCRIPTION
## Summary
Fixes #564.

The admin Users page and the group "Add Member" picker both fetched users via `adminApi.listUsers()` with no explicit pagination, so they were effectively capped at the backend's first page (default 20 rows, hard clamp of 100 per page). On instances with more users, anyone past the first page was unreachable from the UI.

- **Users list page**: switched to server-side pagination. The page now calls the new `adminApi.listUsersPage({ page, perPage })`, keeps `page`/`pageSize` in state, and passes `total`/`page`/`pageSize`/`onPageChange`/`onPageSizeChange` into the shared `DataTable` (which renders `DataTablePagination`), matching the pattern used by downloads, audit, and security scans pages.
- **Group member picker**: a picker needs search, not paging, and the backend users endpoint already supports server-side filtering (`search` ILIKE on username/email/display_name). The Add Member section now has a search input wired (via `useDeferredValue`) to `adminApi.listUsersPage({ search, perPage: 100 })`, plus a `ListTruncationNotice` when the server-reported total exceeds the fetched page so truncation is never silent.
- **`adminApi`**: added `listUsersPage()` returning `{ items, total }` from the pagination envelope and a `search` param (trimmed, blank dropped); `listUsers()` keeps its `User[]` signature and delegates, so existing callers (permissions, audit, age-gate) are untouched.

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [ ] Manually tested locally
- [x] No regressions in existing tests

New/updated coverage:
- Users page: requests page 1 by default, `queryFn` passes `{ page, perPage }` to `listUsersPage`, server `total` reaches the table, next-page re-queries with page 2, page-size change resets to page 1, empty state only at total 0.
- Groups page (new test file): picker queries with `perPage: 100`, search term is passed through to the server query, current members are excluded, search-empty message, truncation notice shown/hidden based on server total.
- `adminApi`: `listUsersPage` maps the pagination envelope, search pass-through/trimming.

Gates: `npm run test` (171 files, 3167 tests, all green), `npx eslint` on changed files (clean), `npx tsc --noEmit` (23 pre-existing baseline errors, none new), `npm run build` (passes).

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes

UI changes are additive: pagination controls come from the shared `DataTablePagination` component (already accessible, labelled prev/next buttons), and the picker search input has an explicit `aria-label`.
