### PR TITLE
ci: fix Mergify Dependabot auto-merge check names and skip linked-issue check for bots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,8 +490,24 @@ jobs:
       - name: Verify every E2E suite succeeded
         env:
           E2E_RESULTS: ${{ join(needs.*.result, ' ') }}
+          # Keep in step with the `needs:` list above. Asserting the count
+          # makes dropping a suite from `needs:` a hard error instead of a
+          # quietly weaker gate.
+          EXPECTED_SUITES: 4
         run: |
           echo "E2E suite results: ${E2E_RESULTS}"
+          # Without this the loop below would pass over an empty list, so a
+          # `needs:` list that was emptied or mistyped would report a green
+          # E2E having verified nothing. That is the #752 bug class again.
+          if [ -z "${E2E_RESULTS}" ]; then
+            echo "::error::No E2E suite results. The needs: list is empty."
+            exit 1
+          fi
+          actual=$(echo "${E2E_RESULTS}" | wc -w | tr -d ' ')
+          if [ "${actual}" -ne "${EXPECTED_SUITES}" ]; then
+            echo "::error::Expected ${EXPECTED_SUITES} E2E suite results, got ${actual} (${E2E_RESULTS}). Update EXPECTED_SUITES if a suite was added or removed on purpose."
+            exit 1
+          fi
           for result in ${E2E_RESULTS}; do
             if [ "${result}" != "success" ]; then
               echo "::error::Not every E2E suite succeeded (${E2E_RESULTS})"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -474,6 +474,32 @@ jobs:
           path: playwright-report/
           retention-days: 7
 
+  # Single aggregate status for the whole E2E fan-out. The suites above are
+  # sharded and get renamed as suites are added, so anything that wants to
+  # gate on "did E2E pass" (Mergify, branch protection) should reference this
+  # stable `E2E` check instead of enumerating shard names. See issue #752.
+  #
+  # e2e-docs-export is deliberately excluded: it only runs on main, so it is
+  # always skipped on pull requests.
+  e2e:
+    name: E2E
+    if: always()
+    needs: [e2e-interactions, e2e-roles, e2e-visual, e2e-docker-proxy]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify every E2E suite succeeded
+        env:
+          E2E_RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          echo "E2E suite results: ${E2E_RESULTS}"
+          for result in ${E2E_RESULTS}; do
+            if [ "${result}" != "success" ]; then
+              echo "::error::Not every E2E suite succeeded (${E2E_RESULTS})"
+              exit 1
+            fi
+          done
+          echo "All E2E suites succeeded."
+
   e2e-docs-export:
     name: E2E Docs Screenshot Export
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -18,6 +18,12 @@ concurrency:
 jobs:
   require-linked-issue:
     name: Require linked issue in PR body
+    # Bot-authored PRs (Dependabot and friends) have machine-generated bodies
+    # that never link an issue, so this check failed on every one of them and
+    # made otherwise-green PRs look red. Skipping reports a neutral status
+    # rather than a failure. The requirement is unchanged for human-authored
+    # PRs. See #752.
+    if: github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
     steps:
       - name: Check PR body for linked issue

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -18,12 +18,6 @@ concurrency:
 jobs:
   require-linked-issue:
     name: Require linked issue in PR body
-    # Bot-authored PRs (Dependabot and friends) have machine-generated bodies
-    # that never link an issue, so this check failed on every one of them and
-    # made otherwise-green PRs look red. Skipping reports a neutral status
-    # rather than a failure. The requirement is unchanged for human-authored
-    # PRs. See #752.
-    if: github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
     steps:
       - name: Check PR body for linked issue
@@ -32,10 +26,25 @@ jobs:
           script: |
             const BOT_MARKER = '<!-- require-linked-issue-bot -->';
             const BYPASS_LABEL = 'no-issue-required';
+            // Dependabot writes its own PR bodies and never links an issue, so
+            // this check failed on every one of its PRs and made otherwise-green
+            // PRs look red (#752). Exempt it by login rather than by
+            // `user.type === 'Bot'`, which would exempt every GitHub App.
+            const EXEMPT_AUTHORS = ['dependabot[bot]'];
 
             const pr = context.payload.pull_request;
             if (!pr) {
               core.setFailed('This workflow must run on pull_request events.');
+              return;
+            }
+
+            // Returning here reports success rather than skipping the job. A
+            // job-level `if:` would report `skipped`, which Mergify's
+            // `check-success` does not match, so adding this check to
+            // .mergify.yml later would silently stall every exempt PR.
+            const author = (pr.user && pr.user.login) || '';
+            if (EXEMPT_AUTHORS.includes(author)) {
+              core.info(`Author "${author}" is exempt from the linked-issue requirement; skipping check.`);
               return;
             }
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,21 +2,54 @@ queue_rules:
   - name: default
     merge_method: squash
     update_method: rebase
