### PR TITLE
fix(repositories): default private + hide public toggle when guest access is off

### DIFF
--- a/src/app/(app)/repositories/_components/repo-dialogs.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-dialogs.test.tsx
@@ -69,6 +69,19 @@ vi.mock('@/components/common/confirm-dialog', () => ({
     ) : null,
 }));
 
+// Feature flags come from the system-config provider. Default to guest access
+// enabled (the provider's own permissive default); gating tests override this.
+const mockFlags = vi.hoisted(() => ({ guestAccessEnabled: true }));
+vi.mock('@/providers/system-config-provider', () => ({
+  useFeatureFlags: () => mockFlags,
+}));
+
+// Root-level reset so gating tests that disable guest access don't leak state
+// into other suites (their beforeEach hooks don't know about the mock).
+beforeEach(() => {
+  mockFlags.guestAccessEnabled = true;
+});
+
 const defaultProps = {
   createOpen: true,
   onCreateOpenChange: vi.fn(),
@@ -314,15 +327,22 @@ describe('RepoDialogs - Create Dialog', () => {
     expect(screen.getByText(/no.*local or remote repositories available/i)).toBeTruthy();
   });
 
+  it('defaults the public switch to unchecked (private by default)', () => {
+    render(<RepoDialogs {...defaultProps} />);
+
+    const publicSwitch = screen.getByRole('switch');
+    expect(publicSwitch.getAttribute('aria-checked')).toBe('false');
+  });
+
   it('toggles public switch', async () => {
     const user = userEvent.setup();
     render(<RepoDialogs {...defaultProps} />);
 
     const publicSwitch = screen.getByRole('switch');
-    expect(publicSwitch.getAttribute('aria-checked')).toBe('true');
+    expect(publicSwitch.getAttribute('aria-checked')).toBe('false');
 
     await user.click(publicSwitch);
-    expect(publicSwitch.getAttribute('aria-checked')).toBe('false');
+    expect(publicSwitch.getAttribute('aria-checked')).toBe('true');
   });
 
   // Regression: form state must reset when the dialog is reopened after a
@@ -355,6 +375,84 @@ describe('RepoDialogs - Create Dialog', () => {
     const nameInput = within(reopened).getByPlaceholderText('My Repository') as HTMLInputElement;
     expect(keyInput.value).toBe('');
     expect(nameInput.value).toBe('');
+  });
+});
+
+describe('RepoDialogs - Guest access gating', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('hides the public switch and shows a note in the create dialog when guest access is disabled', () => {
+    mockFlags.guestAccessEnabled = false;
+    render(<RepoDialogs {...defaultProps} />);
+
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).queryByRole('switch')).toBeNull();
+    expect(
+      within(dialog).getByText('Public repositories are disabled by the operator.')
+    ).toBeTruthy();
+  });
+
+  it('shows the public switch in the create dialog when guest access is enabled', () => {
+    render(<RepoDialogs {...defaultProps} />);
+
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByRole('switch')).toBeTruthy();
+    expect(
+      within(dialog).queryByText('Public repositories are disabled by the operator.')
+    ).toBeNull();
+  });
+
+  it('hides the public switch and shows a note in the edit dialog when guest access is disabled', () => {
+    mockFlags.guestAccessEnabled = false;
+    render(
+      <RepoDialogs
+        {...defaultProps}
+        createOpen={false}
+        editOpen={true}
+        editRepo={mockEditRepo}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).queryByRole('switch')).toBeNull();
+    expect(
+      within(dialog).getByText('Public repositories are disabled by the operator.')
+    ).toBeTruthy();
+  });
+
+  it('shows the public switch in the edit dialog when guest access is enabled', () => {
+    render(
+      <RepoDialogs
+        {...defaultProps}
+        createOpen={false}
+        editOpen={true}
+        editRepo={mockEditRepo}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByRole('switch')).toBeTruthy();
+    expect(
+      within(dialog).queryByText('Public repositories are disabled by the operator.')
+    ).toBeNull();
+  });
+
+  it('submits is_public: false when the public switch is left untouched', async () => {
+    const onCreateSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(<RepoDialogs {...defaultProps} onCreateSubmit={onCreateSubmit} />);
+
+    const dialog = screen.getByRole('dialog');
+    await user.type(within(dialog).getByPlaceholderText('my-repo'), 'private-repo');
+    await user.type(within(dialog).getByPlaceholderText('My Repository'), 'Private Repo');
+    await user.click(within(dialog).getByRole('button', { name: /^create$/i }));
+
+    expect(onCreateSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ is_public: false })
+    );
   });
 });
 

