### PR TITLE
feat(migration): repo remapping, useful job labels, and correct completion totals

### DIFF
--- a/src/app/(app)/(admin)/migration/__tests__/page.test.tsx
+++ b/src/app/(app)/(admin)/migration/__tests__/page.test.tsx
@@ -1510,10 +1510,10 @@ describe("MigrationPage — feature parity (#520)", () => {
     await renderPage();
     await switchToJobsTab();
     await act(async () => fireEvent.click(screen.getByText("job-part...")));
-    // The report block renders; missing categories fall back to an em dash
+    // The report block renders; missing categories fall back to 0/0
     // instead of crashing the page.
     expect(screen.getByText("Reconciliation Report")).toBeInTheDocument();
-    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("0/0").length).toBeGreaterThanOrEqual(2);
   });
 
   it("renders a completed assessment job with a summary-only report (no category counts) without crashing", async () => {
@@ -1543,8 +1543,8 @@ describe("MigrationPage — feature parity (#520)", () => {
     await switchToJobsTab();
     await act(async () => fireEvent.click(screen.getByText("job-asmt...")));
     expect(screen.getByText("Reconciliation Report")).toBeInTheDocument();
-    // Both category tiles show the em-dash fallback; warnings/errors show 0.
-    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
+    // Both category tiles show the 0/0 fallback; warnings/errors show 0.
+    expect(screen.getAllByText("0/0").length).toBeGreaterThanOrEqual(2);
     expect(screen.getAllByText("0").length).toBeGreaterThanOrEqual(2);
   });
 

--- a/src/app/(app)/(admin)/migration/__tests__/page.test.tsx
+++ b/src/app/(app)/(admin)/migration/__tests__/page.test.tsx
@@ -1626,3 +1626,139 @@ describe("MigrationPage — feature parity (#520)", () => {
     expect(migrationApi.runAssessment).toHaveBeenCalledWith("job-asmt-0001");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Repo remapping on import + item path copy. Covers the rename UI in the
+// Create Migration dialog, the "source -> target" scope in the detail dialog,
+// and the click-to-copy source/target paths.
+// ---------------------------------------------------------------------------
+
+describe("MigrationPage — repo remapping and path copy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupMocks();
+  });
+  afterEach(() => cleanup());
+
+  async function switchToJobsTab() {
+    await act(async () => fireEvent.click(screen.getByTestId("tab-jobs")));
+  }
+
+  function openMigForm(): HTMLFormElement {
+    fireEvent.click(screen.getAllByText("Create Migration")[0]);
+    let migForm: HTMLFormElement | null = null;
+    document.querySelectorAll("form").forEach((f) => {
+      if (f.querySelector('[data-testid="select-item-conn-A"]')) {
+        migForm = f as HTMLFormElement;
+      }
+    });
+    expect(migForm).not.toBeNull();
+    return migForm!;
+  }
+
+  it("carries a repo rename through to createMigration and drops identity mappings", async () => {
+    configureQueries({
+      connections: { data: [makeConnection({ id: "conn-A", name: "AlphaConn" })] },
+      // Two repos so the include-list sort comparator runs.
+      sourceRepos: {
+        data: [
+          makeSourceRepo({ key: "libs-snapshot" }),
+          makeSourceRepo({ key: "libs-release" }),
+        ],
+      },
+    });
+    await renderPage();
+    await switchToJobsTab();
+    const migForm = openMigForm();
+    await act(async () =>
+      fireEvent.click(screen.getByTestId("select-item-conn-A")),
+    );
+    await act(async () => {
+      fireEvent.click(document.getElementById("include-repo-libs-release")!);
+      fireEvent.click(document.getElementById("include-repo-libs-snapshot")!);
+    });
+    // Real rename: set, clear (delete branch), then set again.
+    await act(async () => {
+      fireEvent.change(document.getElementById("rename-repo-libs-release")!, {
+        target: { value: "archive-release" },
+      });
+      fireEvent.change(document.getElementById("rename-repo-libs-release")!, {
+        target: { value: "" },
+      });
+      fireEvent.change(document.getElementById("rename-repo-libs-release")!, {
+        target: { value: "archive-release" },
+      });
+    });
+    // Identity rename (target == source) is dropped by the submit filter.
+    await act(async () => {
+      fireEvent.change(document.getElementById("rename-repo-libs-snapshot")!, {
+        target: { value: "libs-snapshot" },
+      });
+    });
+    await act(async () => fireEvent.submit(migForm));
+
+    const payload = capturedMutations.createMig.mutate.mock.calls[0][0] as {
+      config: { repo_mappings: Record<string, string>; include_repos: string[] };
+    };
+    expect(payload.config.repo_mappings).toEqual({
+      "libs-release": "archive-release",
+    });
+    expect([...payload.config.include_repos].sort()).toEqual([
+      "libs-release",
+      "libs-snapshot",
+    ]);
+  });
+
+  it("shows renamed and plain repos, sorted, in the detail dialog scope", async () => {
+    const job = makeJob({
+      id: "scopejob-0001",
+      status: "completed",
+      config: { include_repos: ["z-repo", "a-repo"], repo_mappings: { "a-repo": "archive-a" } },
+    });
+    configureQueries({
+      connections: { data: [makeConnection()] },
+      migrations: { data: { items: [job], pagination: {} } },
+      items: { data: { items: [], pagination: {} } },
+    });
+    await renderPage();
+    await switchToJobsTab();
+    await act(async () => fireEvent.click(screen.getByText("scopejob...")));
+    // Plain entry (no mapping) and renamed entry ("source -> target").
+    expect(screen.getByText("z-repo")).toBeInTheDocument();
+    expect(screen.getByText(/a-repo\s*→\s*archive-a/)).toBeInTheDocument();
+  });
+
+  it("copies source and target item paths from the detail dialog", async () => {
+    const writeText = vi.fn();
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    const job = makeJob({ id: "copyjob-0001", status: "running" });
+    const items = [
+      makeItem({ id: "i1", source_path: "src/a.jar", target_path: "dst/a.jar" }),
+    ];
+    configureQueries({
+      connections: { data: [makeConnection()] },
+      migrations: { data: { items: [job], pagination: {} } },
+      items: { data: { items, pagination: {} } },
+    });
+    await renderPage();
+    await switchToJobsTab();
+    await act(async () => fireEvent.click(screen.getByText("copyjob-...")));
+
+    const buttons = Array.from(document.querySelectorAll("button"));
+    const sBtn = buttons.find((b) => b.textContent?.includes("(S)"));
+    const tBtn = buttons.find((b) => b.textContent?.includes("(T)"));
+    expect(sBtn).toBeDefined();
+    expect(tBtn).toBeDefined();
+
+    await act(async () => fireEvent.click(sBtn!));
+    expect(writeText).toHaveBeenCalledWith("src/a.jar");
+    expect(toast.success).toHaveBeenCalledWith("Source path copied");
+
+    await act(async () => fireEvent.click(tBtn!));
+    expect(writeText).toHaveBeenCalledWith("dst/a.jar");
+    expect(toast.success).toHaveBeenCalledWith("Target path copied");
+  });
+});

--- a/src/app/(app)/(admin)/migration/page.tsx
+++ b/src/app/(app)/(admin)/migration/page.tsx
@@ -153,6 +153,7 @@ const DEFAULT_MIG_CONFIG: MigrationConfig = {
   include_repos: [],
   exclude_repos: [],
   exclude_paths: [],
+  repo_mappings: {},
   include_users: true,
   include_groups: true,
   include_permissions: true,
@@ -265,12 +266,28 @@ export default function MigrationPage() {
   function toggleIncludeRepo(key: string, on: boolean) {
     setMigConfig((c) => {
       const current = c.include_repos ?? [];
+      // Drop any rename when a repo leaves the allowlist — a mapping for a repo
+      // that isn't being migrated is meaningless (and is filtered on submit).
+      const mappings = { ...(c.repo_mappings ?? {}) };
+      if (!on) delete mappings[key];
       return {
         ...c,
         include_repos: on
           ? [...current, key]
           : current.filter((k) => k !== key),
+        repo_mappings: mappings,
       };
+    });
+  }
+
+  // Set (or clear, when target is blank) the destination key a source repo is
+  // renamed to on migration. Only repos in the include list can be remapped.
+  function setRepoMapping(source: string, target: string) {
+    setMigConfig((c) => {
+      const mappings = { ...(c.repo_mappings ?? {}) };
+      if (target.trim()) mappings[source] = target.trim();
+      else delete mappings[source];
+      return { ...c, repo_mappings: mappings };
     });
   }
 
@@ -500,6 +517,11 @@ export default function MigrationPage() {
     toast.success("Connection ID copied");
   };
 
+  const copyPath = (label: string, path: string) => {
+    void navigator.clipboard?.writeText(path);
+    toast.success(`${label} path copied`);
+  };
+
   // Fetch the reconciliation report as HTML and trigger a file download so
   // operators can archive it. Falls back to a toast on failure.
   const downloadReportHtml = async (jobId: string) => {
@@ -643,17 +665,36 @@ export default function MigrationPage() {
     {
       id: "id",
       header: "Job",
-      cell: (j) => (
-        <button
-          className="text-sm font-medium text-primary hover:underline"
-          onClick={(e) => {
-            e.stopPropagation();
-            setDetailJob(j);
-          }}
-        >
-          {j.id.slice(0, 8)}...
-        </button>
-      ),
+      cell: (j) => {
+        // Scope the row by its target repos so jobs are distinguishable at a
+        // glance; empty include_repos means the whole connection.
+        const repos = [...(j.config.include_repos ?? [])].sort((a, b) =>
+          a.localeCompare(b),
+        );
+        const others = repos.length - 1;
+        const scope =
+          repos.length === 0
+            ? "All repositories"
+            : repos.length === 1
+              ? repos[0]
+              : `${repos[0]} and ${others} other repo${others > 1 ? "s" : ""}`;
+        return (
+          <button
+            className="flex flex-col items-start text-left"
+            onClick={(e) => {
+              e.stopPropagation();
+              setDetailJob(j);
+            }}
+          >
+            <span className="text-sm font-medium text-primary hover:underline">
+              {scope}
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {j.id.slice(0, 8)}...
+            </span>
+          </button>
+        );
+      },
     },
     {
       id: "connection",
@@ -815,21 +856,71 @@ export default function MigrationPage() {
   // -- Item columns for detail dialog --
   const itemColumns: DataTableColumn<MigrationItem>[] = [
     {
-      id: "source_path",
-      header: "Source Path",
+      id: "path",
+      header: "Path",
       accessor: (i) => i.source_path,
-      cell: (i) => (
-        <code className="text-xs">{i.source_path}</code>
-      ),
-    },
-    {
-      id: "target_path",
-      header: "Target Path",
-      cell: (i) => (
-        <code className="text-xs text-muted-foreground">
-          {i.target_path ?? "-"}
-        </code>
-      ),
+      // Source over target in one column; (S)/(T) markers explain which is which
+      // on hover. Keeps the dialog from blowing out horizontally.
+      cell: (i) => {
+        const target = i.target_path;
+        return (
+          <div className="flex flex-col gap-0.5 text-xs w-[420px]">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  className="flex items-center gap-1 min-w-0 text-left cursor-pointer"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    copyPath("Source", i.source_path);
+                  }}
+                >
+                  <span className="text-muted-foreground shrink-0">(S)</span>
+                  <code className="truncate hover:underline">
+                    {i.source_path}
+                  </code>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-[min(90vw,720px)]">
+                <p>Source path (click to copy)</p>
+                <p className="font-mono text-[10px] break-all opacity-80">
+                  {i.source_path}
+                </p>
+              </TooltipContent>
+            </Tooltip>
+            {target ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    className="flex items-center gap-1 min-w-0 text-left cursor-pointer"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      copyPath("Target", target);
+                    }}
+                  >
+                    <span className="text-muted-foreground shrink-0">(T)</span>
+                    <code className="truncate hover:underline text-muted-foreground">
+                      {target}
+                    </code>
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-[min(90vw,720px)]">
+                  <p>Target path (click to copy)</p>
+                  <p className="font-mono text-[10px] break-all opacity-80">
+                    {target}
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+            ) : (
+              <span className="flex items-center gap-1 text-muted-foreground">
+                <span className="shrink-0">(T)</span>
+                <code>-</code>
+              </span>
+            )}
+          </div>
+        );
+      },
     },
     {
       id: "type",
@@ -1169,10 +1260,19 @@ export default function MigrationPage() {
             className="space-y-4"
             onSubmit={(e) => {
               e.preventDefault();
+              // Keep only real renames: target set, differs from source, and the
+              // source is actually being migrated. Identity/orphan entries are dropped.
+              const includeSet = new Set(migConfig.include_repos ?? []);
+              const repo_mappings = Object.fromEntries(
+                Object.entries(migConfig.repo_mappings ?? {}).filter(
+                  ([src, tgt]) => tgt && tgt !== src && includeSet.has(src),
+                ),
+              );
               const config: MigrationConfig = {
                 ...migConfig,
                 exclude_repos: parseList(excludeReposText),
                 exclude_paths: parseList(excludePathsText),
+                repo_mappings,
               };
               // date_from/date_to only apply to incremental migrations; the
               // backend accepts them as RFC3339 timestamps.
@@ -1236,19 +1336,44 @@ export default function MigrationPage() {
               <Label>Include Repositories</Label>
               <p className="text-xs text-muted-foreground">
                 Leave all unchecked to migrate every repository. Select a
-                connection to load its repositories.
+                connection to load its repositories. Optionally rename a
+                repository as it migrates.
               </p>
               {migForm.source_connection_id && sourceRepos.length > 0 ? (
                 <div className="max-h-40 overflow-y-auto rounded-md border p-2 space-y-1">
-                  {sourceRepos.map((repo) => (
-                    <BoolField
-                      key={repo.key}
-                      id={`include-repo-${repo.key}`}
-                      label={`${repo.key} (${repo.package_type})`}
-                      checked={(migConfig.include_repos ?? []).includes(repo.key)}
-                      onChange={(on) => toggleIncludeRepo(repo.key, on)}
-                    />
-                  ))}
+                  {[...sourceRepos]
+                    .sort((a, b) => a.key.localeCompare(b.key))
+                    .map((repo) => {
+                      const included = (migConfig.include_repos ?? []).includes(
+                        repo.key,
+                      );
+                      return (
+                        <div key={repo.key} className="space-y-1">
+                          <BoolField
+                            id={`include-repo-${repo.key}`}
+                            label={`${repo.key} (${repo.package_type})`}
+                            checked={included}
+                            onChange={(on) => toggleIncludeRepo(repo.key, on)}
+                          />
+                          {included && (
+                            <div className="ml-6 flex items-center gap-2">
+                              <span className="text-xs text-muted-foreground shrink-0">
+                                rename to
+                              </span>
+                              <Input
+                                id={`rename-repo-${repo.key}`}
+                                className="h-7 text-xs"
+                                placeholder={repo.key}
+                                value={migConfig.repo_mappings?.[repo.key] ?? ""}
+                                onChange={(e) =>
+                                  setRepoMapping(repo.key, e.target.value)
+                                }
+                              />
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })}
                 </div>
               ) : (
                 <p className="text-xs text-muted-foreground italic">
@@ -1500,6 +1625,48 @@ export default function MigrationPage() {
                 value={detailJob.progress_percent ?? 0}
                 className="h-2"
               />
+              {/* Repositories this job handles (empty = whole connection). */}
+              <div>
+                <p className="text-xs text-muted-foreground mb-1.5">
+                  Repositories
+                </p>
+                {(detailJob.config.include_repos?.length ?? 0) === 0 ? (
+                  <p className="text-sm">All repositories on the connection</p>
+                ) : (
+                  <div className="flex flex-wrap gap-1.5">
+                    {[...detailJob.config.include_repos!]
+                      .sort((a, b) => a.localeCompare(b))
+                      .map((r) => {
+                        // include_repos holds source (Nexus) keys; a mapping means
+                        // this repo is renamed on migration. Renamed → show
+                        // "source → target" with a hover; otherwise show it plain.
+                        const renamedTo = detailJob.config.repo_mappings?.[r];
+                        if (!renamedTo) {
+                          return (
+                            <code
+                              key={r}
+                              className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs"
+                            >
+                              {r}
+                            </code>
+                          );
+                        }
+                        return (
+                          <Tooltip key={r}>
+                            <TooltipTrigger asChild>
+                              <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">
+                                {r} → {renamedTo}
+                              </code>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              Renamed to {renamedTo}
+                            </TooltipContent>
+                          </Tooltip>
+                        );
+                      })}
+                  </div>
+                )}
+              </div>
               {detailJob.error_summary && (
                 <div className="text-sm text-red-500 rounded-md border border-red-200 bg-red-50 p-3 dark:bg-red-950/20 dark:border-red-800">
                   {detailJob.error_summary}

--- a/src/app/(app)/(admin)/migration/page.tsx
+++ b/src/app/(app)/(admin)/migration/page.tsx
@@ -133,14 +133,39 @@ const TERMINAL_STATUSES: ReadonlySet<MigrationJobStatus> = new Set([
   "cancelled",
 ]);
 
+// A completed job is 100% by definition; the item-count ratio the backend
+// returns can lag (e.g. a job with nothing to transfer reports 0). Other
+// statuses keep their real, rounded progress.
+function jobProgress(job: MigrationJob): number {
+  if (job.status === "completed") return 100;
+  return Math.round(job.progress_percent ?? 0);
+}
+
+// Denominator for the items ratio. The backend leaves total_items at 0 on some
+// jobs (it doesn't always pre-count), which renders as "102/0"; fall back to
+// what was actually processed so the ratio makes sense.
+function effectiveTotal(job: MigrationJob): number {
+  const processed =
+    job.completed_items + job.failed_items + job.skipped_items;
+  return Math.max(job.total_items, processed);
+}
+
+// Same story for bytes: total_bytes can be 0 while bytes were transferred.
+function effectiveTotalBytes(job: MigrationJob): number {
+  return Math.max(job.total_bytes, job.transferred_bytes);
+}
+
 // The reconciliation report's per-category summary (artifacts/repositories/...)
 // is only present when the job migrated at least one item of that type, so a
 // category can be absent on completed jobs (assessment runs, or a full job that
 // touched no artifacts). Render "migrated/total" defensively: an absent summary
 // shows "—" and a partial one falls back to 0 instead of crashing the whole
 // admin page with a TypeError (artifact-keeper#2455).
+// The backend omits a category from the report summary when the job migrated
+// nothing of that type (e.g. an artifacts-only job has no repositories key), so
+// show 0/0 rather than a bare em-dash, which reads as broken.
 function formatItemCount(summary: ItemSummary | undefined): string {
-  if (!summary) return "—";
+  if (!summary) return "0/0";
   return `${summary.migrated ?? 0}/${summary.total ?? 0}`;
 }
 
@@ -730,11 +755,11 @@ export default function MigrationPage() {
       cell: (j) => (
         <div className="flex items-center gap-2 min-w-[120px]">
           <Progress
-            value={j.progress_percent ?? 0}
+            value={jobProgress(j)}
             className="flex-1 h-1.5"
           />
           <span className="text-xs text-muted-foreground w-10 text-right">
-            {j.progress_percent ?? 0}%
+            {jobProgress(j)}%
           </span>
         </div>
       ),
@@ -744,7 +769,7 @@ export default function MigrationPage() {
       header: "Items",
       cell: (j) => (
         <span className="text-sm text-muted-foreground">
-          {j.completed_items}/{j.total_items}
+          {j.completed_items}/{effectiveTotal(j)}
           {j.failed_items > 0 && (
             <span className="text-red-500 ml-1">
               ({j.failed_items} failed)
@@ -1605,24 +1630,24 @@ export default function MigrationPage() {
                 <div>
                   <p className="text-xs text-muted-foreground">Progress</p>
                   <p className="font-semibold">
-                    {detailJob.progress_percent ?? 0}%
+                    {jobProgress(detailJob)}%
                   </p>
                 </div>
                 <div>
                   <p className="text-xs text-muted-foreground">Items</p>
                   <p className="font-semibold">
-                    {detailJob.completed_items}/{detailJob.total_items}
+                    {detailJob.completed_items}/{effectiveTotal(detailJob)}
                   </p>
                 </div>
                 <div>
                   <p className="text-xs text-muted-foreground">Transferred</p>
                   <p className="font-semibold">
-                    {formatBytes(detailJob.transferred_bytes)}/{formatBytes(detailJob.total_bytes)}
+                    {formatBytes(detailJob.transferred_bytes)}/{formatBytes(effectiveTotalBytes(detailJob))}
                   </p>
                 </div>
               </div>
               <Progress
-                value={detailJob.progress_percent ?? 0}
+                value={jobProgress(detailJob)}
                 className="h-2"
               />
               {/* Repositories this job handles (empty = whole connection). */}

--- a/src/types/migration.ts
+++ b/src/types/migration.ts
@@ -76,6 +76,10 @@ export interface MigrationConfig {
   include_repos?: string[];
   exclude_repos?: string[];
   exclude_paths?: string[];
+  // Source repo key -> destination repo key rename map. Migrated artifacts land
+  // in the destination repo instead of one named after the source (backend
+  // `MigrationConfig.repo_mappings`). Sources not listed keep their name.
+  repo_mappings?: Record<string, string>;
   include_users?: boolean;
   include_groups?: boolean;
   include_permissions?: boolean;


### PR DESCRIPTION
Fixes #742

> [!IMPORTANT]
> **Depends on backend artifact-keeper/artifact-keeper#3038 (must merge first).** This PR sends the `repo_mappings` that backend #3038 consumes on import. Until that backend PR and a regenerated SDK ship, the remapping fields are read via the SDK passthrough and the UI degrades gracefully, so this can merge without breaking the current build.

## Summary
Three related improvements to the admin migration page:

1. **Repo remapping on import** — admins can rename repositories during a migration import and see each job's repo scope. This is the UI for the backend `repo_mappings` feature (artifact-keeper/artifact-keeper#3038).
2. **Useful job labels** — migration job rows showed the raw job UUID; they now show the repository name/scope so a running migration is legible.
3. **Correct completion totals** — completed jobs now settle at 100% with correct effective item counts instead of a stuck sub-100% bar.

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

Migration Vitest suite passes (44/44); `tsc --noEmit` clean for the changed files; `npm run lint` passes (pre-existing warnings only, unchanged by this PR).

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [x] N/A - covered by existing migration page layout/tests