### PR TITLE
Fix Maven install snippet: split colon-joined package name into groupId/artifactId

### DIFF
--- a/src/lib/__tests__/maven.test.ts
+++ b/src/lib/__tests__/maven.test.ts
@@ -6,6 +6,7 @@ import {
   isPomFile,
   findPomFile,
   parseMavenGav,
+  parseMavenPackageName,
   buildPomDependencySnippet,
 } from "../maven";
 
@@ -144,5 +145,47 @@ describe("buildPomDependencySnippet", () => {
         "</dependency>",
       ].join("\n"),
     );
+  });
+});
+
+describe("parseMavenPackageName", () => {
+  it("splits a colon-joined groupId:artifactId name", () => {
+    expect(parseMavenPackageName("com.example.team:team-spring-archetype")).toEqual({
+      groupId: "com.example.team",
+      artifactId: "team-spring-archetype",
+      version: undefined,
+    });
+  });
+
+  it("splits on colons, never on dots (dotted artifactId survives)", () => {
+    expect(parseMavenPackageName("org.foo:bar.baz")).toEqual({
+      groupId: "org.foo",
+      artifactId: "bar.baz",
+      version: undefined,
+    });
+  });
+
+  it("parses a full groupId:artifactId:version coordinate", () => {
+    expect(parseMavenPackageName("com.acme.sub:my-artifact:1.0")).toEqual({
+      groupId: "com.acme.sub",
+      artifactId: "my-artifact",
+      version: "1.0",
+    });
+    expect(parseMavenPackageName("org.foo:bar.baz:2.0-SNAPSHOT")).toEqual({
+      groupId: "org.foo",
+      artifactId: "bar.baz",
+      version: "2.0-SNAPSHOT",
+    });
+  });
+
+  it("treats a colon-free name as a bare artifactId", () => {
+    expect(parseMavenPackageName("plain-name")).toEqual({
+      artifactId: "plain-name",
+    });
+  });
+
+  it("falls back to the whole name when a colon segment is empty", () => {
+    expect(parseMavenPackageName(":oops")).toEqual({ artifactId: ":oops" });
+    expect(parseMavenPackageName("oops:")).toEqual({ artifactId: "oops:" });
   });
 });

--- a/src/lib/__tests__/package-utils.test.ts
+++ b/src/lib/__tests__/package-utils.test.ts
@@ -127,6 +127,73 @@ describe("getInstallCommand", () => {
   });
 });
 
