### PR TITLE
fix(repositories): Maven GAVC parsing, download filenames, groupable formats, member-less virtual create

### DIFF
--- a/src/app/(app)/repositories/_components/__tests__/artifact-browser-toggle.test.tsx
+++ b/src/app/(app)/repositories/_components/__tests__/artifact-browser-toggle.test.tsx
@@ -7,6 +7,7 @@ import userEvent from "@testing-library/user-event";
 
 import {
   ArtifactBrowserToggle,
+  DOCKER_FAMILY_FORMATS,
   supportsGrouping,
   supportsTree,
 } from "../artifact-browser-toggle";
@@ -18,12 +19,17 @@ describe("supportsGrouping", () => {
   it.each<[RepositoryFormat, boolean]>([
     ["maven", true],
     ["gradle", true],
+    // The whole Docker family groups by tag (#418).
     ["docker", true],
+    ["podman", true],
+    ["buildx", true],
+    ["oras", true],
+    ["helm_oci", true],
+    ["wasm_oci", true],
     ["npm", false],
     ["pypi", false],
     ["helm", false],
     ["generic", false],
-    ["podman", false],
   ])("returns %s for %s repos", (format, expected) => {
     expect(supportsGrouping(format)).toBe(expected);
   });
@@ -113,6 +119,21 @@ describe("ArtifactBrowserToggle", () => {
       expect(screen.getByTestId("artifact-browser-toggle")).toBeInTheDocument();
     });
 
+    // #418: the grouped view is server-side `group_by=docker_tag`, which every
+    // Docker-family OCI registry supports — the toggle must render for each.
+    it.each([...DOCKER_FAMILY_FORMATS])(
+      "renders the toggle for Docker-family format %s",
+      (format) => {
+        render(
+          <ArtifactBrowserToggle value="flat" onChange={NOOP} format={format} />,
+        );
+        expect(
+          screen.getByTestId("artifact-browser-toggle"),
+        ).toBeInTheDocument();
+        expect(screen.getByTestId("toggle-grouped")).toBeInTheDocument();
+      },
+    );
+
     it("renders nothing for non-groupable formats (npm)", () => {
       const { container } = render(
         <ArtifactBrowserToggle value="flat" onChange={NOOP} format="npm" />,
@@ -147,14 +168,17 @@ describe("ArtifactBrowserToggle", () => {
       ).toBeInTheDocument();
     });
 
-    it('uses "Group by tag" for docker repos', () => {
-      render(
-        <ArtifactBrowserToggle value="flat" onChange={NOOP} format="docker" />,
-      );
-      expect(
-        screen.getByRole("button", { name: /group by tag/i }),
-      ).toBeInTheDocument();
-    });
+    it.each([...DOCKER_FAMILY_FORMATS])(
+      'uses "Group by tag" for Docker-family format %s',
+      (format) => {
+        render(
+          <ArtifactBrowserToggle value="flat" onChange={NOOP} format={format} />,
+        );
+        expect(
+          screen.getByRole("button", { name: /group by tag/i }),
+        ).toBeInTheDocument();
+      },
+    );
   });
 
   describe("aria-pressed reflects selected state", () => {

--- a/src/app/(app)/repositories/_components/artifact-browser-toggle.tsx
+++ b/src/app/(app)/repositories/_components/artifact-browser-toggle.tsx
@@ -9,14 +9,29 @@ import type { RepositoryFormat } from "@/types";
 export type ArtifactViewMode = "flat" | "grouped" | "tree";
 
 /**
- * Repository formats for which a "grouped" artifact view is meaningful.
- * Maven/Gradle use server-side `group_by=maven_component` (#254).  Docker
- * uses client-side aggregation by manifest tag (#330).
+ * Docker-family OCI registry formats (#418). They all expose the same
+ * manifest+blobs shape, so the server-side `group_by=docker_tag` rollup
+ * (#330, backend ak#1336) works for each of them — the grouped toggle and
+ * the grouped-view gate both key off this set.
  */
-const GROUPABLE_FORMATS = new Set<RepositoryFormat>([
+export const DOCKER_FAMILY_FORMATS = new Set<RepositoryFormat>([
+  "docker",
+  "podman",
+  "buildx",
+  "oras",
+  "helm_oci",
+  "wasm_oci",
+]);
+
+/**
+ * Repository formats for which a "grouped" artifact view is meaningful.
+ * Maven/Gradle use server-side `group_by=maven_component` (#254).  The
+ * Docker family uses server-side `group_by=docker_tag` (#330, #418).
+ */
+const GROUPABLE_FORMATS: ReadonlySet<RepositoryFormat> = new Set([
   "maven",
   "gradle",
-  "docker",
+  ...DOCKER_FAMILY_FORMATS,
 ]);
 
 /**
@@ -67,7 +82,7 @@ export function ArtifactBrowserToggle({
   // the folder-tree alternate.
   const altMode: ArtifactViewMode = groupable ? "grouped" : "tree";
   const altLabel = groupable
-    ? format === "docker"
+    ? DOCKER_FAMILY_FORMATS.has(format)
       ? "Group by tag"
       : "Group by component"
     : "Folder tree view";

--- a/src/app/(app)/repositories/_components/artifact-versions-section.tsx
+++ b/src/app/(app)/repositories/_components/artifact-versions-section.tsx
@@ -80,7 +80,9 @@ export function ArtifactVersionsSection({
     try {
       const link = document.createElement("a");
       link.href = href;
-      link.download = artifact.name;
+      // `name` can be a bare artifactId with no extension (Maven, #477); the
+      // real filename is the last path segment.
+      link.download = artifact.path.split("/").pop() || artifact.name;
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);

--- a/src/app/(app)/repositories/_components/repo-detail-content.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.test.tsx
@@ -210,6 +210,16 @@ vi.mock("./artifact-browser-toggle", () => ({
   ArtifactBrowserToggle: () => <div data-stub="ArtifactBrowserToggle" />,
   supportsGrouping: () => false,
   supportsTree: () => false,
+  // The real Docker-family set (#418): the grouped-view gate in
+  // repo-detail-content keys off it.
+  DOCKER_FAMILY_FORMATS: new Set([
+    "docker",
+    "podman",
+    "buildx",
+    "oras",
+    "helm_oci",
+    "wasm_oci",
+  ]),
 }));
 vi.mock("@/components/common/data-table", () => ({
   // Minimal row rendering so tests can open the artifact detail dialog via
@@ -501,6 +511,26 @@ describe("RepoDetailContent Docker grouped view (#330 / ak#1336)", () => {
     // The stub received the rollup rows from the response's docker_tags array.
     expect(screen.getByTestId("stub-tag-click")).toHaveTextContent("library/node:14");
   });
+
+  // #418: every Docker-family OCI format gates into the same server-side
+  // docker_tag rollup, not just plain `docker`.
+  it.each(["podman", "buildx", "oras", "helm_oci", "wasm_oci"])(
+    "requests group_by=docker_tag for Docker-family format %s",
+    async (format) => {
+      repository.format = format;
+      await renderDockerGrouped();
+
+      const lastKey = h.artifactsQueryKeys.at(-1) as unknown[];
+      expect(lastKey).toContain("grouped:docker");
+      // The useQuery mock records the queryFn without running it; run it to
+      // observe the request the component would actually issue.
+      h.artifactsQueryFns.at(-1)?.();
+      expect(artifactsApi.listGrouped).toHaveBeenCalledWith(
+        "demo",
+        expect.objectContaining({ group_by: "docker_tag" }),
+      );
+    },
+  );
 
   it("resolves a tag click to the manifest via its deterministic v2 path", async () => {
     await renderDockerGrouped();

--- a/src/app/(app)/repositories/_components/repo-detail-content.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.test.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import "@testing-library/jest-dom/vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, cleanup, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 // ---------------------------------------------------------------------------
@@ -27,6 +27,12 @@ const h = vi.hoisted(() => ({
   // Tests that assert on the *request parameters* (not just the query key)
   // invoke it themselves.
   artifactsQueryFns: [] as Array<() => unknown>,
+  // What the artifact-stats query (#472) returns; null simulates a failed or
+  // unavailable stats fetch.
+  artifactStats: null as {
+    download_count: number;
+    last_downloaded: string | null;
+  } | null,
 }));
 
 vi.mock("next/navigation", () => ({
@@ -95,6 +101,9 @@ vi.mock("@tanstack/react-query", () => ({
         isLoading: false,
         isFetching: false,
       };
+    }
+    if (key === "artifact-stats") {
+      return { data: h.artifactStats ?? undefined, isLoading: false, isFetching: false };
     }
     return { data: undefined, isLoading: false, isFetching: false };
   },
@@ -473,6 +482,56 @@ describe("RepoDetailContent flat view classifier column (#474)", () => {
     expect(table.getAttribute("data-columns")?.split(",")).not.toContain(
       "classifier",
     );
+  });
+});
+
+describe("RepoDetailContent artifact detail dialog — Last downloaded (#472)", () => {
+  beforeEach(() => {
+    cleanup();
+    repository.format = "generic";
+    h.artifactStats = null;
+  });
+  afterEach(() => {
+    cleanup();
+    repository.format = "generic";
+    h.artifactStats = null;
+  });
+
+  async function openDetailDialog() {
+    render(<RepoDetailContent repoKey="demo" />);
+    await userEvent.click(screen.getByRole("tab", { name: /artifacts/i }));
+    const row = await screen.findByTestId("stub-row-a1", {}, { timeout: 2000 });
+    row.click();
+    return await screen.findByRole("dialog", {}, { timeout: 2000 });
+  }
+
+  it("shows the last-downloaded timestamp when the stats endpoint provides one", async () => {
+    h.artifactStats = {
+      download_count: 3,
+      last_downloaded: "2026-08-01T12:30:00Z",
+    };
+    const dialog = await openDetailDialog();
+    expect(within(dialog).getByText("Last downloaded")).toBeInTheDocument();
+    expect(
+      within(dialog).getByText(
+        new Date("2026-08-01T12:30:00Z").toLocaleString(),
+      ),
+    ).toBeInTheDocument();
+    // The download count row from the artifact payload is kept.
+    expect(within(dialog).getByText("Downloads")).toBeInTheDocument();
+  });
+
+  it("hides the row when stats are unavailable (fetch failure / older backend)", async () => {
+    h.artifactStats = null;
+    const dialog = await openDetailDialog();
+    expect(within(dialog).queryByText("Last downloaded")).toBeNull();
+    expect(within(dialog).getByText("Downloads")).toBeInTheDocument();
+  });
+
+  it("hides the row when the artifact was never downloaded", async () => {
+    h.artifactStats = { download_count: 0, last_downloaded: null };
+    const dialog = await openDetailDialog();
+    expect(within(dialog).queryByText("Last downloaded")).toBeNull();
   });
 });
 

--- a/src/app/(app)/repositories/_components/repo-detail-content.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.test.tsx
@@ -223,7 +223,10 @@ vi.mock("@/components/common/data-table", () => ({
     columns?: Array<{ id: string; cell?: (row: unknown) => React.ReactNode }>;
     onRowClick?: (row: unknown) => void;
   }) => (
-    <div data-stub="DataTable">
+    <div
+      data-stub="DataTable"
+      data-columns={(columns ?? []).map((c) => c.id).join(",")}
+    >
       {(data ?? []).map((row) => (
         <button
           key={row.id}
@@ -428,6 +431,38 @@ describe("RepoDetailContent artifact detail dialog — Versions tab (#571)", () 
     repository.format = "maven";
     await openDetailDialog();
     expect(screen.queryByRole("tab", { name: /versions/i })).toBeNull();
+  });
+});
+
+describe("RepoDetailContent flat view classifier column (#474)", () => {
+  beforeEach(() => {
+    cleanup();
+  });
+  afterEach(() => {
+    cleanup();
+    repository.format = "generic";
+  });
+
+  async function renderArtifactsTab() {
+    render(<RepoDetailContent repoKey="demo" />);
+    await userEvent.click(screen.getByRole("tab", { name: /artifacts/i }));
+    return await screen.findByText("", { selector: '[data-stub="DataTable"]' });
+  }
+
+  it("adds a classifier/extension column for maven-family repos", async () => {
+    repository.format = "maven";
+    const table = await renderArtifactsTab();
+    expect(table.getAttribute("data-columns")?.split(",")).toContain(
+      "classifier",
+    );
+  });
+
+  it("omits the classifier column for non-Maven formats", async () => {
+    repository.format = "generic";
+    const table = await renderArtifactsTab();
+    expect(table.getAttribute("data-columns")?.split(",")).not.toContain(
+      "classifier",
+    );
   });
 });
 

--- a/src/app/(app)/repositories/_components/repo-detail-content.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.tsx
@@ -310,6 +310,15 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
     ? null
     : (fetchedQuarantine ?? selectedArtifact);
   const quarantineBlocked = isActivelyQuarantined(quarantine);
+  // Download stats for the detail dialog's "Last downloaded" row (#472).
+  // Best-effort: if the stats fetch fails (older backend, transient error)
+  // the row is simply hidden — the dialog itself is unaffected.
+  const { data: artifactStats } = useQuery({
+    queryKey: ["artifact-stats", selectedArtifactId],
+    queryFn: async () =>
+      selectedArtifactId ? await artifactsApi.getStats(selectedArtifactId) : null,
+    enabled: detailOpen && !!selectedArtifactId,
+  });
   // A rejection is terminal: the backend only accepts
   // `quarantined -> released|rejected`, so offering either on an already
   // rejected artifact would only ever produce a 409.
@@ -1343,6 +1352,14 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
                     label="Downloads"
                     value={selectedArtifact.download_count.toLocaleString()}
                   />
+                  {artifactStats?.last_downloaded && (
+                    <DetailRow
+                      label="Last downloaded"
+                      value={new Date(
+                        artifactStats.last_downloaded
+                      ).toLocaleString()}
+                    />
+                  )}
                   {quarantineBlocked && (
                     <>
                       <DetailRow

--- a/src/app/(app)/repositories/_components/repo-detail-content.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.tsx
@@ -47,7 +47,11 @@ import {
   ANALYZABLE_DISABLED_REASON,
   isArtifactAnalyzable,
 } from "@/lib/artifact-analyzable";
-import { buildPomDependencySnippet, parseMavenGav } from "@/lib/maven";
+import {
+  buildPomDependencySnippet,
+  mavenGavcFromMetadata,
+  parseMavenGav,
+} from "@/lib/maven";
 import { formatRelativeTimestamp, formatCacheExpiry } from "@/lib/cache-time";
 import type { Artifact } from "@/types";
 import type { UpsertScanConfigRequest } from "@/types/security";
@@ -1355,7 +1359,10 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
                     mono
                   />
                   {(repoFormat === "maven" || repoFormat === "gradle") && (
-                    <MavenGavSection path={selectedArtifact.path} />
+                    <MavenGavSection
+                      path={selectedArtifact.path}
+                      metadata={selectedArtifact.metadata}
+                    />
                   )}
                   {selectedArtifact.metadata &&
                     Object.keys(selectedArtifact.metadata).length > 0 && (
@@ -1582,12 +1589,23 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
 // -- detail row helper --
 
 /**
- * Maven GAV coordinates plus a copy/paste pom.xml dependency snippet, derived
- * from the artifact path. Shown in the artifact detail view for maven/gradle
- * repositories so users can identify the GAV and reuse it. (issue #442)
+ * Maven GAV coordinates plus a copy/paste pom.xml dependency snippet. Shown
+ * in the artifact detail view for maven/gradle repositories so users can
+ * identify the GAV and reuse it. (issue #442)
+ *
+ * The backend parses the coordinates (classifier included) once at upload
+ * time and stores them in `artifact.metadata`; prefer that over re-parsing
+ * the path client-side, falling back to `parseMavenGav` for backends that
+ * predate the stored form (#482).
  */
-function MavenGavSection({ path }: { path: string }) {
-  const gav = parseMavenGav(path);
+function MavenGavSection({
+  path,
+  metadata,
+}: {
+  path: string;
+  metadata?: Record<string, unknown>;
+}) {
+  const gav = mavenGavcFromMetadata(metadata) ?? parseMavenGav(path);
   if (!gav) return null;
   const snippet = buildPomDependencySnippet(gav);
   return (
@@ -1595,6 +1613,12 @@ function MavenGavSection({ path }: { path: string }) {
       <DetailRow label="Group ID" value={gav.groupId} copy mono />
       <DetailRow label="Artifact ID" value={gav.artifactId} copy mono />
       <DetailRow label="Version" value={gav.version} copy mono />
+      {gav.classifier && (
+        <DetailRow label="Classifier" value={gav.classifier} copy mono />
+      )}
+      {gav.extension && (
+        <DetailRow label="Extension" value={gav.extension} copy mono />
+      )}
       <div>
         <div className="mb-1 flex items-center justify-between">
           <p className="text-xs font-medium text-muted-foreground">

--- a/src/app/(app)/repositories/_components/repo-detail-content.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.tsx
@@ -454,11 +454,15 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
         return;
       }
       const url = artifactsApi.getDownloadUrl(repoKey, artifact.path);
+      // Maven artifacts store a bare artifactId as `name`, so saving under it
+      // drops the version and extension (#477). The real filename is the last
+      // path segment; fall back to `name` when the path is somehow empty.
+      const filename = artifact.path.split("/").pop() || artifact.name;
       try {
         const ticket = await artifactsApi.createDownloadTicket(repoKey, artifact.path);
         const link = document.createElement("a");
         link.href = `${url}?ticket=${ticket}`;
-        link.download = artifact.name;
+        link.download = filename;
         document.body.appendChild(link);
         link.click();
         document.body.removeChild(link);
@@ -466,7 +470,7 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
         // Fallback: try without ticket (backend may allow cookie auth)
         const link = document.createElement("a");
         link.href = url;
-        link.download = artifact.name;
+        link.download = filename;
         document.body.appendChild(link);
         link.click();
         document.body.removeChild(link);

--- a/src/app/(app)/repositories/_components/repo-detail-content.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.tsx
@@ -67,6 +67,7 @@ import { RepoLabelsPanel } from "./repo-labels-panel";
 import { PackagesTabContent } from "./packages-tab-content";
 import {
   ArtifactBrowserToggle,
+  DOCKER_FAMILY_FORMATS,
   supportsGrouping,
   supportsTree,
   type ArtifactViewMode,
@@ -220,7 +221,12 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
   const useServerGrouping =
     viewMode === "grouped" &&
     (repoFormat === "maven" || repoFormat === "gradle");
-  const isDockerGrouped = viewMode === "grouped" && repoFormat === "docker";
+  // The whole Docker family shares the OCI manifest+blobs layout, so the
+  // server-side docker_tag rollup applies to all of them (#418).
+  const isDockerGrouped =
+    viewMode === "grouped" &&
+    !!repoFormat &&
+    DOCKER_FAMILY_FORMATS.has(repoFormat);
   // Folder-tree view for RAW/Generic repos (#2791): the tree is grouped
   // client-side from the flat artifact list, so it needs the whole listing
   // on one page (bounded) rather than a paginated slice.
@@ -1019,7 +1025,11 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
           */}
           <div role="status" aria-live="polite" className="sr-only">
             {viewMode === "grouped"
-              ? `Showing grouped ${repoFormat === "docker" ? "tag" : "component"} view`
+              ? `Showing grouped ${
+                  repoFormat && DOCKER_FAMILY_FORMATS.has(repoFormat)
+                    ? "tag"
+                    : "component"
+                } view`
               : viewMode === "tree"
                 ? "Showing folder tree view"
                 : "Showing flat list view"}

--- a/src/app/(app)/repositories/_components/repo-detail-content.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.tsx
@@ -519,6 +519,14 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
   );
 
   // --- artifact columns ---
+  // Maven-family repos store many files per GAV that differ only by
+  // classifier and/or extension (`lib-1.0.jar` vs `lib-1.0-sources.jar` vs
+  // `lib-1.0.tar.gz`); the flat view could not tell them apart (#474). The
+  // coordinates come from the backend-parsed metadata when present, with the
+  // path parser as fallback (#482).
+  const isMavenFamily = repoFormat === "maven" || repoFormat === "gradle";
+  const artifactGavc = (a: Artifact) =>
+    mavenGavcFromMetadata(a.metadata) ?? parseMavenGav(a.path);
   const artifactColumns: DataTableColumn<Artifact>[] = [
     {
       id: "name",
@@ -586,6 +594,35 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
           <span className="text-xs text-muted-foreground">-</span>
         ),
     },
+    ...(isMavenFamily
+      ? [
+          {
+            id: "classifier",
+            header: "Classifier",
+            accessor: (a: Artifact) => artifactGavc(a)?.classifier ?? "",
+            cell: (a: Artifact) => {
+              const gavc = artifactGavc(a);
+              if (!gavc || (!gavc.classifier && !gavc.extension)) {
+                return <span className="text-xs text-muted-foreground">-</span>;
+              }
+              return (
+                <span className="flex items-center gap-1 text-xs">
+                  {gavc.classifier && (
+                    <Badge variant="outline" className="text-xs font-normal">
+                      {gavc.classifier}
+                    </Badge>
+                  )}
+                  {gavc.extension && (
+                    <span className="text-muted-foreground">
+                      {gavc.extension}
+                    </span>
+                  )}
+                </span>
+              );
+            },
+          } satisfies DataTableColumn<Artifact>,
+        ]
+      : []),
     {
       id: "size",
       header: "Size",

--- a/src/app/(app)/repositories/_components/repo-dialogs.test.tsx
+++ b/src/app/(app)/repositories/_components/repo-dialogs.test.tsx
@@ -1877,6 +1877,50 @@ describe('RepoDialogs - Upstream Auth Edge Cases', () => {
   });
 });
 
+describe('RepoDialogs - member-less virtual repo (#754)', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  // The backend rejects an explicit empty member list, so creating a
+  // member-less virtual repo must omit the member_repos key entirely.
+  it('omits member_repos when a virtual repo has no members selected', async () => {
+    const onCreateSubmit = vi.fn();
+    const user = userEvent.setup();
+    const localRepo = {
+      ...mockEditRepo,
+      key: 'local-1',
+      name: 'Local 1',
+      format: 'generic' as const,
+      repo_type: 'local' as const,
+    };
+
+    render(
+      <RepoDialogs
+        {...defaultProps}
+        onCreateSubmit={onCreateSubmit}
+        availableRepos={[localRepo]}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog');
+    const selects = within(dialog).getAllByTestId('mock-select');
+    fireEvent.change(selects[0], { target: { value: 'generic' } });
+    fireEvent.change(selects[1], { target: { value: 'virtual' } });
+
+    // No member checkbox selected — submit with an empty member list.
+    await user.type(within(dialog).getByPlaceholderText('my-repo'), 'my-virtual');
+    await user.type(within(dialog).getByPlaceholderText('My Repository'), 'My Virtual');
+    await user.click(within(dialog).getByRole('button', { name: /^create$/i }));
+
+    expect(onCreateSubmit).toHaveBeenCalledTimes(1);
+    const submitted = onCreateSubmit.mock.calls[0][0] as Record<string, unknown>;
+    expect(submitted.repo_type).toBe('virtual');
+    expect(submitted).not.toHaveProperty('member_repos');
+  });
+});
+
 describe('RepoDialogs - 1.6.0 format-specific config (#602)', () => {
   beforeEach(() => {
     cleanup();

--- a/src/app/(app)/repositories/_components/repo-dialogs.tsx
+++ b/src/app/(app)/repositories/_components/repo-dialogs.tsx
@@ -347,8 +347,18 @@ export function RepoDialogs({
                 format_key: selectedPlugin?.format_key,
                 quota_bytes: quotaToBytes(createQuotaValue, createQuotaUnit) ?? undefined,
                 upstream_url: createForm.repo_type === "remote" ? createForm.upstream_url : undefined,
-                member_repos: createForm.repo_type === "virtual" ? buildMemberRepos() : undefined,
               };
+              // #754: the backend rejects an *explicit* empty member list, so
+              // a member-less virtual repo must omit `member_repos` entirely
+              // (the spread above carries the form's own empty array — drop
+              // the key rather than send `[]`).
+              const memberRepos =
+                createForm.repo_type === "virtual" ? buildMemberRepos() : [];
+              if (memberRepos.length > 0) {
+                submitData.member_repos = memberRepos;
+              } else {
+                delete submitData.member_repos;
+              }
               if (createForm.repo_type === "remote" && upstreamAuthType !== "none") {
                 submitData.upstream_auth_type = upstreamAuthType;
                 if (upstreamAuthType === "basic") {

--- a/src/lib/__tests__/maven.test.ts
+++ b/src/lib/__tests__/maven.test.ts
@@ -22,7 +22,18 @@ describe("buildMavenSearchQuery", () => {
         classifier: "sources",
         extension: "jar",
       }),
-    ).toBe("org.junit.jupiter junit-jupiter-api 5.11.0 sources jar");
+    ).toBe("org junit jupiter junit-jupiter-api 5.11.0 sources jar");
+  });
+
+  it("splits a dotted groupId into separate terms (#475)", () => {
+    // The backend FTS vector tokenizes the artifact path on `/`, so the
+    // groupId is stored as one lexeme per segment; the dotted form as a
+    // single term can never match.
+    expect(buildMavenSearchQuery({ groupId: "com.example.team" })).toBe(
+      "com example team",
+    );
+    // A dotless groupId is a single term, unchanged.
+    expect(buildMavenSearchQuery({ groupId: "junit" })).toBe("junit");
   });
 
   it("skips empty and whitespace-only fields", () => {
@@ -33,13 +44,13 @@ describe("buildMavenSearchQuery", () => {
         version: "   ",
         classifier: undefined,
       }),
-    ).toBe("com.example");
+    ).toBe("com example");
   });
 
   it("trims surrounding whitespace from each field", () => {
     expect(
       buildMavenSearchQuery({ groupId: "  com.example  ", artifactId: " lib " }),
-    ).toBe("com.example lib");
+    ).toBe("com example lib");
   });
 
   it("strips a leading dot from the extension", () => {

--- a/src/lib/__tests__/maven.test.ts
+++ b/src/lib/__tests__/maven.test.ts
@@ -5,7 +5,9 @@ import {
   mavenFilePath,
   isPomFile,
   findPomFile,
+  parseMavenFilename,
   parseMavenGav,
+  mavenGavcFromMetadata,
   parseMavenPackageName,
   buildPomDependencySnippet,
 } from "../maven";
@@ -103,6 +105,62 @@ describe("findPomFile", () => {
   });
 });
 
+describe("parseMavenFilename", () => {
+  it("parses a plain artifact with no classifier", () => {
+    expect(parseMavenFilename("lib-1.0.jar", "lib", "1.0")).toEqual({
+      extension: "jar",
+    });
+  });
+
+  it("recovers the classifier from a classified artifact", () => {
+    expect(
+      parseMavenFilename("examplelib-1.0-sources.jar", "examplelib", "1.0"),
+    ).toEqual({ classifier: "sources", extension: "jar" });
+  });
+
+  it("keeps compound extensions whole (.tar.gz)", () => {
+    expect(parseMavenFilename("lib-1.0.tar.gz", "lib", "1.0")).toEqual({
+      extension: "tar.gz",
+    });
+    expect(parseMavenFilename("lib-1.0-bin.tar.gz", "lib", "1.0")).toEqual({
+      classifier: "bin",
+      extension: "tar.gz",
+    });
+  });
+
+  it("treats signature/checksum suffixes as extension, not classifier", () => {
+    expect(parseMavenFilename("lib-1.0.jar.asc", "lib", "1.0")).toEqual({
+      extension: "jar.asc",
+    });
+    expect(parseMavenFilename("lib-1.0.jar.sha256", "lib", "1.0")).toEqual({
+      extension: "jar.sha256",
+    });
+    expect(parseMavenFilename("lib-1.0-sources.jar.sha1", "lib", "1.0")).toEqual({
+      classifier: "sources",
+      extension: "jar.sha1",
+    });
+  });
+
+  it("handles versions that contain dots and dashes", () => {
+    expect(
+      parseMavenFilename("lib-2.0-SNAPSHOT-javadoc.jar", "lib", "2.0-SNAPSHOT"),
+    ).toEqual({ classifier: "javadoc", extension: "jar" });
+  });
+
+  it("returns undefined when the filename does not match the GAV prefix", () => {
+    expect(
+      parseMavenFilename("other-1.0.jar", "lib", "1.0"),
+    ).toBeUndefined();
+    // Timestamped snapshot filename against a -SNAPSHOT version.
+    expect(
+      parseMavenFilename("lib-1.0-20240101.123456-1.jar", "lib", "1.0-SNAPSHOT"),
+    ).toBeUndefined();
+    // No extension at all.
+    expect(parseMavenFilename("lib-1.0", "lib", "1.0")).toBeUndefined();
+    expect(parseMavenFilename("lib-1.0-", "lib", "1.0")).toBeUndefined();
+  });
+});
+
 describe("parseMavenGav", () => {
   it("parses a standard Maven layout path", () => {
     expect(
@@ -113,18 +171,89 @@ describe("parseMavenGav", () => {
       groupId: "org.junit.jupiter",
       artifactId: "junit-jupiter-api",
       version: "5.11.0",
+      extension: "jar",
+    });
+  });
+
+  it("recovers classifier and extension from the filename (#482)", () => {
+    expect(
+      parseMavenGav("com/example/examplelib/1.0/examplelib-1.0-sources.jar"),
+    ).toEqual({
+      groupId: "com.example",
+      artifactId: "examplelib",
+      version: "1.0",
+      classifier: "sources",
+      extension: "jar",
+    });
+    expect(
+      parseMavenGav("com/example/lib/1.0/lib-1.0.tar.gz"),
+    ).toEqual({
+      groupId: "com.example",
+      artifactId: "lib",
+      version: "1.0",
+      extension: "tar.gz",
     });
   });
 
   it("tolerates a leading slash", () => {
     expect(
       parseMavenGav("/com/example/lib/1.0/lib-1.0.jar"),
-    ).toEqual({ groupId: "com.example", artifactId: "lib", version: "1.0" });
+    ).toEqual({
+      groupId: "com.example",
+      artifactId: "lib",
+      version: "1.0",
+      extension: "jar",
+    });
   });
 
   it("returns undefined for non-Maven paths", () => {
     expect(parseMavenGav("lib.jar")).toBeUndefined();
     expect(parseMavenGav("a/b/c")).toBeUndefined();
+  });
+});
+
+describe("mavenGavcFromMetadata", () => {
+  it("reads the backend-parsed GAVC from artifact metadata (#482)", () => {
+    expect(
+      mavenGavcFromMetadata({
+        groupId: "com.example",
+        artifactId: "examplelib",
+        version: "1.0",
+        classifier: "sources",
+        extension: "jar",
+      }),
+    ).toEqual({
+      groupId: "com.example",
+      artifactId: "examplelib",
+      version: "1.0",
+      classifier: "sources",
+      extension: "jar",
+    });
+  });
+
+  it("omits absent classifier/extension", () => {
+    expect(
+      mavenGavcFromMetadata({
+        groupId: "com.example",
+        artifactId: "lib",
+        version: "1.0",
+      }),
+    ).toEqual({ groupId: "com.example", artifactId: "lib", version: "1.0" });
+  });
+
+  it("returns undefined when metadata is missing or not Maven-shaped", () => {
+    expect(mavenGavcFromMetadata(undefined)).toBeUndefined();
+    expect(mavenGavcFromMetadata({})).toBeUndefined();
+    expect(
+      mavenGavcFromMetadata({ groupId: "com.example", artifactId: "lib" }),
+    ).toBeUndefined();
+    expect(
+      mavenGavcFromMetadata({
+        groupId: 42,
+        artifactId: "lib",
+        version: "1.0",
+      }),
+    ).toBeUndefined();
   });
 });
 
@@ -142,6 +271,26 @@ describe("buildPomDependencySnippet", () => {
         "  <groupId>org.junit.jupiter</groupId>",
         "  <artifactId>junit-jupiter-api</artifactId>",
         "  <version>5.11.0</version>",
+        "</dependency>",
+      ].join("\n"),
+    );
+  });
+
+  it("includes a <classifier> element when the coordinate has one (#482)", () => {
+    expect(
+      buildPomDependencySnippet({
+        groupId: "com.example",
+        artifactId: "examplelib",
+        version: "1.0",
+        classifier: "sources",
+      }),
+    ).toBe(
+      [
+        "<dependency>",
+        "  <groupId>com.example</groupId>",
+        "  <artifactId>examplelib</artifactId>",
+        "  <version>1.0</version>",
+        "  <classifier>sources</classifier>",
         "</dependency>",
       ].join("\n"),
     );

--- a/src/lib/api/__tests__/artifacts.test.ts
+++ b/src/lib/api/__tests__/artifacts.test.ts
@@ -9,11 +9,13 @@ vi.mock("@/lib/sdk-client", () => ({
 const mockListArtifacts = vi.fn();
 const mockDeleteArtifact = vi.fn();
 const mockCreateDownloadTicket = vi.fn();
+const mockGetArtifactStats = vi.fn();
 
 vi.mock("@artifact-keeper/sdk", () => ({
   listArtifacts: (...args: unknown[]) => mockListArtifacts(...args),
   deleteArtifact: (...args: unknown[]) => mockDeleteArtifact(...args),
   createDownloadTicket: (...args: unknown[]) => mockCreateDownloadTicket(...args),
+  getArtifactStats: (...args: unknown[]) => mockGetArtifactStats(...args),
 }));
 
 describe("artifactsApi", () => {
@@ -716,6 +718,27 @@ describe("artifactsApi", () => {
     expect(mockCreateDownloadTicket).toHaveBeenCalledWith({
       body: { purpose: "download", resource_path: expectedPath },
     });
+  });
+
+  // ---- getStats (#472) ----
+
+  it("getStats returns download stats for the artifact", async () => {
+    const stats = {
+      artifact_id: "a1",
+      download_count: 7,
+      first_downloaded: "2026-07-01T00:00:00Z",
+      last_downloaded: "2026-08-01T12:30:00Z",
+    };
+    mockGetArtifactStats.mockResolvedValue({ data: stats, error: undefined });
+    const { artifactsApi } = await import("../artifacts");
+    await expect(artifactsApi.getStats("a1")).resolves.toEqual(stats);
+    expect(mockGetArtifactStats).toHaveBeenCalledWith({ path: { id: "a1" } });
+  });
+
+  it("getStats throws on error", async () => {
+    mockGetArtifactStats.mockResolvedValue({ data: undefined, error: "fail" });
+    const { artifactsApi } = await import("../artifacts");
+    await expect(artifactsApi.getStats("a1")).rejects.toBe("fail");
   });
 
   // ---- upload() via XMLHttpRequest ----

--- a/src/lib/api/artifacts.ts
+++ b/src/lib/api/artifacts.ts
@@ -3,10 +3,12 @@ import {
   listArtifacts,
   deleteArtifact,
   createDownloadTicket,
+  getArtifactStats,
 } from '@artifact-keeper/sdk';
 import type {
   ArtifactResponse,
   ArtifactListResponse,
+  ArtifactStatsResponse,
 } from '@artifact-keeper/sdk';
 import { getActiveInstanceBaseUrl } from '@/lib/sdk-client';
 import type {
@@ -235,6 +237,16 @@ export const artifactsApi = {
 
   getDownloadUrl: (repoKey: string, artifactPath: string): string => {
     return `/api/v1/repositories/${repoKey}/download/${artifactPath}`;
+  },
+
+  /**
+   * Download statistics for one artifact (issue #472): download count plus
+   * first/last download timestamps. The artifact detail dialog renders the
+   * "Last downloaded" row from this; a fetch failure simply hides the row.
+   */
+  getStats: async (artifactId: string): Promise<ArtifactStatsResponse> => {
+    const data = await unwrap(getArtifactStats({ path: { id: artifactId } }));
+    return assertData(data, 'artifactsApi.getStats');
   },
 
   /**

--- a/src/lib/maven.ts
+++ b/src/lib/maven.ts
@@ -96,25 +96,108 @@ export function findPomFile(filenames: string[]): string | undefined {
 }
 
 /**
+ * Full Maven coordinates for one file: the GAV plus the optional classifier
+ * and the file extension (GAVC).
+ */
+export interface MavenGavc {
+  groupId: string;
+  artifactId: string;
+  version: string;
+  classifier?: string;
+  extension?: string;
+}
+
+/**
+ * Split a Maven filename into its classifier and extension, given the
+ * artifactId and version it was deployed under (issue #482).
+ *
+ * Maven filenames follow `<artifactId>-<version>[-<classifier>].<ext>`, so
+ * once the known `<artifactId>-<version>` prefix is stripped, whatever
+ * remains before the first dot is the classifier and everything after it is
+ * the extension. Keeping the whole tail as the extension handles the two
+ * gotchas called out in the issue:
+ *
+ * - compound extensions: `lib-1.0.tar.gz`        -> extension `tar.gz`
+ * - signature/checksum files: `lib-1.0.jar.asc`  -> extension `jar.asc`
+ *   (the `.asc`/`.sha256`/… suffix extends the extension; it is never a
+ *   classifier)
+ *
+ * Returns `undefined` when the filename does not start with the expected
+ * prefix (e.g. a timestamped snapshot filename against a `-SNAPSHOT`
+ * version, or a non-Maven file).
+ */
+export function parseMavenFilename(
+  filename: string,
+  artifactId: string,
+  version: string,
+): { classifier?: string; extension: string } | undefined {
+  const prefix = `${artifactId}-${version}`;
+  if (!filename.startsWith(prefix)) return undefined;
+  const rest = filename.slice(prefix.length);
+
+  if (rest.startsWith(".")) {
+    const extension = rest.slice(1);
+    return extension ? { extension } : undefined;
+  }
+  if (rest.startsWith("-")) {
+    const dot = rest.indexOf(".");
+    const classifier = rest.slice(1, dot === -1 ? rest.length : dot);
+    const extension = dot === -1 ? "" : rest.slice(dot + 1);
+    if (!classifier || !extension) return undefined;
+    return { classifier, extension };
+  }
+  return undefined;
+}
+
+/**
  * Parse GAV coordinates out of a Maven artifact path. Returns `undefined` when
  * the path does not look like a Maven layout (fewer than four segments). The
  * version is the second-to-last segment and the artifactId the one before it;
- * everything earlier is the dotted groupId.
+ * everything earlier is the dotted groupId. The classifier and extension are
+ * recovered from the filename via `parseMavenFilename` when it matches the
+ * `<artifactId>-<version>` prefix (#482).
  *
  *   org/junit/jupiter/junit-jupiter-api/5.11.0/junit-jupiter-api-5.11.0.jar
- *     -> { groupId: org.junit.jupiter, artifactId: junit-jupiter-api, version: 5.11.0 }
+ *     -> { groupId: org.junit.jupiter, artifactId: junit-jupiter-api, version: 5.11.0, extension: jar }
  */
-export function parseMavenGav(
-  path: string,
-): { groupId: string; artifactId: string; version: string } | undefined {
+export function parseMavenGav(path: string): MavenGavc | undefined {
   const segments = path.split("/").filter(Boolean);
   if (segments.length < 4) return undefined;
   // Last segment is the filename; the two before it are version and artifactId.
+  const filename = segments[segments.length - 1];
   const version = segments[segments.length - 2];
   const artifactId = segments[segments.length - 3];
   const groupId = segments.slice(0, segments.length - 3).join(".");
   if (!groupId || !artifactId || !version) return undefined;
-  return { groupId, artifactId, version };
+  return { groupId, artifactId, version, ...parseMavenFilename(filename, artifactId, version) };
+}
+
+/**
+ * Read the GAVC coordinates the backend parsed at upload time out of
+ * `artifact.metadata` (`groupId`/`artifactId`/`version`/`extension`/
+ * `classifier`). Preferring this over re-parsing the path in the UI is the
+ * fix called for in #482; callers should fall back to `parseMavenGav` when
+ * the backend stored nothing (older server, non-Maven upload path).
+ */
+export function mavenGavcFromMetadata(
+  metadata: Record<string, unknown> | undefined,
+): MavenGavc | undefined {
+  if (!metadata) return undefined;
+  const { groupId, artifactId, version, classifier, extension } = metadata;
+  if (
+    typeof groupId !== "string" || !groupId ||
+    typeof artifactId !== "string" || !artifactId ||
+    typeof version !== "string" || !version
+  ) {
+    return undefined;
+  }
+  return {
+    groupId,
+    artifactId,
+    version,
+    ...(typeof classifier === "string" && classifier ? { classifier } : {}),
+    ...(typeof extension === "string" && extension ? { extension } : {}),
+  };
 }
 
 /**
@@ -151,18 +234,22 @@ export function parseMavenPackageName(name: string): {
 /**
  * Render a copy/paste-ready `<dependency>` snippet for a pom.xml. Used in the
  * artifact detail view so users can drop a Maven coordinate straight into
- * their build (issue #442).
+ * their build (issue #442). The optional classifier is included when known
+ * (#482) — a classified artifact (sources, javadoc, native builds, …) cannot
+ * be depended on without it.
  */
 export function buildPomDependencySnippet(gav: {
   groupId: string;
   artifactId: string;
   version: string;
+  classifier?: string;
 }): string {
   return [
     "<dependency>",
     `  <groupId>${gav.groupId}</groupId>`,
     `  <artifactId>${gav.artifactId}</artifactId>`,
     `  <version>${gav.version}</version>`,
+    ...(gav.classifier ? [`  <classifier>${gav.classifier}</classifier>`] : []),
     "</dependency>",
   ].join("\n");
 }

--- a/src/lib/maven.ts
+++ b/src/lib/maven.ts
@@ -28,12 +28,12 @@ export interface MavenGavcQuery {
  *
  * The backend advanced-search endpoint matches a single `query` string against
  * a text vector built from each artifact's name, path, and version. Maven
- * coordinates are encoded in the path (dotted groupIds become path segments,
- * which the tokenizer splits the same way it splits the dotted form), so
- * feeding the coordinates in as space-separated terms lets the full-text
- * search prefix-match every supplied component. Empty fields are skipped, and
- * a leading dot on the extension is stripped so `.jar` and `jar` behave the
- * same.
+ * coordinates are encoded in the path, where the tokenizer splits on `/` —
+ * so a dotted groupId is stored as *separate* lexemes (`org`, `junit`,
+ * `jupiter`), and pushing the dotted form as one term never matches (#475).
+ * The groupId is therefore split on `.` into separate AND-ed terms; the
+ * remaining fields go in as-is. Empty fields are skipped, and a leading dot
+ * on the extension is stripped so `.jar` and `jar` behave the same.
  */
 export function buildMavenSearchQuery(q: MavenGavcQuery): string {
   const terms: string[] = [];
@@ -42,7 +42,9 @@ export function buildMavenSearchQuery(q: MavenGavcQuery): string {
     if (value) terms.push(value);
   };
 
-  push(q.groupId);
+  for (const segment of q.groupId?.trim().split(".") ?? []) {
+    push(segment);
+  }
   push(q.artifactId);
   push(q.version);
   push(q.classifier);


### PR DESCRIPTION
Fixes #477, fixes #482, fixes #474, fixes #475, fixes #418, fixes #754, and the web half of #472 (last-downloaded; uploader waits on artifact-keeper/artifact-keeper#3271). One commit per issue.

## What changed

- **#477** — downloads derive their filename from the last segment of `artifact.path` instead of the bare-artifactId `name`, so Maven downloads keep their extension (also fixes the revision download in the versions section).
- **#482** — new classifier-aware `parseMavenFilename` + full `MavenGavc` from `parseMavenGav`; `MavenGavSection` prefers the backend-parsed `artifact.metadata` (groupId/artifactId/version/extension/classifier) with path-parse fallback; `buildPomDependencySnippet` emits `<classifier>` when present.
- **#474** — flat artifact table gains a Classifier column (maven/gradle repos only), badge + compound-aware extension, so same-GAV files are distinguishable.
- **#475** — `buildMavenSearchQuery` splits the dotted groupId into separate AND-ed terms, matching how the backend FTS vector tokenizes the path on `/`. GAV search now matches.
- **#418** — shared `DOCKER_FAMILY_FORMATS` ({docker, podman, buildx, oras, helm_oci, wasm_oci}) drives both the Group toggle and the `group_by=docker_tag` request gate, consistent with the e2e expectation.
- **#754** — the create-repo dialog omits `member_repos` entirely when no members are selected, so member-less virtual repos can be created (backend rejects an explicit `[]`).
- **#472 (web half)** — the artifact detail dialog fetches `GET /api/v1/artifacts/{id}/stats` on open and shows a Last downloaded row when available (hidden on fetch failure / never downloaded).

## Tests
3237 unit tests green (173 files), incl. ~40 new cases across maven.test.ts, repo-detail-content.test.tsx, repo-dialogs.test.tsx, artifacts.test.ts, artifact-browser-toggle tests. eslint clean; tsc shows only the 22 pre-existing unrelated errors.