### PR TITLE
test(e2e): Playwright coverage for the 1.8.x feature batch (#738/#740/#743/#744/#746/#748)

### DIFF
--- a/e2e/setup/seed-data.ts
+++ b/e2e/setup/seed-data.ts
@@ -42,6 +42,9 @@ export async function seedRepositories(request: APIRequestContext): Promise<void
     // Visibility test repos: one public, one private (default)
     { key: 'e2e-public-pypi', name: 'E2E Public PyPI', format: 'pypi', repo_type: 'local', is_public: true },
     { key: 'e2e-private-pypi', name: 'E2E Private PyPI', format: 'pypi', repo_type: 'local', is_public: false },
+    // Pub (Dart) repo so the Dart-specific setup-guide snippets (#748) have a
+    // real target in the repo detail Setup tab.
+    { key: 'e2e-pub-local', name: 'E2E Pub Local', format: 'pub', repo_type: 'local' },
     // Generic repo opted into first-class versioning (#571) so the
     // version-history UI has real revisions to exercise. Harmless on a
     // backend that predates the flag (the field is simply ignored).

--- a/e2e/suites/interactions/dashboard/dashboard-stats.spec.ts
+++ b/e2e/suites/interactions/dashboard/dashboard-stats.spec.ts
@@ -1,0 +1,144 @@
+import {
+  test,
+  expect,
+  filterCriticalErrors,
+  navigateTo,
+} from '../../../fixtures/test-fixtures';
+import type { Page, Locator } from '@playwright/test';
+
+/**
+ * Dashboard Statistics cards (PR #738):
+ * "Storage Used" and "Artifacts" show local + remote (proxy cache) combined
+ * totals, with a hover tooltip breaking down Local vs Remote. Proxy values
+ * come from admin-stats fields `proxy_artifact_count` / `proxy_storage_bytes`
+ * and default to 0 on older backends.
+ */
+
+/** The "Statistics" section of the dashboard (admin only). */
+function statsSection(page: Page): Locator {
+  return page
+    .locator('section')
+    .filter({ has: page.getByRole('heading', { name: 'Statistics' }) });
+}
+
+/** A stat card within the Statistics section, located by its exact label. */
+function statCard(page: Page, label: string): Locator {
+  // Cards with a hover tooltip (Artifacts, Storage Used) are wrapped in a
+  // Radix TooltipTrigger whose `asChild` Slot overrides the Card's
+  // `data-slot="card"` with `data-slot="tooltip-trigger"` — match both.
+  return statsSection(page)
+    .locator('[data-slot="card"], [data-slot="tooltip-trigger"]')
+    .filter({ has: page.getByText(label, { exact: true }) });
+}
+
+/** The numeric value paragraph of a stat card. */
+function cardValue(card: Locator): Locator {
+  return card.locator('p.text-2xl');
+}
+
+/** Mirror of src/lib/utils.ts formatBytes for the units we can encounter. */
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return '--';
+  if (bytes === 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const k = 1024;
+  const i = Math.max(
+    0,
+    Math.min(Math.floor(Math.log(bytes) / Math.log(k)), units.length - 1)
+  );
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${units[i]}`;
+}
+
+test.describe('Dashboard Statistics cards', () => {
+  test('Statistics section renders with combined-total stat cards', async ({
+    page,
+  }) => {
+    await navigateTo(page, '/');
+
+    const section = statsSection(page);
+    await expect(
+      page.getByRole('heading', { name: 'Statistics' })
+    ).toBeVisible({ timeout: 10000 });
+
+    // All four stat cards render once admin-stats loads.
+    for (const label of ['Repositories', 'Artifacts', 'Users', 'Storage Used']) {
+      await expect(statCard(page, label)).toBeVisible({ timeout: 10000 });
+    }
+
+    // Artifacts shows a plain count.
+    await expect(cardValue(statCard(page, 'Artifacts'))).toHaveText(/^\d+$/);
+
+    // Storage Used shows a formatted byte size (e.g. "0 B", "1.5 MB").
+    await expect(cardValue(statCard(page, 'Storage Used'))).toHaveText(
+      /^\d+(\.\d+)?\s(B|KB|MB|GB|TB)$/
+    );
+    await expect(section).toBeVisible();
+  });
+
+  test('cards show combined local + remote totals from admin-stats', async ({
+    page,
+    adminApi,
+  }) => {
+    const response = await adminApi.get('/admin/stats');
+    expect(response.ok()).toBeTruthy();
+    const stats = await response.json();
+
+    // Proxy fields are absent on older backends; the UI defaults them to 0.
+    const expectedArtifacts =
+      stats.total_artifacts + (stats.proxy_artifact_count ?? 0);
+    const expectedStorage = formatBytes(
+      stats.total_storage_bytes + (stats.proxy_storage_bytes ?? 0)
+    );
+
+    await navigateTo(page, '/');
+
+    await expect(cardValue(statCard(page, 'Artifacts'))).toHaveText(
+      String(expectedArtifacts),
+      { timeout: 10000 }
+    );
+    await expect(cardValue(statCard(page, 'Storage Used'))).toHaveText(
+      expectedStorage,
+      { timeout: 10000 }
+    );
+  });
+
+  test('hover shows Local/Remote breakdown tooltip on combined cards', async ({
+    page,
+  }) => {
+    await navigateTo(page, '/');
+
+    const tooltip = page.getByRole('tooltip');
+
+    for (const label of ['Artifacts', 'Storage Used']) {
+      const card = statCard(page, label);
+      await expect(card).toBeVisible({ timeout: 10000 });
+      await card.hover();
+
+      // The tooltip always renders for these cards (StatBreakdown is passed
+      // unconditionally); on a fresh seeded backend Remote is 0.
+      await expect(tooltip).toBeVisible({ timeout: 10000 });
+      await expect(tooltip).toContainText('Local');
+      await expect(tooltip).toContainText('Remote');
+
+      // Move off the card so the tooltip closes before hovering the next one.
+      // (A single-jump mouse.move doesn't trigger Radix's pointer-leave
+      // handling reliably — step the pointer out instead.)
+      await page.mouse.move(0, 0, { steps: 20 });
+      await expect(tooltip).toBeHidden({ timeout: 10000 });
+    }
+  });
+
+  test('dashboard loads without console errors', async ({
+    page,
+    consoleErrors,
+  }) => {
+    await navigateTo(page, '/');
+    await expect(
+      page.getByRole('heading', { name: 'Statistics' })
+    ).toBeVisible({ timeout: 10000 });
+    // Give late-loading queries a chance to surface errors.
+    await page.waitForTimeout(1000);
+
+    expect(filterCriticalErrors(consoleErrors)).toEqual([]);
+  });
+});

--- a/e2e/suites/interactions/operations/migration.spec.ts
+++ b/e2e/suites/interactions/operations/migration.spec.ts
@@ -1,0 +1,191 @@
+import {
+  test,
+  expect,
+  filterCriticalErrors,
+  navigateTo,
+} from '../../../fixtures/test-fixtures';
+
+/**
+ * Migration UI overhaul (PR #743): job rows are labelled by their repository
+ * scope ("All repositories" or "repo and N other repos") with a truncated job
+ * id subtitle, the Create Migration dialog offers per-repo "rename to" mapping
+ * inputs, and completion totals render defensively (completed/effective-total).
+ *
+ * A source connection is seeded via the API (offline-safe: creation stores the
+ * record without contacting the source). Migration jobs are created as
+ * assessment jobs directly via the API — they never reach a real source — and
+ * deleted afterwards. The source-repositories endpoint does contact the source
+ * registry, so it is route-intercepted for the rename-inputs test (precedent:
+ * admin/migration-config.spec.ts).
+ */
+
+const RUN_ID = `e2e-mig743-${Date.now().toString(36)}`;
+
+/** Seed a source connection; returns its id. */
+async function seedConnection(
+  adminApi: { post: (p: string, d?: unknown) => Promise<{ ok(): boolean; json(): Promise<{ id: string }> }> },
+  name: string
+): Promise<string> {
+  const resp = await adminApi.post('/migrations/connections', {
+    name,
+    url: 'https://artifactory.e2e.example.com',
+    auth_type: 'api_token',
+    source_type: 'artifactory',
+    credentials: { token: 'e2e-token' },
+  });
+  expect(resp.ok()).toBeTruthy();
+  return (await resp.json()).id;
+}
+
+test.describe('Migration page (#743)', () => {
+  test('job list shows scope labels, truncated id, and completion totals', async ({
+    page,
+    adminApi,
+  }) => {
+    const connectionId = await seedConnection(adminApi, `${RUN_ID}-list`);
+    const jobIds: string[] = [];
+    try {
+      // Unscoped job -> "All repositories" row label.
+      const unscoped = await adminApi.post('/migrations', {
+        source_connection_id: connectionId,
+        job_type: 'assessment',
+        config: { include_repos: [] },
+      });
+      expect(unscoped.ok()).toBeTruthy();
+      jobIds.push((await unscoped.json()).id);
+
+      // Scoped job -> "alpha-repo and 1 other repo" row label.
+      const scoped = await adminApi.post('/migrations', {
+        source_connection_id: connectionId,
+        job_type: 'assessment',
+        config: { include_repos: ['alpha-repo', 'beta-repo'] },
+      });
+      expect(scoped.ok()).toBeTruthy();
+      jobIds.push((await scoped.json()).id);
+
+      await navigateTo(page, '/migration');
+      await page
+        .getByRole('tablist')
+        .getByRole('tab', { name: /migration jobs/i })
+        .click();
+
+      // Scope labels distinguish the two jobs at a glance.
+      await expect(
+        page.getByRole('button', { name: /All repositories/ })
+      ).toBeVisible({ timeout: 10000 });
+      await expect(
+        page.getByRole('button', { name: /alpha-repo and 1 other repo/ })
+      ).toBeVisible({ timeout: 10000 });
+
+      // Truncated job id subtitle under each scope label.
+      await expect(
+        page.getByText(/^[0-9a-f]{8}\.\.\.$/).first()
+      ).toBeVisible();
+
+      // Completion totals render as completed/total per row.
+      const rows = page.getByRole('row');
+      await expect(
+        rows.filter({ hasText: 'All repositories' })
+      ).toContainText(/\d+\/\d+/);
+      await expect(
+        rows.filter({ hasText: 'alpha-repo and 1 other repo' })
+      ).toContainText(/\d+\/\d+/);
+    } finally {
+      for (const id of jobIds) {
+        await adminApi.delete(`/migrations/${id}`).catch(() => {});
+      }
+      await adminApi
+        .delete(`/migrations/connections/${connectionId}`)
+        .catch(() => {});
+    }
+  });
+
+  test('create dialog shows per-repo "rename to" mapping inputs', async ({
+    page,
+    adminApi,
+  }) => {
+    const connectionName = `${RUN_ID}-dialog`;
+    const connectionId = await seedConnection(adminApi, connectionName);
+    try {
+      // The backend resolves source repos by contacting the source registry,
+      // which is unreachable in e2e — stub the listing instead.
+      await page.route(
+        '**/api/v1/migrations/connections/*/repositories',
+        (route) =>
+          route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify([
+              { key: 'alpha-repo', package_type: 'maven' },
+              { key: 'beta-repo', package_type: 'npm' },
+            ]),
+          })
+      );
+
+      await navigateTo(page, '/migration');
+      await page
+        .getByRole('tablist')
+        .getByRole('tab', { name: /migration jobs/i })
+        .click();
+      await page
+        .getByRole('button', { name: /create migration/i })
+        .first()
+        .click();
+      const dialog = page.getByRole('dialog');
+      await expect(dialog).toBeVisible({ timeout: 10000 });
+
+      // Pick the seeded connection so its repositories load.
+      await dialog.getByRole('combobox').first().click();
+      await page
+        .getByRole('option', { name: connectionName })
+        .click();
+
+      // Both stubbed repos are offered for inclusion.
+      const alphaInclude = dialog.locator('#include-repo-alpha-repo');
+      const betaInclude = dialog.locator('#include-repo-beta-repo');
+      await expect(alphaInclude).toBeVisible({ timeout: 10000 });
+      await expect(betaInclude).toBeVisible();
+
+      // No rename inputs until a repo is included.
+      await expect(dialog.locator('#rename-repo-alpha-repo')).toHaveCount(0);
+      await expect(dialog.locator('#rename-repo-beta-repo')).toHaveCount(0);
+
+      // Including a repo reveals its "rename to" mapping input.
+      await alphaInclude.check();
+      const renameInput = dialog.locator('#rename-repo-alpha-repo');
+      await expect(renameInput).toBeVisible();
+      await expect(dialog.getByText('rename to')).toBeVisible();
+      await expect(renameInput).toHaveAttribute('placeholder', 'alpha-repo');
+      await renameInput.fill('alpha-renamed');
+      await expect(renameInput).toHaveValue('alpha-renamed');
+
+      // Excluded repos still have no rename input.
+      await expect(dialog.locator('#rename-repo-beta-repo')).toHaveCount(0);
+
+      // Un-hiding toggles back off.
+      await alphaInclude.uncheck();
+      await expect(dialog.locator('#rename-repo-alpha-repo')).toHaveCount(0);
+
+      await dialog.getByRole('button', { name: /cancel/i }).click();
+      await expect(dialog).toBeHidden({ timeout: 10000 });
+    } finally {
+      await page.unroute('**/api/v1/migrations/connections/*/repositories');
+      await adminApi
+        .delete(`/migrations/connections/${connectionId}`)
+        .catch(() => {});
+    }
+  });
+
+  test('migration page loads without console errors', async ({
+    page,
+    consoleErrors,
+  }) => {
+    await navigateTo(page, '/migration');
+    await expect(
+      page.getByRole('heading', { name: /migration/i })
+    ).toBeVisible({ timeout: 10000 });
+    await page.waitForTimeout(1000);
+
+    expect(filterCriticalErrors(consoleErrors)).toEqual([]);
+  });
+});

--- a/e2e/suites/interactions/repositories/repo-create-npm.spec.ts
+++ b/e2e/suites/interactions/repositories/repo-create-npm.spec.ts
@@ -1,0 +1,126 @@
+import {
+  test,
+  expect,
+  filterCriticalErrors,
+  navigateTo,
+} from '../../../fixtures/test-fixtures';
+import type { Page } from '@playwright/test';
+
+/**
+ * npm scope-policy gating in the create-repository dialog (PR #746, backend
+ * #2424): the policy lives on npm **remote** (proxy) repos only — the backend
+ * rejects it for any other type — so the dialog only shows the scope-policy
+ * fields for npm+remote, and creating an npm **virtual** repo must not send
+ * the policy (the original bug made every npm virtual create fail).
+ */
+
+/** Open the create dialog and pick a format + repo type. */
+async function openCreateDialog(page: Page, format: string, type: string) {
+  await navigateTo(page, '/repositories');
+  await page
+    .getByRole('button', { name: /create repository/i })
+    .first()
+    .click();
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible({ timeout: 10000 });
+
+  // First combobox = Format, second = Type.
+  await dialog.getByRole('combobox').nth(0).click();
+  await page.getByRole('option', { name: format, exact: true }).click();
+  await dialog.getByRole('combobox').nth(1).click();
+  await page.getByRole('option', { name: type, exact: true }).click();
+  return dialog;
+}
+
+test.describe('Create npm repository (#746)', () => {
+  test('npm virtual does not show scope-policy fields', async ({ page }) => {
+    const dialog = await openCreateDialog(page, 'NPM', 'Virtual');
+
+    await expect(dialog.getByText('npm Scope Policy')).toHaveCount(0);
+    await expect(dialog.getByLabel('Allowed scopes')).toHaveCount(0);
+    await expect(dialog.getByLabel('Allowed name patterns')).toHaveCount(0);
+    await expect(dialog.getByLabel('Allow unscoped names')).toHaveCount(0);
+
+    await dialog.getByRole('button', { name: /cancel/i }).click();
+    await expect(dialog).toBeHidden({ timeout: 10000 });
+  });
+
+  test('npm remote shows scope-policy fields', async ({ page }) => {
+    const dialog = await openCreateDialog(page, 'NPM', 'Remote');
+
+    await expect(dialog.getByText('npm Scope Policy')).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(dialog.getByLabel('Allowed scopes')).toBeVisible();
+    await expect(dialog.getByLabel('Allowed name patterns')).toBeVisible();
+    await expect(dialog.getByLabel('Allow unscoped names')).toBeVisible();
+
+    await dialog.getByRole('button', { name: /cancel/i }).click();
+    await expect(dialog).toBeHidden({ timeout: 10000 });
+  });
+
+  test('creating an npm virtual repository succeeds', async ({
+    page,
+    adminApi,
+  }) => {
+    const key = `e2e-npm-virt-${Date.now().toString(36)}`;
+    try {
+      const dialog = await openCreateDialog(page, 'NPM', 'Virtual');
+      await dialog.locator('#create-key').fill(key);
+      await dialog.locator('#create-name').fill('E2E NPM Virtual');
+
+      // Virtual repos need at least one member (backend #1279/#1444 rejects an
+      // explicit empty member_repos) — aggregate the seeded npm remote repo.
+      await dialog
+        .getByRole('checkbox', { name: /E2E NPM Remote/ })
+        .check();
+
+      // Capture the create payload: it must not carry any npm scope-policy
+      // fields (the #746 bug — the backend rejects the policy on non-remote
+      // repos, which used to make every npm virtual create fail).
+      const createRequest = page.waitForRequest(
+        (req) =>
+          req.url().includes('/api/v1/repositories') && req.method() === 'POST',
+        { timeout: 15000 }
+      );
+      await dialog.getByRole('button', { name: 'Create', exact: true }).click();
+      const payload = createRequest.then((r) => r.postDataJSON());
+
+      // The backend accepts the payload and the dialog closes with a toast.
+      await expect(dialog).toBeHidden({ timeout: 15000 });
+      await expect(page.getByText('Repository created')).toBeVisible({
+        timeout: 10000,
+      });
+
+      const body = await payload;
+      expect(body.format).toBe('npm');
+      expect(body.repo_type).toBe('virtual');
+      expect(body).not.toHaveProperty('npm_allowed_scopes');
+      expect(body).not.toHaveProperty('npm_allowed_name_patterns');
+      expect(body).not.toHaveProperty('npm_allow_unscoped');
+      expect(body).not.toHaveProperty('npm_scope_policy');
+
+      // The new repo appears in the list.
+      await expect(
+        page.getByRole('button', { name: new RegExp(`^${key} `) })
+      ).toBeVisible({ timeout: 10000 });
+    } finally {
+      // Clean up so reruns stay idempotent.
+      await adminApi.delete(`/repositories/${key}`).catch(() => {});
+    }
+  });
+
+  test('create dialog loads without console errors', async ({
+    page,
+    consoleErrors,
+  }) => {
+    const dialog = await openCreateDialog(page, 'NPM', 'Remote');
+    await expect(dialog.getByText('npm Scope Policy')).toBeVisible({
+      timeout: 10000,
+    });
+    await page.waitForTimeout(1000);
+    expect(filterCriticalErrors(consoleErrors)).toEqual([]);
+
+    await dialog.getByRole('button', { name: /cancel/i }).click();
+  });
+});

--- a/e2e/suites/interactions/repositories/repo-search.spec.ts
+++ b/e2e/suites/interactions/repositories/repo-search.spec.ts
@@ -1,0 +1,90 @@
+import {
+  test,
+  expect,
+  filterCriticalErrors,
+  navigateTo,
+} from '../../../fixtures/test-fixtures';
+import type { Page, Locator } from '@playwright/test';
+
+/**
+ * Cross-page repository search (PR #740): the repositories list search is
+ * server-side (the list query sends a `q` param and resets to page 1), so a
+ * match on any page appears — not just repos loaded on the current page.
+ * Uses seeded repos `e2e-docker-virtual` / `e2e-maven-local`.
+ */
+
+/** A repository row in the master list (button named "<key> <name> …"). */
+function repoListItem(page: Page, key: string): Locator {
+  return page.getByRole('button', { name: new RegExp(`^${key} `) });
+}
+
+test.describe('Repositories search (#740)', () => {
+  test('full-name search queries the server and filters the list', async ({
+    page,
+  }) => {
+    await navigateTo(page, '/repositories');
+
+    const searchInput = page.getByPlaceholder('Search...');
+    await expect(searchInput).toBeVisible({ timeout: 10000 });
+
+    // The unfiltered list shows the seeded repos.
+    await expect(repoListItem(page, 'e2e-maven-local')).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(repoListItem(page, 'e2e-docker-virtual')).toBeVisible();
+
+    // Typing a full repo name issues a server-side search (?q=...).
+    const searchRequest = page.waitForRequest(
+      (req) =>
+        req.url().includes('/api/v1/repositories') &&
+        req.url().includes('q=e2e-docker-virtual'),
+      { timeout: 10000 }
+    );
+    await searchInput.fill('e2e-docker-virtual');
+    await searchRequest;
+
+    // The match is shown; unrelated repos are filtered out.
+    await expect(repoListItem(page, 'e2e-docker-virtual')).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(repoListItem(page, 'e2e-maven-local')).toBeHidden({
+      timeout: 10000,
+    });
+  });
+
+  test('clearing the search restores the full list', async ({ page }) => {
+    await navigateTo(page, '/repositories');
+
+    const searchInput = page.getByPlaceholder('Search...');
+    await expect(repoListItem(page, 'e2e-maven-local')).toBeVisible({
+      timeout: 10000,
+    });
+
+    await searchInput.fill('e2e-docker-virtual');
+    await expect(repoListItem(page, 'e2e-maven-local')).toBeHidden({
+      timeout: 10000,
+    });
+
+    await searchInput.fill('');
+    await expect(repoListItem(page, 'e2e-maven-local')).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(repoListItem(page, 'e2e-docker-virtual')).toBeVisible();
+  });
+
+  test('searching repositories loads without console errors', async ({
+    page,
+    consoleErrors,
+  }) => {
+    await navigateTo(page, '/repositories');
+    const searchInput = page.getByPlaceholder('Search...');
+    await expect(searchInput).toBeVisible({ timeout: 10000 });
+    await searchInput.fill('e2e');
+    await expect(repoListItem(page, 'e2e-maven-local')).toBeVisible({
+      timeout: 10000,
+    });
+    await page.waitForTimeout(1000);
+
+    expect(filterCriticalErrors(consoleErrors)).toEqual([]);
+  });
+});

--- a/e2e/suites/interactions/repositories/repo-setup-pub.spec.ts
+++ b/e2e/suites/interactions/repositories/repo-setup-pub.spec.ts
@@ -1,0 +1,70 @@
+import {
+  test,
+  expect,
+  filterCriticalErrors,
+  navigateTo,
+} from '../../../fixtures/test-fixtures';
+import type { Page, Locator } from '@playwright/test';
+
+/**
+ * Pub (Dart) setup-guide snippets (PR #748): Pub-format repositories get
+ * Dart-specific steps in the repo detail Setup tab (PUB_HOSTED_URL,
+ * `dart pub token add`, pubspec.yaml hosted block, `dart pub get`,
+ * `dart pub publish`) instead of the generic curl upload/download fallback.
+ * Uses the seeded `e2e-pub-local` repository.
+ */
+
+/** Open the Setup tab on a repo detail page and return the active panel. */
+async function openSetupTab(page: Page, repoKey: string): Promise<Locator> {
+  await navigateTo(page, `/repositories/${repoKey}`);
+  const setupTab = page.getByRole('tab', { name: 'Setup' });
+  await expect(setupTab).toBeVisible({ timeout: 10000 });
+  await setupTab.click();
+  const panel = page.getByRole('tabpanel', { name: 'Setup' });
+  await expect(
+    panel.getByText(/Configure your tools to publish to and install from/)
+  ).toBeVisible({ timeout: 10000 });
+  return panel;
+}
+
+test.describe('Pub repository Setup tab (#748)', () => {
+  test('shows Dart tooling snippets with the repo key', async ({ page }) => {
+    const panel = await openSetupTab(page, 'e2e-pub-local');
+
+    // PUB_HOSTED_URL points the Dart client at /pub/<key>.
+    await expect(
+      panel.getByRole('heading', {
+        name: 'Point the Dart client at this repository',
+      })
+    ).toBeVisible();
+    await expect(panel).toContainText('PUB_HOSTED_URL');
+    await expect(panel).toContainText('/pub/e2e-pub-local');
+
+    // Token auth, pubspec hosted block, resolve, and publish steps.
+    await expect(panel).toContainText('dart pub token add');
+    await expect(panel).toContainText('hosted:');
+    await expect(panel).toContainText('dart pub get');
+    await expect(panel).toContainText('dart pub publish');
+  });
+
+  test('does not show the generic curl upload fallback', async ({ page }) => {
+    const panel = await openSetupTab(page, 'e2e-pub-local');
+    await expect(panel).toContainText('dart pub get');
+
+    // The generic-format fallback (curl PUT to /api/v1/repositories/…) must
+    // not render for a Pub repository.
+    await expect(panel).not.toContainText('curl -X PUT');
+    await expect(panel).not.toContainText('/api/v1/repositories/');
+  });
+
+  test('pub setup tab loads without console errors', async ({
+    page,
+    consoleErrors,
+  }) => {
+    await openSetupTab(page, 'e2e-pub-local');
+    // Give late-loading queries a chance to surface errors.
+    await page.waitForTimeout(1000);
+
+    expect(filterCriticalErrors(consoleErrors)).toEqual([]);
+  });
+});

--- a/e2e/suites/interactions/repositories/repo-setup-tab.spec.ts
+++ b/e2e/suites/interactions/repositories/repo-setup-tab.spec.ts
@@ -1,0 +1,91 @@
+import {
+  test,
+  expect,
+  filterCriticalErrors,
+  navigateTo,
+} from '../../../fixtures/test-fixtures';
+
+/**
+ * Per-repo "Setup" tab (PR #744, issue #560): the repository detail page has a
+ * Setup tab (Rocket icon) rendering the format-aware RepoSetupGuide — client
+ * variants (Maven/Gradle/SBT) for JVM repos, flat steps for e.g. Docker — with
+ * the repo key embedded in every snippet and a CopyButton per code block.
+ */
+
+/** Open the Setup tab on a repo detail page and return the active panel. */
+async function openSetupTab(page: import('@playwright/test').Page, repoKey: string) {
+  await navigateTo(page, `/repositories/${repoKey}`);
+  const setupTab = page.getByRole('tab', { name: 'Setup' });
+  await expect(setupTab).toBeVisible({ timeout: 10000 });
+  await setupTab.click();
+  const panel = page.getByRole('tabpanel', { name: 'Setup' });
+  await expect(
+    panel.getByText(/Configure your tools to publish to and install from/)
+  ).toBeVisible({ timeout: 10000 });
+  return panel;
+}
+
+test.describe('Repository Setup tab', () => {
+  test('maven repo shows client-variant guide with repo key in snippets', async ({
+    page,
+  }) => {
+    const panel = await openSetupTab(page, 'e2e-maven-local');
+
+    // Intro line names the repository.
+    await expect(panel).toContainText('e2e-maven-local');
+
+    // JVM formats render one tab per client tool, defaulting to Maven.
+    for (const label of ['Maven', 'Gradle (Groovy)', 'Gradle (Kotlin)', 'SBT']) {
+      await expect(panel.getByRole('tab', { name: label })).toBeVisible();
+    }
+
+    // Default (Maven) variant: settings.xml snippet uses the repo key as the
+    // server id and the pom snippet points at /maven/<key>/.
+    await expect(
+      panel.getByRole('heading', { name: 'Configure settings.xml' })
+    ).toBeVisible();
+    await expect(panel).toContainText('<id>e2e-maven-local</id>');
+    await expect(panel).toContainText('/maven/e2e-maven-local/');
+
+    // Switching to another client swaps the snippet content.
+    await panel.getByRole('tab', { name: 'Gradle (Groovy)' }).click();
+    await expect(
+      panel.getByRole('heading', { name: 'Add repository to build.gradle' })
+    ).toBeVisible({ timeout: 10000 });
+    await expect(panel).toContainText('/maven/e2e-maven-local/');
+
+    // Every code block carries a Copy button (sr-only label "Copy").
+    const copyButtons = panel.getByRole('button', { name: 'Copy' });
+    expect(await copyButtons.count()).toBeGreaterThan(0);
+    await expect(copyButtons.first()).toBeAttached();
+  });
+
+  test('docker repo shows flat step list with repo key in snippets', async ({
+    page,
+  }) => {
+    const panel = await openSetupTab(page, 'e2e-docker-virtual');
+
+    // Docker renders a flat step list — no client-variant tabs.
+    await expect(panel.getByRole('tab')).toHaveCount(0);
+    await expect(
+      panel.getByRole('heading', { name: 'Login to registry' })
+    ).toBeVisible();
+
+    await expect(panel).toContainText('docker login');
+    await expect(panel).toContainText('/e2e-docker-virtual/my-image:latest');
+
+    const copyButtons = panel.getByRole('button', { name: 'Copy' });
+    expect(await copyButtons.count()).toBeGreaterThan(0);
+  });
+
+  test('setup tab loads without console errors', async ({
+    page,
+    consoleErrors,
+  }) => {
+    await openSetupTab(page, 'e2e-maven-local');
+    // Give late-loading queries a chance to surface errors.
+    await page.waitForTimeout(1000);
+
+    expect(filterCriticalErrors(consoleErrors)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Playwright e2e coverage for the six feature PRs merged in the 1.8.x batch — closes the testing gap Mergify flags with `needs-e2e`:

| Spec | Feature | Tests |
|---|---|---|
| `dashboard/dashboard-stats.spec.ts` | Combined local + proxy-cache stat cards, Local/Remote hover breakdown (#738) | 4 |
| `repositories/repo-setup-tab.spec.ts` | Per-repo Setup tab with format-specific client guides (#744) | 3 |
| `repositories/repo-search.spec.ts` | Server-side cross-page repository search (#740) | 3 |
| `repositories/repo-create-npm.spec.ts` | Scope policy hidden/absent for non-remote npm repos (#746) | 4 |
| `operations/migration.spec.ts` | Job scope labels, repo remapping inputs, completion totals (#743) | 3 |
| `repositories/repo-setup-pub.spec.ts` | Dart/Pub setup snippets instead of generic curl (#748) | 3 |

Also seeds `e2e-pub-local` in `e2e/setup/seed-data.ts` (idempotent, 409-tolerant like the other seeded repos).

## Verification

- Every spec run green locally against the docker stack (`docker-compose.e2e.yml`, backend `:dev`, web on :3100): **20 tests passed** across the 6 files, plus an idempotency rerun.
- `npx eslint` clean on all new/changed files.
- Post-run API sweep confirms no leftover repos/jobs/connections — specs clean up after themselves.

## Notes

- Found while testing: member-less virtual repos can't be created via UI (`member_repos: []` rejected by backend) — filed as #754; the npm spec uses a seeded member to stay on the happy path.
- The migration spec route-intercepts the source-repos endpoint (it contacts an external registry by design); precedent already exists in `migration-config.spec.ts`.