### PR TITLE
fix: cap and middle-elide the artifact name column so a long filename cannot push the table off-panel

### DIFF
--- a/src/app/(app)/repositories/_components/repo-detail-content.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.test.tsx
@@ -211,9 +211,11 @@ vi.mock("@/components/common/data-table", () => ({
   // onRowClick, without pulling in the real table.
   DataTable: ({
     data,
+    columns,
     onRowClick,
   }: {
     data?: Array<{ id: string; name: string }>;
+    columns?: Array<{ id: string; cell?: (row: unknown) => React.ReactNode }>;
     onRowClick?: (row: unknown) => void;
   }) => (
     <div data-stub="DataTable">
@@ -225,6 +227,15 @@ vi.mock("@/components/common/data-table", () => ({
         >
           {row.name}
         </button>
+      ))}
+      {/* The real `name` column cell, so the column definition is covered
+          rather than stubbed away (#768). Only this column is rendered: the
+          `actions` cell mounts Radix tooltips, which need a provider that this
+          suite deliberately does not set up. */}
+      {(data ?? []).map((row) => (
+        <div key={`name-cell-${row.id}`} data-testid={`stub-name-cell-${row.id}`}>
+          {columns?.find((c) => c.id === "name")?.cell?.(row)}
+        </div>
       ))}
     </div>
   ),
@@ -330,6 +341,27 @@ describe("RepoDetailContent default primary tab (#2793)", () => {
     );
     // Active panel is the artifact browser (its stubbed row is mounted).
     expect(screen.getByTestId("stub-row-a1")).toBeInTheDocument();
+  });
+
+  it("caps and middle-elides the artifact name column (#768)", () => {
+    repository.format = "generic";
+    render(<RepoDetailContent repoKey="demo" />);
+
+    const cell = screen.getByTestId("stub-name-cell-a1");
+
+    // The width cap is the fix: uncapped, `whitespace-nowrap` cells made the
+    // column as wide as the longest filename, pushing the table past the
+    // detail panel where an `overflow-x: hidden` viewport clipped it beyond
+    // reach. Asserted as a class because jsdom does no layout.
+    const capped = cell.querySelector(".max-w-\\[360px\\]");
+    expect(capped).not.toBeNull();
+
+    // Routed through MiddleEllipsis, which exposes the untruncated name as the
+    // native tooltip so nothing is lost to the elision.
+    expect(cell.querySelector("[title]")).toHaveAttribute(
+      "title",
+      artifactFixture.name,
+    );
   });
 
   it("defaults package-oriented (Maven) repositories to the Packages tab", () => {

--- a/src/app/(app)/repositories/_components/repo-detail-content.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.tsx
@@ -130,6 +130,7 @@ import {
 
 import { DataTable, type DataTableColumn } from "@/components/common/data-table";
 import { CopyButton } from "@/components/common/copy-button";
+import { MiddleEllipsis } from "@/components/common/middle-ellipsis";
 import { FileUpload } from "@/components/common/file-upload";
 import { RepoSetupGuide } from "@/components/setup/repo-setup-guide";
 
@@ -511,22 +512,40 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
       header: "Name",
       accessor: (a) => a.name,
       sortable: true,
+      // The name is width-capped and middle-elided (#768). Uncapped, a long
+      // filename set this column's width directly — every table cell is
+      // `whitespace-nowrap`, so nothing wrapped — and widened the table past
+      // the detail panel. The panel's ScrollArea viewport sizes its content
+      // with `display: table` and is `overflow-x: hidden`, so the extra width
+      // applied to the whole detail column (displacing right-aligned controls
+      // in the cards above) and was then clipped, unreachable. One long
+      // filename was enough to hide Downloads, Created and the row actions
+      // outright.
+      //
+      // Elided in the MIDDLE, not the end: artifact names are distinguished by
+      // their tail as often as their head (`…-tlsconsul` vs
+      // `…-tlsconsul-docker`), which end-truncation would collapse into
+      // identical-looking rows. Full name via tooltip and the detail dialog.
       cell: (a) => (
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 max-w-[360px]">
           <button
-            className="flex items-center gap-2 text-sm font-medium text-primary hover:underline"
+            className="flex min-w-0 items-center gap-2 text-sm font-medium text-primary hover:underline"
             onClick={(e) => {
               e.stopPropagation();
               showDetail(a);
             }}
           >
-            <FileIcon className="size-4 text-muted-foreground" />
-            {a.name}
+            <FileIcon className="size-4 shrink-0 text-muted-foreground" />
+            <MiddleEllipsis text={a.name} />
           </button>
           {isActivelyQuarantined(a) && (
             // The listing carries no reason (#2966); the badge tooltip falls
-            // back to the hold expiry.
-            <QuarantineBadge quarantineUntil={a.quarantine_until} />
+            // back to the hold expiry. `shrink-0` keeps the badge legible when
+            // the name beside it is being truncated.
+            <QuarantineBadge
+              quarantineUntil={a.quarantine_until}
+              className="shrink-0"
+            />
           )}
         </div>
       ),

--- a/src/components/common/__tests__/middle-ellipsis.test.tsx
+++ b/src/components/common/__tests__/middle-ellipsis.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+import {
+  MiddleEllipsis,
+  splitForMiddleEllipsis,
+} from "@/components/common/middle-ellipsis";
+
+// The name that motivated #768: long enough to widen the flat artifact table
+// past the repository detail panel, where the overflow was then clipped by an
+// `overflow-x: hidden` viewport with no way to scroll to it.
+const LONG_NAME =
+  "foobar-testfile-foobar-very-long-filename-to-demonstrate-the-artifact-keeper-web-artifact-name-problem.txt";
+
+describe("splitForMiddleEllipsis", () => {
+  it("keeps the trailing characters out of the clippable head", () => {
+    const { head, tail } = splitForMiddleEllipsis(LONG_NAME);
+    expect(tail).toBe("-problem.txt");
+    expect(head + tail).toBe(LONG_NAME);
+  });
+
+  it("preserves a variant suffix that end-truncation would collapse", () => {
+    // The reason the elision is in the middle: these two differ only in their
+    // tail, so clipping the end would render them identical on screen.
+    const plain = splitForMiddleEllipsis(
+      "some-package-v2.11.2-cloudflare-ovh-tlsconsul",
+    );
+    const docker = splitForMiddleEllipsis(
+      "some-package-v2.11.2-cloudflare-ovh-tlsconsul-docker",
+    );
+    expect(plain.tail).not.toBe(docker.tail);
+    expect(docker.tail).toContain("docker");
+  });
+
+  it("leaves a short value whole so nothing is elided needlessly", () => {
+    expect(splitForMiddleEllipsis("lib.jar")).toEqual({
+      head: "lib.jar",
+      tail: "",
+    });
+  });
+
+  it("leaves a value whole at the boundary and splits just past it", () => {
+    // Boundary is tailLength * 2: at or below, no split.
+    expect(splitForMiddleEllipsis("a".repeat(24)).tail).toBe("");
+    expect(splitForMiddleEllipsis("a".repeat(25)).tail).toHaveLength(12);
+  });
+
+  it("honours a custom tail length", () => {
+    const { head, tail } = splitForMiddleEllipsis(LONG_NAME, 4);
+    expect(tail).toBe(".txt");
+    expect(head + tail).toBe(LONG_NAME);
+  });
+
+  it("degenerates to end-truncation for a non-positive tail length", () => {
+    expect(splitForMiddleEllipsis(LONG_NAME, 0).tail).toBe("");
+    expect(splitForMiddleEllipsis(LONG_NAME, -5).tail).toBe("");
+  });
+
+  it("never drops or reorders characters", () => {
+    for (const value of [
+      "",
+      "a",
+      "a".repeat(200),
+      LONG_NAME,
+      "no-extension-but-quite-long-indeed",
+    ]) {
+      const { head, tail } = splitForMiddleEllipsis(value);
+      expect(head + tail).toBe(value);
+    }
+  });
+});
+
+describe("MiddleEllipsis", () => {
+  // This repo does not enable testing-library auto-cleanup, so renders would
+  // otherwise accumulate and the title queries would match several nodes.
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the full value as the native tooltip", () => {
+    render(<MiddleEllipsis text={LONG_NAME} />);
+    expect(screen.getByTitle(LONG_NAME)).toBeInTheDocument();
+  });
+
+  it("renders the whole value across head and tail so it stays selectable", () => {
+    render(<MiddleEllipsis text={LONG_NAME} />);
+    // The ellipsis is painted by CSS `text-overflow`, not inserted into the
+    // DOM, so the text content remains complete and copyable.
+    expect(screen.getByTitle(LONG_NAME).textContent).toBe(LONG_NAME);
+  });
+
+  it("puts the clippable head and the pinned tail in separate elements", () => {
+    render(<MiddleEllipsis text={LONG_NAME} />);
+    const root = screen.getByTitle(LONG_NAME);
+    const [head, tail] = Array.from(root.children) as HTMLElement[];
+    // `truncate` supplies overflow:hidden + ellipsis; without `min-w-0` on the
+    // ancestors a flex item refuses to shrink and nothing would ever elide.
+    expect(head).toHaveClass("truncate");
+    expect(root).toHaveClass("min-w-0");
+    // The tail must NOT shrink — that is what keeps the elision in the middle.
+    expect(tail).toHaveClass("shrink-0");
+    expect(tail.textContent).toBe("-problem.txt");
+  });
+
+  it("renders a short value as a single element with no pinned tail", () => {
+    render(<MiddleEllipsis text="lib.jar" />);
+    const root = screen.getByTitle("lib.jar");
+    expect(root.children).toHaveLength(1);
+    expect(root.textContent).toBe("lib.jar");
+  });
+});

--- a/src/components/common/middle-ellipsis.tsx
+++ b/src/components/common/middle-ellipsis.tsx
@@ -1,0 +1,80 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Number of trailing characters kept verbatim when a value is elided.
+ *
+ * Artifact filenames carry their most distinguishing information at BOTH
+ * ends: the package name at the front, the version / variant / extension at
+ * the back. End-truncation collapses that tail, rendering
+ * `foo-cloudflare-tlsconsul` and `foo-cloudflare-tlsconsul-docker`
+ * indistinguishable. 12 characters is enough for a `-docker` style variant
+ * suffix or a `.tar.gz` extension.
+ */
+const DEFAULT_TAIL_LENGTH = 12;
+
+/**
+ * Split `text` into the part that may be clipped and the tail that must stay
+ * visible.
+ *
+ * Returns an empty tail when the value is too short for a middle ellipsis to
+ * be worth it — below roughly twice the tail length, eliding hides more than
+ * it reveals, so the value is left whole (and simply end-truncates if it
+ * still does not fit).
+ *
+ * Exported for testing: the visual result depends on flexbox, which jsdom
+ * does not lay out, so the split is pinned here as a pure function.
+ */
+export function splitForMiddleEllipsis(
+  text: string,
+  tailLength: number = DEFAULT_TAIL_LENGTH,
+): { head: string; tail: string } {
+  // A non-positive tail degenerates to plain end-truncation.
+  if (tailLength <= 0 || text.length <= tailLength * 2) {
+    return { head: text, tail: "" };
+  }
+  return {
+    head: text.slice(0, text.length - tailLength),
+    tail: text.slice(text.length - tailLength),
+  };
+}
+
+export interface MiddleEllipsisProps {
+  /** The full value. Always exposed verbatim as the native tooltip. */
+  text: string;
+  /** Trailing characters kept visible. Defaults to 12. */
+  tailLength?: number;
+  className?: string;
+}
+
+/**
+ * Renders `text` on one line, eliding the MIDDLE rather than the end when it
+ * does not fit the available width.
+ *
+ * CSS `text-overflow: ellipsis` can only elide the end, so the value is split
+ * into two spans: the head is allowed to shrink and truncate, the tail is
+ * pinned with `shrink-0`. The ellipsis therefore lands between them, and the
+ * result is width-responsive — no character-count guesswork against a
+ * container whose width is not known until layout.
+ *
+ * The caller must provide the width bound. This component only shrinks to
+ * whatever its flex parent allows, so an ancestor needs a width cap (and
+ * `min-w-0` on the intervening flex items) for the elision to ever trigger.
+ */
+export function MiddleEllipsis({
+  text,
+  tailLength,
+  className,
+}: MiddleEllipsisProps) {
+  const { head, tail } = splitForMiddleEllipsis(text, tailLength);
+
+  return (
+    <span className={cn("flex min-w-0 items-baseline", className)} title={text}>
+      <span className="truncate">{head}</span>
+      {/* Pinned: the tail is what end-truncation would have eaten. Kept short
+          by `splitForMiddleEllipsis` so it cannot itself overflow the cap.
+          `whitespace-nowrap` is explicit rather than inherited, so the tail
+          cannot wrap when used outside a `whitespace-nowrap` table cell. */}
+      {tail && <span className="shrink-0 whitespace-nowrap">{tail}</span>}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #768

A single artifact with a long filename widened the flat artifact table past the repository detail panel, and the overflow was **unreachable** — Size, Downloads, Created and the per-row Details/Download actions were clipped with no horizontal scrollbar and no way to scroll to them.

### Root cause

The Name column was the only wide column with no width constraint. Path, directly beside it, was already capped:

```jsx
// path — already correct
<code className="text-xs text-muted-foreground max-w-[200px] truncate block">

// name — unconstrained
<button className="flex items-center gap-2 text-sm font-medium ...">
  <FileIcon className="size-4 text-muted-foreground" />
  {a.name}
</button>
```

Both table primitives force `whitespace-nowrap` (`table.tsx:73`, `table.tsx:86`), so nothing wrapped and the column took the full rendered width of the longest filename on the page.

That width then escaped the table. The detail panel's `ScrollArea` viewport places children in `<div style="min-width:100%; display:table">` — shrink-to-fit with a 100% floor, so it grows to its content instead of clamping it — and Radix derives the viewport's overflow from the scrollbars that mount (`overflowX: scrollbarXEnabled ? "scroll" : "hidden"`). With only a vertical `ScrollBar` rendered, that viewport is permanently `overflow-x: hidden`. So the excess applied to the *entire* detail column and was then clipped out of reach. That is why right-aligned controls in unrelated cards above the table — the Storage card's `Estimate` button, in a `justify-between` row — were displaced too.

### Fix

Cap the cell (`max-w-[360px]`) and elide the name in the **middle** rather than the end.

Artifact names are distinguished by their tail as often as their head: `…-tlsconsul` versus `…-tlsconsul-docker` differ only in the last seven characters, and version suffixes, variant suffixes and file extensions all live at the end. End-truncation would have rendered such rows visually identical — worse than the bug for anyone scanning a list.

CSS `text-overflow: ellipsis` can only elide the end, so the new `MiddleEllipsis` component splits the value into a head that shrinks and truncates and a tail pinned with `shrink-0`. The ellipsis lands between them, and the result is width-responsive — no character-count guesswork against a container whose width is unknown until layout. The full name stays available via the native tooltip and the detail dialog, and the DOM text content stays complete, so the name remains selectable and copyable.

### Note on scope

An earlier draft also added `<ScrollBar orientation="horizontal" />` to `ScrollArea`, which would make horizontal overflow reachable app-wide instead of silently clipped. That was dropped on maintainer preference against introducing a horizontal scrollbar.

Worth being explicit about the consequence: the `overflow-x: hidden` trap described above is still present at every `ScrollArea` call site. This PR removes the one input that was tripping it, not the trap itself. Any future content that overflows a `ScrollArea` horizontally will again be clipped with no affordance. Filing that separately as a latent issue would be reasonable.

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

12 tests added:

- `middle-ellipsis.test.tsx` — the split keeps the trailing characters out of the clippable head; two names differing only in a variant suffix stay distinguishable; short values are left whole; the boundary at `tailLength * 2`; custom and non-positive tail lengths; and a round-trip check that no input ever loses or reorders characters. Plus component tests for the tooltip, the complete text content, and the head/tail element structure.
- `repo-detail-content.test.tsx` — the name column carries the width cap and routes through `MiddleEllipsis`.

The elision is asserted structurally (classes and element split) rather than visually, because jsdom performs no layout — hence the split being a pure exported function.

While adding that second test I found the suite's `DataTable` stub discarded `columns` entirely, so the column definitions had **no** coverage. It now renders the real `name` cell. Only that column: the `actions` cell mounts Radix tooltips, which need a provider this suite deliberately does not set up.

**Not done, for the record:** no Playwright spec, and the visual result has not been checked in a browser — the fix is verified by unit tests and by reading the layout chain. A screenshot at a narrow panel width would be worth having before merge, since the exact `360px` cap is a judgement call.

Full suite: **3169 passed, 7 failed in 2 files.** The 7 are pre-existing and unrelated — locale-dependent `Intl` fixtures that fail on a non-English machine (`cache-time.test.ts`, `repo-settings-tab.test.tsx`), identical before and after this change. `tsc --noEmit` and `eslint` clean on all four files.

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [ ] N/A - no UI changes

Left unchecked rather than claimed, since none were verified in a browser. Reasoning about each, for a reviewer to confirm:

- **Responsive** — the elision is width-driven by design and shrinks with the panel; the cap only sets an upper bound. The mobile breakpoint renders the list without the detail panel, so it is unaffected.
- **Dark mode** — no colours introduced; only layout utilities (`max-w`, `min-w-0`, `shrink-0`, `truncate`).
- **Accessibility** — the accessible name of the row button is unchanged, since the full string stays in the DOM and the ellipsis is painted by CSS rather than inserted as text. Screen readers still announce the complete filename. `title` adds a hover affordance for sighted users, and the detail dialog remains the non-hover path to the full name.
