### PR TITLE
fix(setup): give Pub repositories Dart-specific setup snippets

### DIFF
--- a/src/app/(app)/setup/page.test.tsx
+++ b/src/app/(app)/setup/page.test.tsx
@@ -572,3 +572,27 @@ describe("SetupPage - Generic download snippet uses /download/ path (#408)", () 
     );
   });
 });
+
+describe("SetupPage - Pub repos show Dart tooling, not the generic fallback (#747)", () => {
+  beforeEach(() => mockUseQuery.mockReset());
+  afterEach(() => cleanup());
+
+  it("shows PUB_HOSTED_URL and dart pub commands instead of a generic curl upload", async () => {
+    // Pub has no case in getSetupSnippets, so it falls through to the
+    // generic default: a `curl -X PUT ... /api/v1/repositories/<key>/artifacts/`
+    // snippet. That path is not how a Dart client talks to a Pub registry —
+    // `dart pub` is driven by the PUB_HOSTED_URL environment variable.
+    await openRepoDialog(makeRepo({ format: "pub", key: "my-pub" }));
+
+    const dialog = await screen.findByRole("dialog");
+    const text = dialog.textContent ?? "";
+
+    // Must point the Dart client at this repository.
+    expect(text).toContain("PUB_HOSTED_URL");
+    expect(text).toContain("/pub/my-pub");
+    // Must use the real client, not a raw upload.
+    expect(text).toContain("dart pub");
+    // Must not hand users the generic artifact-upload command.
+    expect(text).not.toMatch(/curl -X PUT/);
+  });
+});

--- a/src/components/setup/repo-setup-guide.tsx
+++ b/src/components/setup/repo-setup-guide.tsx
@@ -584,6 +584,35 @@ helm repo update`,
           code: `dotnet add package MyPackage --source ${repoKey}`,
         },
       ];
+    case "pub":
+      return [
+        {
+          title: "Point the Dart client at this repository",
+          description:
+            "dart and flutter read the registry location from PUB_HOSTED_URL:",
+          code: `export PUB_HOSTED_URL=${REGISTRY_URL}/pub/${repoKey}`,
+        },
+        {
+          title: "Authenticate",
+          code: `dart pub token add ${REGISTRY_URL}/pub/${repoKey}`,
+        },
+        {
+          title: "Add a dependency",
+          description: "In pubspec.yaml:",
+          code: `dependencies:
+  my_package:
+    hosted: ${REGISTRY_URL}/pub/${repoKey}
+    version: ^1.0.0`,
+        },
+        {
+          title: "Resolve dependencies",
+          code: `dart pub get   # or: flutter pub get`,
+        },
+        {
+          title: "Publish a package",
+          code: `dart pub publish`,
+        },
+      ];
     case "go":
       return [
         {


### PR DESCRIPTION
## Summary

Fixes #747.

`getSetupSnippets` had no `case "pub"`, so a Pub (Dart/Flutter) repository fell through to the `default:` branch and showed users a generic `curl -X PUT` upload against `/api/v1/repositories/<key>/artifacts/`. Dart clients do not work that way: `dart` and `flutter` resolve packages through `PUB_HOSTED_URL`, and the backend serves the Pub protocol at `/pub/<repo_key>` (`backend/src/api/routes.rs:75`). `PUB_HOSTED_URL` did not appear anywhere in this repository before this change.

This adds a Pub case with five steps, following the shape of the existing `go` and `cargo` cases:

1. `export PUB_HOSTED_URL=<registry>/pub/<key>`
2. `dart pub token add <registry>/pub/<key>`
3. A `hosted:` dependency block for `pubspec.yaml`
4. `dart pub get` / `flutter pub get`
5. `dart pub publish`

No other formats are touched, and the `default:` branch is unchanged for the formats that legitimately use it.

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [ ] Manually tested locally
- [x] No regressions in existing tests

Added a regression test in `src/app/(app)/setup/page.test.tsx`, in the style of the existing `#408` test. It asserts the dialog contains `PUB_HOSTED_URL`, the `/pub/<key>` path and `dart pub`, and that it no longer renders `curl -X PUT`.

Verified it fails before the fix and passes after:

```
# before
AssertionError: expected 'Set Up: my-pubpubConfigure your tools…' to contain 'PUB_HOSTED_URL'

# after
Test Files  1 passed (1)
     Tests  42 passed (42)
```

Two notes on the boxes I left unchecked, so a reviewer does not have to guess:

- **Manually tested locally** — not checked. I verified this at the unit-test level only; I did not run the dev server and click through the dialog, and I did not run a real `dart pub` client against the rendered commands. The command content is derived from the backend's Pub routes rather than from an observed successful client session.
- **E2E Playwright** — not checked. Happy to add a spec if you would like this covered there; I did not want to assume the E2E surface should grow for a snippet change.

`npm test` on this branch reports 7 pre-existing failures in `src/lib/__tests__/cache-time.test.ts` and `src/app/(app)/repositories/_components/repo-settings-tab.test.tsx`. They reproduce identically with this branch's changes stashed, so they are unrelated to this PR. Likewise `npx tsc --noEmit` reports pre-existing errors in `security/blast-radius/__tests__/page.test.tsx`, untouched here. `npm run lint` reports 0 errors and no new warnings.

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [x] N/A - no UI changes

The change is snippet content rendered by the existing step component; no layout, styling or markup structure changes.
