### PR TITLE
ci(codeql): pin init to v4.37.6 to match analyze (#730 follow-up)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,3 +42,10 @@ updates:
       - "ci"
     commit-message:
       prefix: "chore"
+    groups:
+      # codeql-action/init and codeql-action/analyze must move in lockstep —
+      # a version skew fails every run ("Loaded a configuration file for
+      # version X, but running version Y"). See #753.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,7 +67,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}


### PR DESCRIPTION
## Summary
- #730 bumped `github/codeql-action/analyze` 4.36.0 → 4.37.6 but `init` stayed pinned at v4.36.0
- Every CodeQL run since fails in the analyze post-action: `Loaded a configuration file for version '4.36.0', but running version '4.37.6'`
- Pins `init` to the same v4.37.6 commit (`5595ccaf`) so the pair moves in lockstep
- Adds a `codeql-action` group to dependabot.yml so future bumps keep init/analyze/autobuild in one PR

Unblocks CodeQL on #748 and all future PRs.