### PR TITLE
fix: request an exact total for the repository artifact list pagination

### DIFF
--- a/src/app/(app)/repositories/_components/repo-detail-content.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.test.tsx
@@ -23,6 +23,10 @@ import userEvent from "@testing-library/user-event";
 const h = vi.hoisted(() => ({
   searchParams: new URLSearchParams(),
   artifactsQueryKeys: [] as unknown[][],
+  // The artifacts `queryFn`, recorded but not executed by the useQuery mock.
+  // Tests that assert on the *request parameters* (not just the query key)
+  // invoke it themselves.
+  artifactsQueryFns: [] as Array<() => unknown>,
 }));
 
 vi.mock("next/navigation", () => ({
@@ -74,13 +78,14 @@ const dockerTagFixture = {
 vi.mock("@tanstack/react-query", () => ({
   // Return canned data by the first element of the query key; never execute
   // queryFn (so the mocked API modules are never actually called).
-  useQuery: (opts: { queryKey: unknown[] }) => {
+  useQuery: (opts: { queryKey: unknown[]; queryFn?: () => unknown }) => {
     const key = Array.isArray(opts.queryKey) ? opts.queryKey[0] : undefined;
     if (key === "repository") {
       return { data: repository, isLoading: false, isFetching: false };
     }
     if (key === "artifacts") {
       h.artifactsQueryKeys.push(opts.queryKey);
+      if (opts.queryFn) h.artifactsQueryFns.push(opts.queryFn);
       return {
         data: {
           items: [artifactFixture],
@@ -400,6 +405,7 @@ describe("RepoDetailContent Docker grouped view (#330 / ak#1336)", () => {
     repository.format = "docker";
     h.searchParams = new URLSearchParams("view=grouped");
     h.artifactsQueryKeys = [];
+    h.artifactsQueryFns = [];
     vi.clearAllMocks();
   });
   afterEach(() => {
@@ -407,6 +413,7 @@ describe("RepoDetailContent Docker grouped view (#330 / ak#1336)", () => {
     repository.format = "generic";
     h.searchParams = new URLSearchParams();
     h.artifactsQueryKeys = [];
+    h.artifactsQueryFns = [];
   });
 
   async function renderDockerGrouped() {
@@ -466,5 +473,21 @@ describe("RepoDetailContent Docker grouped view (#330 / ak#1336)", () => {
     const lastKey = h.artifactsQueryKeys.at(-1) as unknown[];
     expect(lastKey[3]).toBe(1);
     expect(lastKey[4]).toBe(50);
+  });
+
+  it("asks for an exact total so the pagination bar does not grow with the page", async () => {
+    await renderDockerGrouped();
+
+    // The useQuery mock records the queryFn without running it; run it here to
+    // observe the request the component would actually issue.
+    h.artifactsQueryFns.at(-1)?.();
+
+    // The pagination bar renders `pagination.total` verbatim. Without
+    // `count=exact` the backend returns a lower bound (offset + rows +
+    // has_more), which reads as "1-20 of 21" then "21-40 of 41" (ak#2520).
+    expect(artifactsApi.listGrouped).toHaveBeenCalledWith(
+      "demo",
+      expect.objectContaining({ count: "exact" }),
+    );
   });
 });

--- a/src/app/(app)/repositories/_components/repo-detail-content.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.tsx
@@ -262,6 +262,11 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
         q: searchQuery || undefined,
         per_page: effectivePageSize,
         page: effectivePage,
+        // The pagination bar renders `pagination.total` verbatim ("1-20 of N",
+        // "Page 1 of M"), so it needs the real count. Without this the backend
+        // returns a per-page lower bound (offset + rows + has_more) and the bar
+        // reads "1-20 of 21", then "21-40 of 41", growing with the page.
+        count: "exact" as const,
         ...(useServerGrouping ? { group_by: "maven_component" as const } : {}),
         ...(isDockerGrouped ? { group_by: "docker_tag" as const } : {}),
       }),

--- a/src/lib/api/__tests__/artifacts.test.ts
+++ b/src/lib/api/__tests__/artifacts.test.ts
@@ -385,6 +385,43 @@ describe("artifactsApi", () => {
       expect(url).toContain("q=lib");
     });
 
+    it("forwards count=exact so pagination.total is a real count, not a lower bound", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: vi.fn().mockResolvedValue(
+          JSON.stringify({ items: [], pagination: {} })
+        ),
+      });
+      global.fetch = fetchMock;
+
+      const { artifactsApi } = await import("../artifacts");
+      await artifactsApi.listGrouped("maven-releases", {
+        page: 2,
+        per_page: 20,
+        count: "exact",
+      });
+      // Without `count=exact` the backend answers with `offset + rows +
+      // has_more`, which the pagination bar renders as "21-40 of 41" on
+      // page 2 and grows with every page (ak#2520).
+      expect(String(fetchMock.mock.calls[0][0])).toContain("count=exact");
+    });
+
+    it("omits count when not requested", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: vi.fn().mockResolvedValue(
+          JSON.stringify({ items: [], pagination: {} })
+        ),
+      });
+      global.fetch = fetchMock;
+
+      const { artifactsApi } = await import("../artifacts");
+      await artifactsApi.listGrouped("maven-releases", { page: 1 });
+      expect(String(fetchMock.mock.calls[0][0])).not.toContain("count=");
+    });
+
     it("falls back from `list` to `listGrouped` when group_by is set", async () => {
       const fetchMock = vi.fn().mockResolvedValue({
         ok: true,

--- a/src/lib/api/artifacts.ts
+++ b/src/lib/api/artifacts.ts
@@ -38,6 +38,20 @@ export interface ListArtifactsParams {
    *   empty) `items` array.
    */
   group_by?: 'maven_component' | 'docker_tag';
+  /**
+   * Total-count mode (backend ak#2520/#2519/#2518).
+   *
+   * The keyset-paged listings default to a *lower bound* for
+   * `pagination.total`: rows seen so far plus one when another page exists.
+   * On a `per_page=20` listing that renders as "1-20 of 21", then
+   * "21-40 of 41" on page 2 — the count grows with the page instead of
+   * describing the repository.
+   *
+   * Pass `'exact'` on any surface that shows a total or a page count; it
+   * costs one extra COUNT query per page. Leave unset when only `has_more`
+   * matters (infinite scroll, prefetch, "give me up to N rows").
+   */
+  count?: 'exact';
 }
 
 // Local Artifact extends ArtifactResponse with quarantine fields the SDK
@@ -121,6 +135,7 @@ function buildArtifactsListPath(repoKey: string, params: ListArtifactsParams): s
   const q = params.q || params.search;
   if (q) search.set('q', q);
   if (params.group_by) search.set('group_by', params.group_by);
+  if (params.count) search.set('count', params.count);
   const qs = search.toString();
   const base = `/api/v1/repositories/${encodeURIComponent(repoKey)}/artifacts`;
   return qs ? `${base}?${qs}` : base;


### PR DESCRIPTION
## Summary

Closes #767

The pagination bar under a repository's artifact list reports a total that grows with the page number instead of describing the repository:

| Page | Shown |
|---|---|
| 1 | `1-20 of 21` — `Page 1 of 2` |
| 2 | `21-40 of 41` — `Page 2 of 3` |
| 3 | `41-60 of 61` — `Page 3 of 4` |

…regardless of how many artifacts the repository actually holds.

**Root cause is not the arithmetic in `DataTablePagination` — it is the number handed to it.** The keyset-paged listings (ak#2520 / #2519 / #2518) deliberately avoid a whole-catalog `COUNT` on every page request, so `pagination.total` defaults to a cheap *lower bound*:

```rust
// backend: grouped_listing_total()
None => offset + returned as i64 + i64::from(has_more),
```

`has_more` is the authoritative next-page signal, and exact counts are opt-in via `?count=exact`. The web client never sent it. Because the bar derives **both** the range label and `totalPages` from `total`, that single lower-bound value produced both reported symptoms.

Substituting the values reproduces the screenshots exactly: page 2 → `20 + 20 + 1 = 41`.

### Fix

Opt in to `count=exact` on the one surface that actually displays a total.

- `src/lib/api/artifacts.ts` — add `count?: 'exact'` to `ListArtifactsParams` and forward it in `buildArtifactsListPath`. `listGrouped` builds its query string by hand (the SDK models no `group_by`), so it dropped the new param silently until threaded through explicitly.
- `src/app/(app)/repositories/_components/repo-detail-content.tsx` — the repository-content query now passes `count: "exact"`.

No backend change is required: `?count=exact` already exists and is honored on every branch of the handler (flat hosted, virtual, remote-cached, `group_by=maven_component` for hosted + remote, `group_by=docker_tag`) — each was checked. The generated SDK already models the parameter too.

One query feeds all three artifact views, so the flat table, the Maven component list and the Docker tag list are fixed together.

### Trade-off

This costs one extra `COUNT` query per page load — precisely what ak#2520 set out to avoid. Accepted here because this surface renders a total *and* a page count, so it genuinely needs a real one. Listings that only need "is there a next page" should keep `count` unset and read `has_more`.

If that cost proves significant on very large repositories, the alternative is making the UI honest about a lower bound instead — `1-20 of 20+`, with **Next** driven by `has_more` / `next_cursor` rather than a computed `totalPages`. That is a broader change to `DataTablePagination` and all its callers, so it is not attempted here.

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

Three regression tests added:

- `artifacts.test.ts` — `count=exact` is forwarded to the request URL; omitted when unset.
- `repo-detail-content.test.tsx` — the repository view actually requests `count: "exact"`.

The repo-detail `useQuery` mock recorded only query *keys*, so no test could assert on request *parameters*; it now records `queryFn` as well, and the new test invokes it.

**Not done, for the record:** no Playwright spec was added, and the change was not exercised in a running app — this is verified by unit tests and by reading the backend contract only. Worth a manual pass against a repository with a known artifact count before merge.

Full suite: **3160 passed, 7 failed in 2 files**. All 7 failures are pre-existing and unrelated — they are locale-dependent `Intl` fixtures that fail on a non-English machine (`'il y a 4 heures'` vs `/4 hours ago/i` in `cache-time.test.ts`; `3 650` vs `3,650` in `repo-settings-tab.test.tsx`). None touch the changed files. `tsc --noEmit` and `eslint` are clean on all four.

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes

Left deliberately unchecked rather than claimed. No markup, styling or component structure changed — only the numeric value rendered into the existing pagination bar, so responsive layout, dark mode and accessibility are untouched by construction. `N/A` is not ticked either, since user-visible output does change.