+    # Conditions on the pull_request_rule below gate ENTRY into the queue.
+    # These gate the merge itself, after the queue rebases and CI re-runs.
+    # Without them the final merge is gated only by branch protection, which
+    # is Build/Lint/Unit Tests and does not include E2E, so a rebase that
+    # broke E2E would still merge. See #752.
+    merge_conditions:
+      - check-success=Lint
+      - check-success=Unit Tests
+      - check-success=Build
+      - check-success=E2E
+      - check-success=dependency-review
 
 pull_request_rules:
   - name: Auto-merge Dependabot patch updates
     conditions:
       - author=dependabot[bot]
-      - "-title~=major"
+      # Gate on Dependabot's own update-type metadata rather than the PR
+      # title. Dependabot never writes "major" into its titles, so the old
+      # `-title~=major` guard matched every major bump and excluded nothing.
+      # It was inert only because the check-success conditions below could
+      # never pass. See #752.
+      #
+      # This rule is named "patch updates" but has only ever excluded major,
+      # so patch and minor both stay eligible here. Narrowing to patch-only
+      # is a policy call for the maintainer, not a drive-by change.
+      #
+      # dependabot-update-type is a list: a grouped update carries one entry
+      # per dependency. Both halves are needed, since a group containing a
+      # patch and a major would satisfy the first condition on its own.
+      - or:
+          - dependabot-update-type=version-update:semver-patch
+          - dependabot-update-type=version-update:semver-minor
+      - -dependabot-update-type=version-update:semver-major
       # Check names are case-sensitive exact matches against the job `name:`
-      # in .github/workflows/ci.yml. `E2E` is the aggregate job that rolls up
-      # every E2E suite, so shard renames do not silently disable this rule.
-      # See #752.
+      # in the workflow, or the job id where no name is set. `E2E` is the
+      # aggregate job that rolls up every E2E suite, so shard renames do not
+      # silently disable this rule.
       - check-success=Lint
       - check-success=Unit Tests
       - check-success=Build
-      - check-success=Dependency Audit
       - check-success=E2E
+      # dependency-review scans only the dependencies this PR introduces and
+      # fails on high severity. Deliberately not `Dependency Audit`: that job
+      # runs `npm audit` across the whole installed tree, so one unrelated
+      # transitive advisory would block every Dependabot PR, including the
+      # bump that would fix it. It is also not in branch protection, so
+      # requiring it would hold bots to a stricter bar than humans.
+      - check-success=dependency-review
       - "#approved-reviews-by>=1"
       # Scope auto-merge to PRs targeting main only. Maintenance branches
       # (release/1.1.x and similar) overwrite floating dev tags on push,
@@ -30,7 +63,9 @@ pull_request_rules:
   - name: Flag Dependabot major updates
     conditions:
       - author=dependabot[bot]
-      - "title~=major"
+      # Same fix as above: `title~=major` never matched, so no Dependabot
+      # major bump has ever been labelled. See #752.
+      - dependabot-update-type=version-update:semver-major
     actions:
       label:
         add:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,9 +8,15 @@ pull_request_rules:
     conditions:
       - author=dependabot[bot]
       - "-title~=major"
-      - check-success=lint
-      - check-success=build
-      - check-success=e2e
+      # Check names are case-sensitive exact matches against the job `name:`
+      # in .github/workflows/ci.yml. `E2E` is the aggregate job that rolls up
+      # every E2E suite, so shard renames do not silently disable this rule.
+      # See #752.
+      - check-success=Lint
+      - check-success=Unit Tests
+      - check-success=Build
+      - check-success=Dependency Audit
+      - check-success=E2E
       - "#approved-reviews-by>=1"
       # Scope auto-merge to PRs targeting main only. Maintenance branches
       # (release/1.1.x and similar) overwrite floating dev tags on push,


### PR DESCRIPTION
## Summary

Closes #752

The Mergify rule "Auto-merge Dependabot patch updates" required `check-success=lint`, `check-success=build` and `check-success=e2e`. Mergify matches check names as case-sensitive exact strings, and no CI job produces any of those three names, so the rule could never fire.

Fixing that turned out to expose a second, more serious bug in the same rule, described under "Version guard" below. Both are fixed here.

### Check names verified against a live run

Names derived from the workflows (job `name:` if set, otherwise job id) and confirmed against a real `pull_request` run, `gh run view 31424267560 --json jobs`:

`Lint`, `Dependency Audit`, `Unit Tests`, `Build`, `E2E Interactions (shard 1/3 .. 3/3)`, `E2E RBAC Roles`, `E2E Visual Regression`, `E2E Docker /v2/* Header Forwarding`, plus `dependency-review` from `dependency-review.yml`, and `Docker (...)`, `Create Multi-Arch Manifest` and `E2E Docs Screenshot Export` which are skipped on PRs.

Branch protection on `main` requires exactly `["Build", "Lint", "Unit Tests"]` (`gh api repos/.../branches/main/protection`).

### Version guard: the rule had no working protection against major bumps

`-title~=major` was the rule's only defence against major version bumps, and it never matched anything. Dependabot does not put the word "major" in its PR titles.

- 0 of the last 100 Dependabot PR titles in this repo match `/major/i`.
- All four currently open Dependabot PRs are major bumps: framer-motion 12 to 13 (#761), jsdom 29 to 30 (#726), @types/node 25 to 26 (#723), typescript 6 to 7 (#720).
- None carries a `major-update` label, which also proves the sibling "Flag Dependabot major updates" rule (`title~=major`) has never fired either.

This was inert only because the rule could never fire at all. Correcting the check names makes it live, so without this fix, merging this PR would mean one approval on `typescript 6.0.3 -> 7.0.2` queues and squash-merges it into `main`, which publishes Docker images on every push.

Both rules now use Dependabot's own metadata. Confirmed against the actual commit trailers on those four PRs, each of which reads `update-type: version-update:semver-major`:

```yaml
- or:
    - dependabot-update-type=version-update:semver-patch
    - dependabot-update-type=version-update:semver-minor
- -dependabot-update-type=version-update:semver-major
```

`dependabot-update-type` is a list attribute (a grouped update carries one entry per dependency), so it is checked in both directions. The positive half alone would let a group containing both a patch and a major through, since the list would still contain a patch entry. This repo does group `github/codeql-action*` today, so that is a live concern, not hypothetical.

**Naming discrepancy for a maintainer to settle**: the rule is called "patch updates" but its conditions have only ever excluded major, meaning patch *and* minor. I preserved that existing intent rather than silently narrowing to patch-only. If patch-only was the real intent, drop the `semver-minor` line and rename accordingly.

### E2E: aggregate job (option a)

The issue offered two options. I took option (a), a single aggregate `E2E` job:

- Dropping the E2E condition would genuinely lose coverage. No E2E check is in branch protection, so the merge queue would merge a dependency bump with red E2E.
- The usual argument for dropping it, that requiring E2E will stall Dependabot again, does not hold here: E2E passed in 12 of the last 12 `pull_request` CI runs with no flakes.
- Enumerating the six individual E2E check names was considered and rejected. It maximises the drift surface that caused this bug: the shard count is a config value, and when the matrix is skipped GitHub reports a single check under the unexpanded name `E2E Interactions (shard ${{ matrix.shard }}/3)` (observed in run 31366897555's sibling, run 31366826244).

The job runs `if: always()`, requires every dependency result to be exactly `success`, and additionally fails on an empty result list and asserts the expected suite count. Without those last two it would pass over an empty `needs:` list, so a later rename or typo would produce a green `E2E` that verified nothing, which is the #752 bug class relocated into `ci.yml`. `e2e-docs-export` is excluded because it only runs on `main`.

**Correction to an earlier version of this description**: I previously wrote that visual regression catches what dependency bumps break. It does not. `ci.yml` runs the visual suite with `--update-snapshots`, so it rewrites baselines rather than comparing, and all 31 committed baselines are `*-darwin.png` while CI runs on ubuntu, which expects `*-linux.png`. That job cannot currently fail on a visual diff. Filed separately as #781 and deliberately not fixed here. The E2E justification still stands on RBAC roles, the interaction shards and the Docker `/v2/*` header-forwarding proxy, which do really compare behaviour.

### `dependency-review` rather than `Dependency Audit`

`Dependency Audit` runs `npm audit --audit-level=high` across the whole installed tree, not the PR diff. Requiring it would mean one unrelated transitive advisory blocks every Dependabot auto-merge, including the bump that would fix it, which is the same stall class this issue is about. It is also not in branch protection, so humans merge through a red audit freely, and requiring it would hold bots to a stricter bar than humans.

`dependency-review.yml` already scopes to dependencies the PR introduces with `fail-on-severity: high`. Its check name is `dependency-review` (job id, no `name:` set), confirmed on this PR's own run.

### Merge queue gap closed

`queue_rules.default` had no `merge_conditions`, so `check-success` gated queue *entry* only. After queueing, Mergify rebases (`update_method: rebase`), CI re-runs, and the final merge was gated by branch protection alone, which has no E2E. The scenario used to justify option (a) was therefore still reachable. Added `merge_conditions` to the queue rule so the merge itself is gated too. This is in-repo config and needs no branch-protection admin change.

### Linked-issue check on Dependabot PRs

Exempts Dependabot with an early `return` inside the existing `github-script` step, next to the `BYPASS_LABEL` early return, rather than a job-level `if:`.

An early return reports `success`; a job-level skip reports `skipped`. For GitHub branch protection that distinction would not matter, since required status checks accept `successful`, `skipped` or `neutral`. It matters for Mergify: `check-success` does **not** match a skipped check, so if this check were ever added to `.mergify.yml`, the job-level form would silently stall every Dependabot PR, recreating the exact shape of #752.

Scoped by login (`dependabot[bot]`) rather than `user.type != 'Bot'`, which would have exempted every GitHub App. The check, bypass label, body sanitising and bot-comment logic are untouched for everyone else.

This does sit in tension with the CLAUDE.md line that Dependabot PRs are expected to link an issue going forward. Dependabot writes its own PR bodies, so that cannot be enforced through this check; a per-release "Dependabot bumps" tracking issue would need applying some other way.

## Validation

- All three files parse as YAML.
- Every `check-success=` value in the rule and in `merge_conditions` cross-checked against job names parsed from all workflow files. All 10 match.
- Mergify validated the config itself: its `Configuration changed` check on this PR reports "The new Mergify configuration is valid". Note that validates schema, not semantics: it confirms the conditions parse, not that the names correspond to jobs that run. The cross-check above covers that.
- `actionlint` reports no expression or syntax errors, and the same 8 pre-existing shellcheck infos on `ci.yml` before and after, so the new job adds none.
- Aggregate step's shell logic simulated: green only for four successes; red for failure, cancelled, skipped, empty input, and wrong suite count.
- `github-script` body syntax-checked as an async function body (how the action evaluates it), and the author-exemption branch unit-tested: exempts `dependabot[bot]` only, still enforces for `github-actions[bot]`, `renovate[bot]`, human authors, and a missing `pr.user`.
- The aggregate `E2E` job ran green on this PR alongside all four suites.

## What this does and does not fix

Merging this does not by itself clear the Dependabot backlog. The rule also requires `#approved-reviews-by>=1`, and #761, #720, #726 and #723 all currently have zero reviews, so that condition was unsatisfied independently of the check names. Those four are also all major bumps, so under the corrected rule they will now be labelled `major-update` and `needs-review` and will correctly *not* auto-merge. They need deliberate human handling.

Two of the three changes also cannot be self-tested by this PR:

- `require-linked-issue.yml` runs on `pull_request_target`, and GitHub always executes the base branch's copy of such a workflow. The exemption has no effect until this merges. On this PR the check ran from `main`'s current definition, which confirms the human path is unaffected but does not exercise the new code.
- Mergify reads `.mergify.yml` from the base branch too, so the corrected rules take effect after merge.

On the next Dependabot PR, watch for: the `E2E` check appearing and going green; `Require linked issue in PR body` reporting success rather than failing; a minor or patch bump satisfying the rule once approved; and a major bump picking up `major-update` and `needs-review` instead of queueing.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

CI-only change, so no unit or E2E tests apply. "Manually tested locally" refers to the validation listed above.

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [x] N/A - no UI changes