--- a/src/app/(app)/repositories/_components/repo-dialogs.tsx
+++ b/src/app/(app)/repositories/_components/repo-dialogs.tsx
@@ -41,6 +41,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
+import { useFeatureFlags } from "@/providers/system-config-provider";
 import {
   RpmTrustedKeyField,
   DebianConfigFields,
@@ -134,16 +135,28 @@ export function RepoDialogs({
   pluginFormats = [],
 }: RepoDialogsProps) {
   // Create form state
+  // Private by default: matches the backend default and keeps new
+  // repositories from being exposed unintentionally.
   const [createForm, setCreateForm] = useState<CreateRepositoryRequest>({
     key: "",
     name: "",
     description: "",
     format: "generic",
     repo_type: "local",
-    is_public: true,
+    is_public: false,
     upstream_url: "",
     member_repos: [],
   });
+
+  // When guest access is disabled the backend silently coerces is_public to
+  // false, so offering the toggle would be misleading — show a note instead.
+  // While the config loads the provider falls back to DEFAULT_SYSTEM_CONFIG
+  // (guest access enabled), so the switch renders optimistically: briefly
+  // showing a switch that then disappears is harmless (the backend coerces
+  // anyway), whereas flashing "disabled by the operator" at operators who did
+  // not disable it would be actively wrong. This matches the provider's
+  // documented permissive-default philosophy.
+  const { guestAccessEnabled } = useFeatureFlags();
 
   // For virtual repos: selected member repo keys
   const [selectedMembers, setSelectedMembers] = useState<string[]>([]);
@@ -245,7 +258,7 @@ export function RepoDialogs({
     key: editRepo?.key ?? "",
     name: editRepo?.name ?? "",
     description: editRepo?.description ?? "",
-    is_public: editRepo?.is_public ?? true,
+    is_public: editRepo?.is_public ?? false,
   }), [editRepo]);
   const [editFormOverrides, setEditFormOverrides] = useState<{
     key?: string;
@@ -263,7 +276,7 @@ export function RepoDialogs({
       description: "",
       format: "generic",
       repo_type: "local",
-      is_public: true,
+      is_public: false,
       upstream_url: "",
       member_repos: [],
     });
@@ -626,16 +639,22 @@ export function RepoDialogs({
               </div>
             )}
 
-            <div className="flex items-center gap-3">
-              <Switch
-                id="create-public"
-                checked={createForm.is_public}
-                onCheckedChange={(v) =>
-                  setCreateForm((f) => ({ ...f, is_public: v }))
-                }
-              />
-              <Label htmlFor="create-public">Public repository</Label>
-            </div>
+            {guestAccessEnabled ? (
+              <div className="flex items-center gap-3">
+                <Switch
+                  id="create-public"
+                  checked={createForm.is_public}
+                  onCheckedChange={(v) =>
+                    setCreateForm((f) => ({ ...f, is_public: v }))
+                  }
+                />
+                <Label htmlFor="create-public">Public repository</Label>
+              </div>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                Public repositories are disabled by the operator.
+              </p>
+            )}
             <div className="space-y-2">
               <Label htmlFor="create-quota">Storage Quota</Label>
               <div className="flex gap-2">
@@ -761,16 +780,22 @@ export function RepoDialogs({
                 rows={2}
               />
             </div>
-            <div className="flex items-center gap-3">
-              <Switch
-                id="edit-public"
-                checked={editForm.is_public}
-                onCheckedChange={(v) =>
-                  setEditFormOverrides((f) => ({ ...f, is_public: v }))
-                }
-              />
-              <Label htmlFor="edit-public">Public repository</Label>
-            </div>
+            {guestAccessEnabled ? (
+              <div className="flex items-center gap-3">
+                <Switch
+                  id="edit-public"
+                  checked={editForm.is_public}
+                  onCheckedChange={(v) =>
+                    setEditFormOverrides((f) => ({ ...f, is_public: v }))
+                  }
+                />
+                <Label htmlFor="edit-public">Public repository</Label>
+              </div>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                Public repositories are disabled by the operator.
+              </p>
+            )}
             <div className="space-y-2">
               <Label htmlFor="edit-quota">Storage Quota</Label>
               <div className="flex gap-2">


### PR DESCRIPTION
## Summary

Two honesty fixes for the repository dialogs:

1. **Default private**: the create form initialized `is_public: true`, overriding the backend's private default. Now false everywhere (create state, `resetCreateForm`, edit fallback).
2. **Hide a toggle that cannot work**: when `/api/v1/system/config` reports `guest_access_enabled: false`, anonymous access is impossible and the backend coerces `is_public=true` to false anyway. Both dialogs now replace the public switch with a muted note: "Public repositories are disabled by the operator."

Uses the existing `SystemConfigProvider`/`useFeatureFlags` (no new fetch — the config was already loaded app-wide). While the config loads, the provider's existing permissive default keeps the switch visible: the failure mode is a briefly-visible switch the backend would still coerce, not a misleading "disabled" note shown to operators who never disabled anything.

## Test plan

- `repo-dialogs.test.tsx`: 92/92 — new gating suite (hidden+note in create/edit when off, shown when on, default unchecked, submit sends `is_public: false`)
- Full suite: 3115 pass (one pre-existing failure in data-table.test.tsx, identical on main)
- eslint clean on changed files; tsc failures are pre-existing SDK drift, identical on main

Closes #734