### PR TITLE
fix(repositories): show search matches from every page, not just the current one

### DIFF
--- a/src/app/(app)/repositories/_components/repositories-content.tsx
+++ b/src/app/(app)/repositories/_components/repositories-content.tsx
@@ -56,6 +56,9 @@ export function RepositoriesContent() {
   const [formatFilter, setFormatFilter] = useState("__all__");
   const [typeFilter, setTypeFilter] = useState("__all__");
   const [searchQuery, setSearchQuery] = useState("");
+  // Defer the search value so the backend list query (`q`) and artifact search
+  // don't refetch on every keystroke.
+  const deferredSearch = useDeferredValue(searchQuery);
 
   // pagination
   const [page, setPage] = useState(1);
@@ -86,6 +89,9 @@ export function RepositoriesContent() {
     page,
     format: formatFilter === "__all__" ? undefined : formatFilter,
     repo_type: typeFilter === "__all__" ? undefined : typeFilter,
+    // Server-side name/key search so matches on other pages are found, not just
+    // the ones already loaded on the current page (#pagination-search).
+    q: deferredSearch || undefined,
   });
 
   // Installed format handlers — drives the create dialog's custom WASM
@@ -195,9 +201,6 @@ export function RepositoriesContent() {
     setDeleteOpen(true);
   }, []);
 
-  // Debounce the search query for artifact search API calls
-  const deferredSearch = useDeferredValue(searchQuery);
-
   // Search artifacts via backend when query is non-empty
   const { data: artifactSearchResults } = useQuery({
     queryKey: ["repo-artifact-search", deferredSearch],
@@ -278,7 +281,7 @@ export function RepositoriesContent() {
             placeholder="Search..."
             className="pl-8 h-8 text-sm"
             value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
+            onChange={(e) => { setSearchQuery(e.target.value); setPage(1); }}
           />
         </div>
         <div className="flex gap-2">
@@ -385,7 +388,8 @@ export function RepositoriesContent() {
         )}
       </ScrollArea>
 
-      {/* Pagination */}
+      {/* Pagination — total_pages reflects the (searched) result set, so it
+          auto-hides when a filter narrows results to a single page. */}
       {totalPages > 1 && (
         <div className="border-t px-3 py-2 flex items-center justify-between text-xs text-muted-foreground">
           <span>

--- a/src/lib/api/repositories.ts
+++ b/src/lib/api/repositories.ts
@@ -38,6 +38,8 @@ export interface ListRepositoriesParams {
   per_page?: number;
   format?: string;
   repo_type?: string;
+  /** Server-side name/key search filter. */
+  q?: string;
 }
 
 export interface ReorderMemberInput {


### PR DESCRIPTION
## Summary
Repository search only filtered the repositories already loaded on the current page, so a name/key match on another page never showed up. This passes the query to the backend list endpoint (`q`) so the search runs server-side across all repositories. Because `total_pages` now reflects the filtered set, pagination auto-hides for a handful of matches and stays available when there are many.

Fixes #739

## Test Checklist
- [ ] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [ ] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [x] N/A - no UI changes