+// Maven package names are stored colon-joined as `groupId:artifactId`
+// (backend maven_package_name). Issue artifact-keeper#3136: the snippet
+// emitted the full name as the artifactId with a `...` placeholder groupId.
+describe("getInstallCommand with colon-joined Maven coordinates", () => {
+  it("splits groupId and artifactId in the pom.xml dependency snippet (issue reproduction)", () => {
+    expect(
+      getInstallCommand(
+        "com.example.team:team-spring-archetype",
+        "4.2.1-0-SNAPSHOT",
+        "maven"
+      )
+    ).toBe(
+      "<dependency>\n" +
+        "  <groupId>com.example.team</groupId>\n" +
+        "  <artifactId>team-spring-archetype</artifactId>\n" +
+        "  <version>4.2.1-0-SNAPSHOT</version>\n" +
+        "</dependency>"
+    );
+  });
+
+  it("splits on the colon, not on dots: dotted groupId with hyphenated artifactId", () => {
+    const result = getInstallCommand("com.acme.sub:my-artifact", "1.0", "maven");
+    expect(result).toContain("<groupId>com.acme.sub</groupId>");
+    expect(result).toContain("<artifactId>my-artifact</artifactId>");
+    expect(result).toContain("<version>1.0</version>");
+  });
+
+  it("keeps dots inside the artifactId intact", () => {
+    const result = getInstallCommand("org.foo:bar.baz", "2.0-SNAPSHOT", "maven");
+    expect(result).toContain("<groupId>org.foo</groupId>");
+    expect(result).toContain("<artifactId>bar.baz</artifactId>");
+    expect(result).toContain("<version>2.0-SNAPSHOT</version>");
+  });
+
+  it("never leaks the colon-joined name into the artifactId element", () => {
+    const result = getInstallCommand(
+      "com.example.team:team-spring-archetype",
+      "4.2.1-0-SNAPSHOT",
+      "maven"
+    );
+    expect(result).not.toContain("<groupId>...</groupId>");
+    expect(result).not.toContain("<artifactId>com.example.team:");
+  });
+
+  it("positive control: a colon-free name still renders as the artifactId with the placeholder groupId", () => {
+    expect(getInstallCommand("my-package", "1.2.3", "maven")).toBe(
+      "<dependency>\n" +
+        "  <groupId>...</groupId>\n" +
+        "  <artifactId>my-package</artifactId>\n" +
+        "  <version>1.2.3</version>\n" +
+        "</dependency>"
+    );
+  });
+
+  it("gradle snippet uses the real groupId instead of the GROUP placeholder", () => {
+    expect(
+      getInstallCommand("com.acme.sub:my-artifact", "1.0", "gradle")
+    ).toBe("implementation 'com.acme.sub:my-artifact:1.0'");
+  });
+
+  it("sbt snippet uses the real groupId instead of the GROUP placeholder", () => {
+    expect(getInstallCommand("org.foo:bar.baz", "2.0-SNAPSHOT", "sbt")).toBe(
+      'libraryDependencies += "org.foo" % "bar.baz" % "2.0-SNAPSHOT"'
+    );
+  });
+});
+
 describe("FORMAT_OPTIONS", () => {
   it("is a non-empty array of unique strings", () => {
     expect(Array.isArray(FORMAT_OPTIONS)).toBe(true);

--- a/src/lib/maven.ts
+++ b/src/lib/maven.ts
@@ -118,6 +118,37 @@ export function parseMavenGav(
 }
 
 /**
+ * Split a registry package name into Maven coordinates.
+ *
+ * The backend stores Maven packages under the colon-joined name
+ * `groupId:artifactId` (the version lives in a separate column), and a full
+ * coordinate may also carry a trailing `:version` segment. Colons are the
+ * coordinate delimiter and are not legal inside a groupId or artifactId, so
+ * the split is on colons — never on dots: a groupId contains dots
+ * (`com.acme.sub`) and an artifactId may too (`bar.baz`), so dot-based
+ * heuristics mis-split real coordinates.
+ *
+ *   com.example.team:team-spring-archetype -> { groupId: com.example.team, artifactId: team-spring-archetype }
+ *   com.acme.sub:my-artifact:1.0       -> { groupId: com.acme.sub, artifactId: my-artifact, version: 1.0 }
+ *   plain-name                         -> { artifactId: plain-name }
+ */
+export function parseMavenPackageName(name: string): {
+  groupId?: string;
+  artifactId: string;
+  version?: string;
+} {
+  const parts = name.split(":");
+  if (parts.length < 2 || !parts[0] || !parts[1]) {
+    return { artifactId: name };
+  }
+  return {
+    groupId: parts[0],
+    artifactId: parts[1],
+    version: parts.length > 2 && parts[2] ? parts[2] : undefined,
+  };
+}
+
+/**
  * Render a copy/paste-ready `<dependency>` snippet for a pom.xml. Used in the
  * artifact detail view so users can drop a Maven coordinate straight into
  * their build (issue #442).

--- a/src/lib/package-utils.ts
+++ b/src/lib/package-utils.ts
@@ -1,3 +1,5 @@
+import { buildPomDependencySnippet, parseMavenPackageName } from "./maven";
+
 export function getInstallCommand(
   packageName: string,
   version: string | undefined,
@@ -12,12 +14,28 @@ export function getInstallCommand(
     case "pypi":
     case "poetry":
       return `pip install ${packageName}==${v}`;
-    case "maven":
-      return `<dependency>\n  <groupId>...</groupId>\n  <artifactId>${packageName}</artifactId>\n  <version>${v}</version>\n</dependency>`;
-    case "gradle":
-      return `implementation 'GROUP:${packageName}:${v}'`;
-    case "sbt":
-      return `libraryDependencies += "GROUP" % "${packageName}" % "${v}"`;
+    case "maven": {
+      // Maven package names arrive colon-joined as `groupId:artifactId`
+      // (issue: the full string used to be emitted as the artifactId with a
+      // `...` placeholder groupId). Split on the colon delimiter; when the
+      // name carries no groupId, keep the `...` placeholder.
+      const gav = parseMavenPackageName(packageName);
+      return buildPomDependencySnippet({
+        groupId: gav.groupId ?? "...",
+        artifactId: gav.artifactId,
+        version: gav.version ?? v,
+      });
+    }
+    case "gradle": {
+      const gav = parseMavenPackageName(packageName);
+      const group = gav.groupId ?? "GROUP";
+      return `implementation '${group}:${gav.artifactId}:${gav.version ?? v}'`;
+    }
+    case "sbt": {
+      const gav = parseMavenPackageName(packageName);
+      const group = gav.groupId ?? "GROUP";
+      return `libraryDependencies += "${group}" % "${gav.artifactId}" % "${gav.version ?? v}"`;
+    }
     case "cargo":
       return `cargo add ${packageName}@${v}`;
     case "nuget":


### PR DESCRIPTION
Fixes #770
Fixes artifact-keeper/artifact-keeper#3136

## Problem

Maven packages are stored backend-side under the colon-joined name `groupId:artifactId` (`maven_package_name`, backend `api/handlers/maven.rs:2186` / `formats/maven.rs:228`). The package views' install-command generator (`getInstallCommand` in `src/lib/package-utils.ts`) fed that name straight into the snippet, producing:

```xml
<dependency>
  <groupId>...</groupId>
  <artifactId>com.example.team:team-spring-archetype</artifactId>
  <version>4.2.1-0-SNAPSHOT</version>
</dependency>
```

The split is intact at parse time and storage time (both the name convention and the package `metadata` JSON carry it); it was lost only at render time, in this helper. The `gradle` and `sbt` branches had the sibling defect (literal `GROUP:` prefix on the already colon-joined name).

## Fix

- New `parseMavenPackageName` in `src/lib/maven.ts`: splits on the **colon delimiter**, never on dots. Per the Maven POM reference, dependency coordinates are `groupId:artifactId:version`, and `:` is the coordinate separator — it is not legal inside a groupId or artifactId, while dots are legal in both (`com.acme.sub` groupIds, `bar.baz` artifactIds), so any dot-based heuristic mis-splits real coordinates. A trailing `:version` segment, if present, is also recognized.
- The `maven` case now routes through the existing `buildPomDependencySnippet` renderer (same code path as the repository browser view), so both views emit identical XML.
- `gradle`/`sbt` cases use the parsed groupId/artifactId.
- Colon-free names keep the previous placeholder behavior unchanged (positive control below).

## Tests

11 new tests (`package-utils.test.ts` + `maven.test.ts`), asserting against literal expected strings (not the renderer's own helper):

- issue reproduction: `com.example.team:team-spring-archetype` + `4.2.1-0-SNAPSHOT` renders the correctly split `<dependency>` block, exact match
- dot-robustness pins: `com.acme.sub:my-artifact:1.0` and `org.foo:bar.baz:2.0-SNAPSHOT` (dotted artifactId survives)
- negative: output never contains `<groupId>...</groupId>` or `<artifactId>` starting with the colon-joined name
- positive control in the same fixture: colon-free `my-package` still renders exactly as before
- gradle/sbt placeholder removal, parser edge cases (bare name, empty colon segments)

## Revert-proof

Production files reverted byte-identical to merge-base `3da9181` (sha256 of both files equals the merge-base blobs; `git diff <mb>` on the reverted tree = `2 files changed, 110 insertions(+)`, all inside the two test files):

```
Reverted:  Tests  11 failed | 74 passed (85)
  AssertionError: expected '<dependency>\n  <groupId>...</groupId…' to be '<dependency>\n  <groupId>com.example.…'
  AssertionError: expected 'implementation 'GROUP:com.acme.sub:m…' to be 'implementation 'com.acme.sub:my-arti…'
Fixed:     Tests  85 passed (85)
```

Full suite: 172 files / 3176 tests pass. ESLint clean on all touched files; `tsc --noEmit` shows the same 22 pre-existing errors (in an unrelated test file) with and without this change.