### PR TITLE
fix(auth): retry token refresh after tab unfreeze before redirecting to login (#558)

### DIFF
--- a/src/lib/__tests__/sdk-client.test.ts
+++ b/src/lib/__tests__/sdk-client.test.ts
@@ -65,6 +65,21 @@ function setupServerEnv() {
   vi.stubGlobal("window", undefined);
 }
 
+function setupDocument(visibilityState: "visible" | "hidden" = "visible") {
+  const listeners: Array<() => void> = [];
+  vi.stubGlobal("document", {
+    visibilityState,
+    addEventListener: (event: string, cb: () => void) => {
+      if (event === "visibilitychange") listeners.push(cb);
+    },
+  });
+  return {
+    fireVisibilityChange() {
+      for (const cb of listeners) cb();
+    },
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -80,6 +95,7 @@ describe("sdk-client", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
   // -------------------------------------------------------------------------
@@ -799,6 +815,185 @@ describe("sdk-client", () => {
       vi.stubGlobal("window", undefined);
       const result = await interceptor(response, request);
       expect(result.status).toBe(401);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Tab unfreeze mitigation (#558)
+  // -------------------------------------------------------------------------
+
+  describe("tab unfreeze mitigation (#558)", () => {
+    it("retries the refresh once when the tab recently became visible, avoiding the redirect", async () => {
+      vi.useFakeTimers();
+      setupBrowserEnv();
+      mockStorage["ak_active_instance"] = "local";
+      const doc = setupDocument("visible");
+
+      let refreshCalls = 0;
+      const mockFetch = vi.fn((input: unknown) => {
+        const url = typeof input === "string" ? input : (input as Request).url;
+        if (url.includes("/auth/refresh")) {
+          refreshCalls += 1;
+          // First attempt goes out cookieless right after unfreeze and fails;
+          // the retry after the debounce succeeds.
+          return Promise.resolve(
+            new Response(refreshCalls === 1 ? "Unauthorized" : "{}", {
+              status: refreshCalls === 1 ? 401 : 200,
+            })
+          );
+        }
+        return Promise.resolve(new Response("{}", { status: 200 }));
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const { initTabUnfreezeGuards, UNFREEZE_REFRESH_RETRY_DELAY_MS } =
+        await import("../tab-unfreeze");
+      await import("../sdk-client");
+      initTabUnfreezeGuards();
+      doc.fireVisibilityChange();
+
+      const interceptor = responseInterceptors[0];
+      const resultPromise = interceptor(
+        new Response("Unauthorized", { status: 401 }),
+        new Request("http://localhost:3000/api/v1/repos")
+      );
+
+      // The retry fires after the debounce; this also flushes the warm-up.
+      await vi.advanceTimersByTimeAsync(UNFREEZE_REFRESH_RETRY_DELAY_MS + 100);
+      const result = await resultPromise;
+
+      expect(refreshCalls).toBe(2);
+      expect(result.status).toBe(200);
+      expect(window.location.href).not.toBe("/login");
+    });
+
+    it("redirects immediately without a retry when the tab was not recently unfrozen", async () => {
+      setupBrowserEnv();
+      mockStorage["ak_active_instance"] = "local";
+
+      const mockFetch = vi.fn();
+      // Refresh endpoint returns 401 (not ok)
+      mockFetch.mockResolvedValue(new Response("Unauthorized", { status: 401 }));
+      vi.stubGlobal("fetch", mockFetch);
+
+      await import("../sdk-client");
+      const interceptor = responseInterceptors[0];
+
+      const result = await interceptor(
+        new Response("Unauthorized", { status: 401 }),
+        new Request("http://localhost:3000/api/v1/repos")
+      );
+
+      // Exactly one refresh attempt (no retry), then the redirect
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(window.location.href).toBe("/login");
+      expect(result.status).toBe(401);
+    });
+
+    it("does not retry the refresh when the visibilitychange is stale", async () => {
+      vi.useFakeTimers();
+      setupBrowserEnv();
+      mockStorage["ak_active_instance"] = "local";
+      const doc = setupDocument("visible");
+
+      let refreshCalls = 0;
+      const mockFetch = vi.fn((input: unknown) => {
+        const url = typeof input === "string" ? input : (input as Request).url;
+        if (url.includes("/auth/refresh")) {
+          refreshCalls += 1;
+          return Promise.resolve(new Response("Unauthorized", { status: 401 }));
+        }
+        return Promise.resolve(new Response("{}", { status: 200 }));
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const { initTabUnfreezeGuards, UNFREEZE_WINDOW_MS } = await import(
+        "../tab-unfreeze"
+      );
+      await import("../sdk-client");
+      initTabUnfreezeGuards();
+      doc.fireVisibilityChange();
+
+      // Move past the unfreeze window before the 401 happens
+      await vi.advanceTimersByTimeAsync(UNFREEZE_WINDOW_MS + 1000);
+
+      const interceptor = responseInterceptors[0];
+      const result = await interceptor(
+        new Response("Unauthorized", { status: 401 }),
+        new Request("http://localhost:3000/api/v1/repos")
+      );
+
+      expect(refreshCalls).toBe(1);
+      expect(window.location.href).toBe("/login");
+      expect(result.status).toBe(401);
+    });
+
+    it("fires a disposable warm-up request to /auth/me when the tab becomes visible", async () => {
+      vi.useFakeTimers();
+      setupBrowserEnv();
+      const doc = setupDocument("visible");
+
+      const mockFetch = vi.fn();
+      mockFetch.mockResolvedValue(new Response("{}", { status: 200 }));
+      vi.stubGlobal("fetch", mockFetch);
+
+      const { initTabUnfreezeGuards, UNFREEZE_WARMUP_DELAY_MS } = await import(
+        "../tab-unfreeze"
+      );
+      initTabUnfreezeGuards();
+      doc.fireVisibilityChange();
+
+      // The warm-up is debounced so it does not race the visibility event
+      expect(mockFetch).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(UNFREEZE_WARMUP_DELAY_MS);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/v1/auth/me",
+        expect.objectContaining({
+          method: "GET",
+          credentials: "include",
+        })
+      );
+    });
+
+    it("does not fire a warm-up request when the tab becomes hidden", async () => {
+      vi.useFakeTimers();
+      setupBrowserEnv();
+      const doc = setupDocument("hidden");
+
+      const mockFetch = vi.fn();
+      mockFetch.mockResolvedValue(new Response("{}", { status: 200 }));
+      vi.stubGlobal("fetch", mockFetch);
+
+      const { initTabUnfreezeGuards, UNFREEZE_WARMUP_DELAY_MS } = await import(
+        "../tab-unfreeze"
+      );
+      initTabUnfreezeGuards();
+      doc.fireVisibilityChange();
+      await vi.advanceTimersByTimeAsync(UNFREEZE_WARMUP_DELAY_MS + 1000);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("swallows warm-up request failures (disposable by design)", async () => {
+      vi.useFakeTimers();
+      setupBrowserEnv();
+      const doc = setupDocument("visible");
+
+      const mockFetch = vi.fn();
+      mockFetch.mockRejectedValue(new Error("Network error"));
+      vi.stubGlobal("fetch", mockFetch);
+
+      const { initTabUnfreezeGuards, UNFREEZE_WARMUP_DELAY_MS } = await import(
+        "../tab-unfreeze"
+      );
+      initTabUnfreezeGuards();
+      doc.fireVisibilityChange();
+
+      // Must not surface an unhandled rejection
+      await vi.advanceTimersByTimeAsync(UNFREEZE_WARMUP_DELAY_MS + 1000);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/lib/sdk-client.ts
+++ b/src/lib/sdk-client.ts
@@ -13,6 +13,10 @@
  */
 
 import { client } from '@artifact-keeper/sdk/client';
+import {
+  recentlyBecameVisible,
+  UNFREEZE_REFRESH_RETRY_DELAY_MS,
+} from './tab-unfreeze';
 
 // ---------------------------------------------------------------------------
 // CSRF defense-in-depth
@@ -110,6 +114,35 @@ function addRefreshSubscriber(cb: () => void) {
   refreshSubscribers.push(cb);
 }
 
+async function attemptRefresh(): Promise<boolean> {
+  try {
+    const refreshResponse = await fetch(
+      `${getActiveInstanceBaseUrl()}/api/v1/auth/refresh`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          [CSRF_HEADER_NAME]: CSRF_HEADER_VALUE,
+        },
+        body: '{}',
+        credentials: 'include',
+      }
+    );
+    return refreshResponse.ok;
+  } catch {
+    return false;
+  }
+}
+
+function retryOriginalRequest(request: Request): Promise<Response> {
+  return fetch(new Request(request.url, {
+    method: request.method,
+    headers: request.headers,
+    body: request.bodyUsed ? undefined : request.body,
+    credentials: 'include',
+  }));
+}
+
 // ---------------------------------------------------------------------------
 // Response interceptor: 401 refresh + 403 SETUP_REQUIRED
 // ---------------------------------------------------------------------------
@@ -149,48 +182,28 @@ client.interceptors.response.use(async (response, request) => {
     // Another request is already refreshing -- wait for it, then retry
     return new Promise<Response>((resolve) => {
       addRefreshSubscriber(async () => {
-        const retried = await fetch(new Request(request.url, {
-          method: request.method,
-          headers: request.headers,
-          body: request.bodyUsed ? undefined : request.body,
-          credentials: 'include',
-        }));
-        resolve(retried);
+        resolve(await retryOriginalRequest(request));
       });
     });
   }
 
   isRefreshing = true;
 
-  try {
-    const refreshResponse = await fetch(
-      `${getActiveInstanceBaseUrl()}/api/v1/auth/refresh`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          [CSRF_HEADER_NAME]: CSRF_HEADER_VALUE,
-        },
-        body: '{}',
-        credentials: 'include',
-      }
+  let refreshed = await attemptRefresh();
+
+  // #558: Chromium can fire the first request(s) after a frozen tab
+  // reactivates before the cookie store reattaches, so the request -- and
+  // the refresh it triggers -- goes out without cookies and fails
+  // spuriously. When the tab only just became visible, wait a beat and try
+  // the refresh once more before concluding the session is really gone.
+  if (!refreshed && recentlyBecameVisible()) {
+    await new Promise((resolve) =>
+      setTimeout(resolve, UNFREEZE_REFRESH_RETRY_DELAY_MS)
     );
+    refreshed = await attemptRefresh();
+  }
 
-    if (!refreshResponse.ok) {
-      throw new Error('Refresh failed');
-    }
-
-    isRefreshing = false;
-    onTokenRefreshed();
-
-    // Retry the original request -- cookies are updated by the refresh response
-    return fetch(new Request(request.url, {
-      method: request.method,
-      headers: request.headers,
-      body: request.bodyUsed ? undefined : request.body,
-      credentials: 'include',
-    }));
-  } catch {
+  if (!refreshed) {
     isRefreshing = false;
     refreshSubscribers = [];
     if (!window.location.pathname.startsWith('/login')) {
@@ -198,6 +211,12 @@ client.interceptors.response.use(async (response, request) => {
     }
     return response;
   }
+
+  isRefreshing = false;
+  onTokenRefreshed();
+
+  // Retry the original request -- cookies are updated by the refresh response
+  return retryOriginalRequest(request);
 });
 
 export { client };

--- a/src/lib/tab-unfreeze.ts
+++ b/src/lib/tab-unfreeze.ts
@@ -1,0 +1,65 @@
+/**
+ * Tab-unfreeze mitigations for cookie-based auth (#558).
+ *
+ * Chromium can fire the first request(s) after a frozen tab reactivates
+ * BEFORE the cookie store reattaches. The request then goes out without a
+ * Cookie header and fails with a 401 even though the session cookies are
+ * still present. Two defenses live here:
+ *
+ * - `recentlyBecameVisible()` lets the 401 interceptor in sdk-client.ts
+ *   distinguish "session really expired" from "tab just unfroze" and retry
+ *   the token refresh once before redirecting to /login.
+ * - `initTabUnfreezeGuards()` fires a disposable warm-up request when the
+ *   tab becomes visible so the cookieless first request is absorbed by
+ *   /auth/me instead of a real data query (e.g. TanStack Query's
+ *   refetchOnWindowFocus).
+ */
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || '';
+
+/** How long after a visibilitychange→visible a failed refresh is suspect. */
+export const UNFREEZE_WINDOW_MS = 5_000;
+/** Delay before the retried refresh, giving the cookie store time to reattach. */
+export const UNFREEZE_REFRESH_RETRY_DELAY_MS = 500;
+/** Delay before the warm-up request after the tab becomes visible. */
+export const UNFREEZE_WARMUP_DELAY_MS = 150;
+
+let lastVisibleAt = 0;
+let initialized = false;
+
+/**
+ * True when the document became visible within the last UNFREEZE_WINDOW_MS.
+ * Used by the 401 interceptor to decide whether a failed token refresh is
+ * worth retrying once (#558).
+ */
+export function recentlyBecameVisible(): boolean {
+  return lastVisibleAt > 0 && Date.now() - lastVisibleAt < UNFREEZE_WINDOW_MS;
+}
+
+/**
+ * Register the visibilitychange tracking + warm-up request. Idempotent and
+ * a no-op on the server. Called once from the app root providers.
+ */
+export function initTabUnfreezeGuards(): void {
+  if (initialized) return;
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+  initialized = true;
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState !== 'visible') return;
+    lastVisibleAt = Date.now();
+
+    // Fire a disposable warm-up request so the cookieless first request
+    // after an unfreeze hits /auth/me (whose 401 the interceptor ignores)
+    // instead of a data query (#558). A failure here is fine — the real
+    // queries that follow carry the actual auth handling.
+    setTimeout(() => {
+      fetch(`${API_BASE_URL}/api/v1/auth/me`, {
+        method: 'GET',
+        credentials: 'include',
+      }).catch(() => {
+        // Disposable by design; swallow network errors and 401s.
+      });
+    }, UNFREEZE_WARMUP_DELAY_MS);
+  });
+}

--- a/src/providers/query-provider.tsx
+++ b/src/providers/query-provider.tsx
@@ -5,10 +5,17 @@ import {
   QueryClient,
   QueryClientProvider,
 } from "@tanstack/react-query";
-import { useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { invalidateGroup } from "@/lib/query-keys";
+import { initTabUnfreezeGuards } from "@/lib/tab-unfreeze";
 
 export function QueryProvider({ children }: { children: ReactNode }) {
+  // #558: absorb Chromium's cookieless first request after a frozen tab
+  // reactivates with a disposable warm-up call, and arm the refresh retry.
+  useEffect(() => {
+    initTabUnfreezeGuards();
+  }, []);
+
   const [queryClient] = useState(() => {
     const client = new QueryClient({
       mutationCache: new MutationCache({


### PR DESCRIPTION
Closes #558

## Summary
Chromium can fire the first request(s) after a frozen tab reactivates before the cookie store reattaches → cookieless request → 401 → cookieless refresh → hard redirect to /login. Two mitigation layers:

- **`src/lib/tab-unfreeze.ts`** (new): tracks the last `visibilitychange` → visible timestamp; fires a disposable warm-up `GET /api/v1/auth/me` 150ms after the tab becomes visible so the cookieless first request hits a disposable call instead of a data query.
- **`src/lib/sdk-client.ts`**: when a 401 refresh attempt fails *and* the tab only recently became visible (5s window), the refresh is retried once after 500ms before falling through to the existing /login redirect. All other paths unchanged (mutex/queue semantics, remote instances, auth endpoints).
- Wired app-wide via `QueryProvider` (SSR-safe, idempotent).

## Tests
New `tab unfreeze mitigation (#558)` block in `sdk-client.test.ts`: retry-then-succeed avoids redirect; no-recent-visibilitychange keeps immediate redirect; stale (>5s) visibilitychange doesn't retry; warm-up fires on visible only and swallows errors. Full suite: 173 files / 3197 tests pass; eslint clean.