### PR TITLE
feat(dashboard): include proxy cache in storage/artifact stats with hover breakdown

### DIFF
--- a/src/app/(app)/__tests__/page.test.tsx
+++ b/src/app/(app)/__tests__/page.test.tsx
@@ -234,6 +234,8 @@ describe("DashboardPage", () => {
           total_artifacts: 200,
           total_users: 5,
           total_storage_bytes: 1024000,
+          proxy_artifact_count: 0,
+          proxy_storage_bytes: 0,
         },
         isLoading: false,
         isFetching: false,
@@ -524,7 +526,7 @@ describe("DashboardPage", () => {
         isFetching: false,
       },
       "admin-stats": {
-        data: { total_repositories: 1, total_artifacts: 1, total_users: 1, total_storage_bytes: 0 },
+        data: { total_repositories: 1, total_artifacts: 1, total_users: 1, total_storage_bytes: 0, proxy_artifact_count: 0, proxy_storage_bytes: 0 },
         isLoading: false,
         isFetching: false,
       },
@@ -559,7 +561,7 @@ describe("DashboardPage", () => {
         isFetching: false,
       },
       "admin-stats": {
-        data: { total_repositories: 1, total_artifacts: 1, total_users: 1, total_storage_bytes: 0 },
+        data: { total_repositories: 1, total_artifacts: 1, total_users: 1, total_storage_bytes: 0, proxy_artifact_count: 0, proxy_storage_bytes: 0 },
         isLoading: false,
         isFetching: false,
       },

--- a/src/app/(app)/_components/__tests__/dashboard-content.test.tsx
+++ b/src/app/(app)/_components/__tests__/dashboard-content.test.tsx
@@ -188,7 +188,7 @@ describe("DashboardContent", () => {
     setupUseQuery({
       health: { data: { status: "healthy", checks: {} }, isLoading: false, isFetching: false },
       "admin-stats": {
-        data: { total_repositories: 10, total_artifacts: 200, total_users: 5, total_storage_bytes: 1024000 },
+        data: { total_repositories: 10, total_artifacts: 200, total_users: 5, total_storage_bytes: 1024000, proxy_artifact_count: 50, proxy_storage_bytes: 512000 },
         isLoading: false,
         isFetching: false,
       },
@@ -202,6 +202,11 @@ describe("DashboardContent", () => {
     render(<DashboardContent />);
     expect(screen.getByText("Statistics")).toBeInTheDocument();
     expect(screen.getByText("Security Overview")).toBeInTheDocument();
+    // Cards show the combined total: local + remote (200+50, 1024000+512000).
+    expect(screen.getByTestId("stat-Artifacts")).toHaveTextContent("250");
+    expect(screen.getByTestId("stat-Storage Used")).toHaveTextContent(
+      "1536000 B"
+    );
   });
 
   it("shows personalized greeting with display_name", () => {
@@ -374,7 +379,7 @@ describe("DashboardContent", () => {
     setupUseQuery({
       health: { data: { status: "healthy", checks: {} }, isLoading: false, isFetching: false },
       "admin-stats": {
-        data: { total_repositories: 1, total_artifacts: 1, total_users: 1, total_storage_bytes: 0 },
+        data: { total_repositories: 1, total_artifacts: 1, total_users: 1, total_storage_bytes: 0, proxy_artifact_count: 0, proxy_storage_bytes: 0 },
         isLoading: false,
         isFetching: false,
       },
@@ -411,7 +416,7 @@ describe("DashboardContent", () => {
     setupUseQuery({
       health: { data: { status: "healthy", checks: {} }, isLoading: false, isFetching: false },
       "admin-stats": {
-        data: { total_repositories: 1, total_artifacts: 1, total_users: 1, total_storage_bytes: 0 },
+        data: { total_repositories: 1, total_artifacts: 1, total_users: 1, total_storage_bytes: 0, proxy_artifact_count: 0, proxy_storage_bytes: 0 },
         isLoading: false,
         isFetching: false,
       },
@@ -430,7 +435,7 @@ describe("DashboardContent", () => {
     setupUseQuery({
       health: { data: { status: "healthy", checks: {} }, isLoading: false, isFetching: false },
       "admin-stats": {
-        data: { total_repositories: 1, total_artifacts: 1, total_users: 1, total_storage_bytes: 0 },
+        data: { total_repositories: 1, total_artifacts: 1, total_users: 1, total_storage_bytes: 0, proxy_artifact_count: 0, proxy_storage_bytes: 0 },
         isLoading: false,
         isFetching: false,
       },

--- a/src/app/(app)/_components/dashboard-content.tsx
+++ b/src/app/(app)/_components/dashboard-content.tsx
@@ -169,6 +169,25 @@ function RepoRow({ repo }: Readonly<{ repo: Repository }>) {
   );
 }
 
+// Local/remote breakdown shown on hover; the card total is local + remote.
+function StatBreakdown({
+  local,
+  remote,
+}: Readonly<{ local: string | number; remote: string | number }>) {
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between gap-6">
+        <span className="opacity-70">Local</span>
+        <span className="font-medium tabular-nums">{local}</span>
+      </div>
+      <div className="flex items-center justify-between gap-6">
+        <span className="opacity-70">Remote</span>
+        <span className="font-medium tabular-nums">{remote}</span>
+      </div>
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Severity breakdown for CVE trends
 // ---------------------------------------------------------------------------
@@ -376,8 +395,14 @@ export function DashboardContent() {
               <StatCard
                 icon={FileBox}
                 label="Artifacts"
-                value={stats.total_artifacts}
+                value={stats.total_artifacts + stats.proxy_artifact_count}
                 color="green"
+                tooltip={
+                  <StatBreakdown
+                    local={stats.total_artifacts}
+                    remote={stats.proxy_artifact_count}
+                  />
+                }
               />
               <StatCard
                 icon={Users}
@@ -388,8 +413,16 @@ export function DashboardContent() {
               <StatCard
                 icon={HardDrive}
                 label="Storage Used"
-                value={formatBytes(stats.total_storage_bytes)}
+                value={formatBytes(
+                  stats.total_storage_bytes + stats.proxy_storage_bytes
+                )}
                 color="yellow"
+                tooltip={
+                  <StatBreakdown
+                    local={formatBytes(stats.total_storage_bytes)}
+                    remote={formatBytes(stats.proxy_storage_bytes)}
+                  />
+                }
               />
             </div>
           )}

--- a/src/components/common/stat-card.tsx
+++ b/src/components/common/stat-card.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
 import { Card, CardContent } from "@/components/ui/card";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 interface StatCardProps {
@@ -12,6 +18,8 @@ interface StatCardProps {
   color?: "default" | "blue" | "green" | "yellow" | "red" | "purple";
   onClick?: () => void;
   className?: string;
+  /** Hover tooltip content. */
+  tooltip?: ReactNode;
 }
 
 const colorMap = {
@@ -40,8 +48,9 @@ export function StatCard({
   color = "default",
   onClick,
   className,
+  tooltip,
 }: StatCardProps) {
-  return (
+  const card = (
     <Card
       className={cn(
         "transition-all duration-200",
@@ -70,5 +79,14 @@ export function StatCard({
         </div>
       </CardContent>
     </Card>
+  );
+
+  if (!tooltip) return card;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{card}</TooltipTrigger>
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
   );
 }

--- a/src/lib/api/__tests__/admin.test.ts
+++ b/src/lib/api/__tests__/admin.test.ts
@@ -30,6 +30,8 @@ describe("adminApi", () => {
       active_peers: 0,
       pending_sync_tasks: 0,
       total_downloads: 0,
+      proxy_artifact_count: 2,
+      proxy_storage_bytes: 2048,
     };
     mockGetSystemStats.mockResolvedValue({ data: stats, error: undefined });
     const { adminApi } = await import("../admin");
@@ -39,7 +41,26 @@ describe("adminApi", () => {
       total_artifacts: 10,
       total_storage_bytes: 1024,
       total_users: 3,
+      proxy_artifact_count: 2,
+      proxy_storage_bytes: 2048,
     });
+  });
+
+  it("getStats defaults proxy_* to 0 on older backends", async () => {
+    const stats = {
+      total_repositories: 5,
+      total_artifacts: 10,
+      total_storage_bytes: 1024,
+      total_users: 3,
+      active_peers: 0,
+      pending_sync_tasks: 0,
+      total_downloads: 0,
+    };
+    mockGetSystemStats.mockResolvedValue({ data: stats, error: undefined });
+    const { adminApi } = await import("../admin");
+    const result = await adminApi.getStats();
+    expect(result.proxy_artifact_count).toBe(0);
+    expect(result.proxy_storage_bytes).toBe(0);
   });
 
   it("getStats throws on error", async () => {

--- a/src/lib/api/admin.ts
+++ b/src/lib/api/admin.ts
@@ -19,12 +19,20 @@ import { assertData } from '@/lib/api/fetch';
 import { unwrap } from '@/lib/sdk-utils';
 
 // SystemStats has a strict superset of AdminStats fields; pass through directly.
+// proxy_* are newer than the installed SDK types, so read them via cast and
+// default to 0 on older backends.
 function adaptStats(sdk: SystemStats): AdminStats {
+  const s = sdk as SystemStats & {
+    proxy_artifact_count?: number;
+    proxy_storage_bytes?: number;
+  };
   return {
     total_repositories: sdk.total_repositories,
     total_artifacts: sdk.total_artifacts,
     total_storage_bytes: sdk.total_storage_bytes,
     total_users: sdk.total_users,
+    proxy_artifact_count: s.proxy_artifact_count ?? 0,
+    proxy_storage_bytes: s.proxy_storage_bytes ?? 0,
   };
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -403,6 +403,10 @@ export interface AdminStats {
   total_artifacts: number;
   total_storage_bytes: number;
   total_users: number;
+  // Proxy-cached objects, counted separately from the totals above (they have
+  // no `artifacts` row). 0 on older backends.
+  proxy_artifact_count: number;
+  proxy_storage_bytes: number;
 }
 
 export interface ApiError {


### PR DESCRIPTION
## Summary
The Storage Used and Artifacts cards now show local + remote combined, with a hover tooltip splitting Local vs Remote. Reads the new `proxy_*` fields from the stats API via passthrough (until the SDK types land), defaulting to 0 on older backends.

Fixes #737
Depends on artifact-keeper/artifact-keeper#3087 (backend must merge first).

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [ ] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [x] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes