### PR TITLE
test: pin grouped pagination.total as a component/tag count (#417)

### DIFF
--- a/src/app/(app)/repositories/_components/__tests__/docker-tag-list.test.tsx
+++ b/src/app/(app)/repositories/_components/__tests__/docker-tag-list.test.tsx
@@ -32,8 +32,8 @@ vi.mock("@/components/common/copy-button", () => ({
 }));
 
 vi.mock("@/components/common/data-table-pagination", () => ({
-  DataTablePagination: ({ total }: { total: number }) => (
-    <div data-testid="pagination" data-total={total} />
+  DataTablePagination: ({ total, itemLabel }: { total: number; itemLabel?: string }) => (
+    <div data-testid="pagination" data-total={total} data-item-label={itemLabel} />
   ),
 }));
 
@@ -179,6 +179,35 @@ describe("DockerTagList", () => {
   it("omits pagination when no total is supplied", () => {
     render(<DockerTagList tags={[TAG_14]} />);
     expect(screen.queryByTestId("pagination")).not.toBeInTheDocument();
+  });
+
+  // `pagination.total` on a `?group_by=docker_tag` response counts TAGS, the
+  // same grouped-unit semantic the Maven component list relies on (#417).
+  // Backend evidence, in
+  // artifact-keeper/backend/src/api/handlers/repositories.rs:
+  //
+  //   - `?count=exact` is answered by `count_docker_tag_rows` (:6705):
+  //     `SELECT COUNT(*) FROM oci_tags t WHERE t.repository_id = $1 ...`,
+  //     reusing the same FROM/WHERE as the page query, so one counted row
+  //     per (image, tag).
+  //   - Without it, `grouped_listing_total` (:6147) returns
+  //     `offset + docker_tags.len() + has_more` (:6479) -- again tags.
+  //
+  // Manifests, layers and index children are never counted.
+  //
+  // Scope: this pins the PROPS handed to `DataTablePagination`, not rendered
+  // copy.  `itemLabel` only reaches the screen in the control's `total === 0`
+  // branch (data-table-pagination.tsx:72); a non-empty page renders the bare
+  // "1-2 of 137" with no noun at all.  And `total` arrives as a prop here, so
+  // this does not verify what the server counts.
+  it("passes the server tag total and a 'tags' item label to the pagination control", () => {
+    // One page of 2 tags; each tag is an image index fronting several
+    // per-platform manifests plus their layers, so the raw artifact count
+    // behind this page is far larger than 2.
+    render(<DockerTagList tags={[TAG_14, TAG_LATEST]} total={137} />);
+    const pagination = screen.getByTestId("pagination");
+    expect(pagination).toHaveAttribute("data-total", "137");
+    expect(pagination).toHaveAttribute("data-item-label", "tags");
   });
 
   // -------------------------------------------------------------------------

--- a/src/app/(app)/repositories/_components/__tests__/maven-component-list.test.tsx
+++ b/src/app/(app)/repositories/_components/__tests__/maven-component-list.test.tsx
@@ -220,6 +220,93 @@ describe("MavenComponentList", () => {
   });
 
   // ---------------------------------------------------------------------
+  // `pagination.total` semantics (issue #417)
+  //
+  // The footer denominator is `pagination.total` from the
+  // `?group_by=maven_component` response, and that total counts COMPONENTS,
+  // not the raw `artifacts` rows they group.  Backend evidence, in
+  // artifact-keeper/backend/src/api/handlers/repositories.rs:
+  //
+  //   - `?count=exact` (what this view sends since #766) is answered by
+  //     `count_maven_catalog_component_keys` (:5997), whose SQL is
+  //     `SELECT COUNT(*) FROM (SELECT DISTINCT p.name, pv.version FROM
+  //     packages p JOIN package_versions pv ...) t` -- one counted row per
+  //     `(groupId:artifactId, version)` component.  The remote/proxy branch
+  //     uses `count_maven_catalog_components` (:6267), a COUNT over
+  //     `packages`, which since migration 113 holds one row per
+  //     `groupId:artifactId` catalog entry.
+  //   - Without `count=exact`, `grouped_listing_total` (:6147) returns
+  //     `offset + returned + has_more`, where `returned` is the number of
+  //     GROUPED rows on the page (`keys.len()` / `components.len()`).
+  //
+  // Neither path ever counts `artifacts` rows.  What these tests pin is the
+  // FRONTEND half of that contract: the denominator must be the server
+  // `total` prop, never recomputed from `components.length` (which is only
+  // the page size).  They do NOT verify the server semantic -- the total is
+  // handed in as a prop here -- so they would not go red if the backend
+  // started reporting raw artifact counts.  Pinning that needs a backend
+  // test in artifact-keeper (see #417).
+  // ---------------------------------------------------------------------
+
+  it("uses the server component total as the denominator, not the page's file count", () => {
+    // One page of 3 components holding 5 files each: 15 raw artifact rows
+    // sit behind this page.  The repository holds 7 components in total.
+    const page = ["alpha", "beta", "gamma"].map((artifactId) => ({
+      ...COMP_B,
+      id: `${artifactId}-1`,
+      artifact_id: artifactId,
+      artifact_files: [
+        `${artifactId}-1.0.0.jar`,
+        `${artifactId}-1.0.0.pom`,
+        `${artifactId}-1.0.0-sources.jar`,
+        `${artifactId}-1.0.0-javadoc.jar`,
+        `${artifactId}-1.0.0.jar.sha1`,
+      ],
+    }));
+
+    render(
+      <MavenComponentList
+        components={page}
+        total={7}
+        page={1}
+        pageSize={3}
+        onPageChange={() => {}}
+      />,
+    );
+
+    // Note the rendered string carries no noun: `DataTablePagination`
+    // (data-table-pagination.tsx:72) only prints `itemLabel` in its
+    // `total === 0` branch, so a non-empty page reads "1-3 of 7" and the
+    // user is left to infer the unit.  #417 assumed the copy said
+    // "components"; that wording was dropped when this shared control was
+    // adopted (#419 -> #466).
+    expect(screen.getByText("1-3 of 7")).toBeInTheDocument();
+    // 15 = the raw artifact rows behind the page.  Documentation more than
+    // a guard: the assertion above already fails for any denominator change
+    // that could produce 15 here.  Kept so the number a reader of #417
+    // expects to be wrong is visible in the test.
+    expect(screen.queryByText(/of 15/)).not.toBeInTheDocument();
+  });
+
+  it("derives the page count from the component total, not from components.length", () => {
+    // 7 components at 3 per page is 3 pages.  Using `components.length` as
+    // the denominator (the tempting "fix") would collapse this to 1 page and
+    // strand the user on page 1.
+    render(
+      <MavenComponentList
+        components={[COMP_A, COMP_B]}
+        total={7}
+        page={1}
+        pageSize={3}
+        onPageChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByText(/page 1 of 3/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /next page/i })).toBeEnabled();
+  });
+
+  // ---------------------------------------------------------------------
   // Clickable file rows (issues #444, #445)
   // ---------------------------------------------------------------------
 

--- a/src/lib/api/__tests__/artifacts.test.ts
+++ b/src/lib/api/__tests__/artifacts.test.ts
@@ -515,6 +515,116 @@ describe("artifactsApi", () => {
       });
       expect(result.docker_tags).toEqual(docker_tags);
     });
+
+    // -----------------------------------------------------------------------
+    // `pagination.total` semantics on a grouped response (issue #417)
+    //
+    // The backend counts GROUPED UNITS, never the raw `artifacts` rows they
+    // group. In artifact-keeper/backend/src/api/handlers/repositories.rs:
+    //
+    //   - maven_component, hosted/virtual: `count_maven_catalog_component_keys`
+    //     (:5997) -> `SELECT COUNT(*) FROM (SELECT DISTINCT p.name, pv.version
+    //     FROM packages p JOIN package_versions pv ...) t`
+    //   - maven_component, remote/proxy: `count_maven_catalog_components`
+    //     (:6267) -> `SELECT COUNT(*) FROM packages p WHERE ...`
+    //   - docker_tag: `count_docker_tag_rows` (:6705) -> `SELECT COUNT(*) FROM
+    //     oci_tags t WHERE ...`
+    //   - no `count=exact`: `grouped_listing_total` (:6147) ->
+    //     `offset + <grouped rows returned> + has_more`
+    //
+    // So the total is a component/tag count that is independent of both the
+    // page length and the number of files per group. The wrapper must hand it
+    // to the UI verbatim: recomputing it from `components.length` or
+    // `docker_tags.length` would replace a repository-wide total with the
+    // current page size.
+    //
+    // Scope: the fixtures below are authored by these tests, so they pin the
+    // WRAPPER's passthrough, not the server's counting. If the backend began
+    // reporting raw artifact counts, these would still pass. Closing that gap
+    // needs a test in artifact-keeper against the grouped handlers (#417).
+    // -----------------------------------------------------------------------
+
+    it("passes the server component total through verbatim, independent of page length", async () => {
+      // 3 components on the page, 15 files between them, 7 components in the
+      // repository. Only 7 may reach the UI.
+      const components = ["alpha", "beta", "gamma"].map((artifactId) => ({
+        id: `${artifactId}-1`,
+        group_id: "com.example",
+        artifact_id: artifactId,
+        version: "1.0.0",
+        repository_key: "maven-releases",
+        format: "maven",
+        size_bytes: 100,
+        download_count: 0,
+        created_at: "2026-01-01T00:00:00Z",
+        artifact_files: [
+          `${artifactId}-1.0.0.jar`,
+          `${artifactId}-1.0.0.pom`,
+          `${artifactId}-1.0.0-sources.jar`,
+          `${artifactId}-1.0.0-javadoc.jar`,
+          `${artifactId}-1.0.0.jar.sha1`,
+        ],
+      }));
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: vi.fn().mockResolvedValue(
+          JSON.stringify({
+            items: [],
+            pagination: { page: 1, per_page: 3, total: 7, total_pages: 3 },
+            components,
+          })
+        ),
+      });
+
+      const { artifactsApi } = await import("../artifacts");
+      const result = await artifactsApi.listGrouped("maven-releases", {
+        group_by: "maven_component",
+        count: "exact",
+        page: 1,
+        per_page: 3,
+      });
+      expect(result.pagination.total).toBe(7);
+      expect(result.pagination.total_pages).toBe(3);
+      // Not the page length (3) and not the raw file count (15).
+      expect(result.components).toHaveLength(3);
+    });
+
+    it("passes the server tag total through verbatim, independent of page length", async () => {
+      const docker_tags = ["1.0.0", "latest"].map((t) => ({
+        id: `tag-${t}`,
+        repository_key: "docker-local",
+        image: "acme/app",
+        tag: t,
+        manifest_digest: "sha256:abc",
+        total_size_bytes: 6000,
+        layer_count: 12,
+        is_index: true,
+        last_pushed_at: "2026-01-01T00:00:00Z",
+        scan_status: "completed",
+      }));
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: vi.fn().mockResolvedValue(
+          JSON.stringify({
+            items: [],
+            pagination: { page: 1, per_page: 2, total: 137, total_pages: 69 },
+            docker_tags,
+          })
+        ),
+      });
+
+      const { artifactsApi } = await import("../artifacts");
+      const result = await artifactsApi.listGrouped("docker-local", {
+        group_by: "docker_tag",
+        count: "exact",
+        page: 1,
+        per_page: 2,
+      });
+      expect(result.pagination.total).toBe(137);
+      expect(result.docker_tags).toHaveLength(2);
+    });
   });
 
   it("get fetches artifact metadata via fetch", async () => {


### PR DESCRIPTION
## Summary

Closes #417

#417 asked whether `pagination.total` on a `?group_by=maven_component` response is the component count or the raw artifact count, because the grouped footer was believed to read "Showing N of M **components**". I traced the backend source rather than a running server.

Two findings, one of which corrects the issue's premise:

1. **The total is a component count.** Every grouped path counts grouped units, never `artifacts` rows. The frontend assumption holds and no code change is needed.
2. **The copy #417 quotes does not exist any more.** The non-empty footer renders no noun at all.

This PR is therefore test-only.

### Ground truth (artifact-keeper/backend/src/api/handlers/repositories.rs)

The `count=exact` path, which is the one this view hits since #766 sends `count: "exact"` unconditionally (`repo-detail-content.tsx:280`):

- **Maven, hosted/virtual** (`list_artifacts_grouped_by_maven_component`, :5730; count requested at :5875) calls `count_maven_catalog_component_keys` (:5997):
  ```sql
  SELECT COUNT(*) FROM (
    SELECT DISTINCT p.name, pv.version
    FROM packages p JOIN package_versions pv ON pv.package_id = p.id
    WHERE p.repository_id = ANY($1) AND <name-shape> AND ($2::text IS NULL OR p.name ILIKE $2)
  ) t
  ```
  One counted row per `(groupId:artifactId, version)`, which is exactly one component. It counts the same key set the page query returns (`maven_component_keys_sql`, :5964), so the total matches a full cursor walk.

- **Maven, remote/proxy** (same function, count at :5784) calls `count_maven_catalog_components` (:6267): `SELECT COUNT(*) FROM packages p WHERE p.repository_id = $1 AND <name-shape> AND ($2::text IS NULL OR p.name ILIKE $2)`. Since migration `113_packages_one_row_per_name.sql:59` replaced the name+version unique key with `UNIQUE (repository_id, name)`, `packages` holds one row per `groupId:artifactId` catalog entry, **not** per GAV. So a proxy repo caching `com.example:foo` at 1.0.0 and 2.0.0 renders one component row, not two. That is a wider notion of "component" than the rest of this UI uses, but it does not affect the #417 answer: the COUNT and the page query enumerate the identical set, and neither is an `artifacts` count. Not fixed here.

- **Docker** (`list_artifacts_grouped_by_docker_tag`, :6418; count at :6474) calls `count_docker_tag_rows` (:6705): `SELECT COUNT(*)` over `DOCKER_TAG_ROWS_FROM_SQL` (`FROM oci_tags t ...`) with the page query's own WHERE clause. One row per `(image, tag)`. Manifests, index children and layers are never counted.

The default lower-bound path (no `count=exact`) is `grouped_listing_total` (:6147):
```rust
match exact {
    Some(total) => total,
    None => offset + returned as i64 + i64::from(has_more),
}
```
`returned` is the grouped-row count at all three call sites: `components.len()` (:5789), `keys.len()` (:5880), `docker_tags.len()` (:6479). So even the cheap path counts components/tags, just imprecisely.

**No frontend surface hits that path today**, but it is a live hazard rather than a non-issue: `artifacts.ts:150` forwards to `listGrouped` when `group_by` is set without adding `count`, so any future caller that goes through `list` instead of the repo detail view gets the lower bound and renders "1-20 of 21", then "21-40 of 41". `grouped_total_pages` (:6156) compounds it by taking `ceil()` of that lower bound, so the page count is wrong too.

**Conclusion: branch (a) from the issue.** No `artifacts`-row COUNT exists on any grouped path. The `components.length` denominator floated in #417 would be actively wrong: it is the page length, not the repository total, so it would collapse "1-20 of 137" to "1-20 of 20" and strand the user on page 1.

### Correction to the issue's premise: there is no noun

#417 quotes "Showing N of M components". `DataTablePagination` (`src/components/common/data-table-pagination.tsx:72`) renders:

```tsx
{total > 0 ? `${rangeStart}-${rangeEnd} of ${total}` : `0 ${itemLabel}`}
```

The noun lives only in the `total === 0` branch. A non-empty page renders the bare **"1-3 of 7"**. The "Showing N of M components" wording was dropped when this shared control was adopted (present in 7348d5e/#419, gone by 9503a21/#466).

This keeps the conclusion safe (no noun means no misleading noun) but changes the reasoning, and it leaves a real UX gap the issue was right to worry about: the user sees "1-3 of 7" with no unit and has to infer whether 7 means components or files. That ambiguity is now silent rather than wrong. Worth its own issue; not in scope here, since fixing it means changing the shared control used by the flat list too.

### Tests added

Five tests, each carrying the backend file/line/SQL it pins so the next reader does not re-derive it:

- `src/app/(app)/repositories/_components/__tests__/maven-component-list.test.tsx` - a page of 3 components holding 5 files each (15 raw artifact rows) with a server total of 7 renders "1-3 of 7"; and the page count derives from the total (3 pages), not from `components.length`.
- `src/app/(app)/repositories/_components/__tests__/docker-tag-list.test.tsx` - the server tag total and a `tags` item label reach `DataTablePagination`. This pins props, not rendered copy, since `itemLabel` only reaches the screen when `total === 0`.
- `src/lib/api/__tests__/artifacts.test.ts` - `listGrouped` hands `pagination.total` to the UI verbatim for both grouping modes; it is not recomputed from `components.length` / `docker_tags.length`.

**What these cover, precisely:** the frontend's use of the denominator. They do **not** verify the server semantic. Every one of them supplies the total itself, as a prop or as a `global.fetch` fixture the test authors, so none would go red if the backend started reporting raw artifact counts tomorrow.

The frontend half is mutation-proven, not merely passing: with `total={components.length}` in `maven-component-list.tsx`, `itemLabel="artifacts"` in `docker-tag-list.tsx`, and a recomputed total in `listGrouped`, all 5 new tests fail (`expected 3 to be 7`, `expected 2 to be 137`, `expected "vi.fn()" to be called with arguments: [ 2 ]`). Mutations reverted; the production diff is empty.

### Acceptance criteria

- [x] **Behavior confirmed** - against backend source, which is stronger evidence than a running server. Files, lines and SQL quoted above. Not confirmed against a live instance.
- [x] **Footer copy matches the response semantics** - satisfied by inspection rather than by a change: no noun is rendered outside the empty state, so there is nothing to correct. The separate ambiguity this exposes is noted above.
- [ ] **Test pinning the agreed semantic** - **frontend half only.** The server half is untested by anything in this repo.

**#417 should not be closed as fully settled on the strength of this PR.** It is on the 1.7.0 milestone and a green checkbox will read as done. The test that would close criterion 3 lives in artifact-keeper, not here:

> A `#[tokio::test]` alongside `seed_maven_component` (`repositories.rs:23101`), following `virtual_maven_grouped_listing_hides_invisible_member_components_3163` (`:23516`) which gates on `tdh::try_pool()` and skips cleanly without a database. Seed 3 components with 5 artifact rows each, request `group_by=maven_component&count=exact`, and assert `pagination.total == 3` and explicitly `!= 15`. Mirror it for `group_by=docker_tag`.

Note that the existing assertion at `repositories.rs:13811` (`assert_eq!(page3.pagination.total, 25, "count=exact total")`) looks like coverage but is not: it lives in `remote_cached_listing_pages_from_catalog_2519`, which exercises the flat remote listing, not either grouped path. It should not be cited as evidence for #417.

### Backend note

No backend change is needed or proposed. One pre-existing nuance is worth recording but is out of scope and is not what #417 describes: on the hosted/virtual Maven path, `build_maven_components_for_keys` (:6049) drops a catalog key whose files no longer exist ("stale catalog row"), while `count_maven_catalog_component_keys` still counts it. That can make a page render fewer components than the total implies. The unit is still components, so this is a catalog/artifact consistency question, not a component-vs-artifact counting question.

No CHANGELOG entry: no user-visible behavior changed.

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [ ] Manually tested locally
- [x] No regressions in existing tests

`npx vitest run` -> 173 files / 3242 tests passed (baseline was 173 / 3237; +5 new).
`npx eslint` -> 0 errors, 37 warnings, all pre-existing and none in the touched files.

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [x] N/A - no UI changes