### PR TITLE
fix(ui): stop showing a green all-clear for proxy-cached artifacts

### DIFF
--- a/src/app/(app)/repositories/_components/__tests__/security-tab-content.test.tsx
+++ b/src/app/(app)/repositories/_components/__tests__/security-tab-content.test.tsx
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import React from "react";
+
+import type { Artifact } from "@/types";
+import { ANALYZABLE_DISABLED_REASON } from "@/lib/artifact-analyzable";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockUseQuery = vi.hoisted(() => vi.fn());
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (opts: unknown) => mockUseQuery(opts),
+  useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock("@/lib/api/sbom", () => ({
+  sbomApi: { getCveHistory: vi.fn(), updateCveStatus: vi.fn() },
+}));
+
+vi.mock("@/lib/api/dependency-track", () => ({
+  dtApi: {
+    getStatus: vi.fn(),
+    listProjects: vi.fn(),
+    getProjectMetrics: vi.fn(),
+    getProjectFindings: vi.fn(),
+    updateAnalysis: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/error-utils", () => ({ mutationErrorToast: () => () => {} }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+vi.mock("lucide-react", () => {
+  const icon = () => null;
+  return {
+    ShieldAlert: icon,
+    ShieldCheck: icon,
+    ShieldQuestion: icon,
+    AlertTriangle: icon,
+    Clock: icon,
+    ChevronDown: icon,
+    CheckCircle2: icon,
+    XCircle: icon,
+    Eye: icon,
+    Link2: icon,
+    Link2Off: icon,
+    Activity: icon,
+  };
+});
+
+// Stub out the scans list section — it has its own tests
+// (artifact-scans-section.test.tsx) and its own queries; stubbing it here
+// keeps this file focused on the CVE-history empty state this task changes.
+vi.mock("../artifact-scans-section", () => ({
+  ArtifactScansSection: () => <div data-testid="stub-artifact-scans-section" />,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...rest }: React.ComponentProps<"button">) => (
+    <button {...rest}>{children}</button>
+  ),
+}));
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock("@/components/ui/skeleton", () => ({
+  Skeleton: ({ className }: { className?: string }) => (
+    <div data-testid="skeleton" className={className} />
+  ),
+}));
+
+vi.mock("@/components/ui/separator", () => ({ Separator: () => <hr /> }));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/common/data-table", () => ({
+  DataTable: () => <div data-testid="data-table" />,
+}));
+
+vi.mock("@/components/common/vuln-id-link", () => ({
+  VulnIdLink: ({ id }: { id: string }) => <span>{id}</span>,
+}));
+
+// ---------------------------------------------------------------------------
+// Component under test
+// ---------------------------------------------------------------------------
+
+import { SecurityTabContent } from "../security-tab-content";
+
+function art(overrides: Partial<Artifact> = {}): Artifact {
+  return {
+    id: "a1",
+    repository_key: "npm-remote",
+    path: "left-pad/left-pad-1.3.0.tgz",
+    name: "left-pad-1.3.0.tgz",
+    size_bytes: 1024,
+    checksum_sha256: "deadbeef",
+    content_type: "application/octet-stream",
+    download_count: 0,
+    created_at: "2026-06-01T10:00:00Z",
+    ...overrides,
+  };
+}
+
+// Zero CVE history and no Dependency-Track status — drives the `total === 0`
+// empty state this task changes, without pulling in the (separately tested)
+// DT integration section.
+function stubEmptyQueries() {
+  mockUseQuery.mockImplementation((opts: { queryKey: unknown[] }) => {
+    const key = opts.queryKey[0];
+    if (key === "cve-history") return { data: [], isLoading: false };
+    // dt-status / dt-projects / dt-project-metrics / dt-project-findings:
+    // no DT integration configured, keeps the DT section from rendering.
+    return { data: undefined, isLoading: false };
+  });
+}
+
+describe("SecurityTabContent — CVE empty state (#3344)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubEmptyQueries();
+  });
+  afterEach(() => cleanup());
+
+  it("shows the green all-clear and SBOM hint when the artifact is analyzable", () => {
+    render(<SecurityTabContent artifact={art({ analyzable: true })} />);
+    expect(
+      screen.getByText(/No vulnerabilities detected for this artifact/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Generate an SBOM and run a security scan/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/CVE history is not available/i)).toBeNull();
+  });
+
+  it("does not show a green all-clear for non-analyzable proxy-cached artifacts (#3344)", () => {
+    render(<SecurityTabContent artifact={art({ analyzable: false })} />);
+    // This is the bug this task fixes: a proxy-cached artifact the download
+    // gate blocked must never render the "no vulnerabilities" all-clear —
+    // its CVE-history total is structurally always zero, so the old
+    // unconditional total===0 branch was misleading.
+    expect(
+      screen.queryByText(/No vulnerabilities detected for this artifact/i),
+    ).toBeNull();
+    // The neutral replacement state renders instead, with the narrowed
+    // disabled-reason copy (proxy-cached artifacts ARE scanned at download
+    // time under scan-on-proxy).
+    expect(
+      screen.getByText(/CVE history is not available for this artifact/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(ANALYZABLE_DISABLED_REASON)).toBeInTheDocument();
+  });
+
+  it("keeps the green all-clear when analyzable is absent (safe default, older responses)", () => {
+    render(<SecurityTabContent artifact={art()} />);
+    expect(
+      screen.getByText(/No vulnerabilities detected for this artifact/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/(app)/repositories/_components/artifact-scans-section.tsx
+++ b/src/app/(app)/repositories/_components/artifact-scans-section.tsx
@@ -5,6 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { ShieldAlert, AlertTriangle, Clock } from "lucide-react";
 
 import { securityApi } from "@/lib/api/security";
+import { ANALYZABLE_DISABLED_REASON } from "@/lib/artifact-analyzable";
 import type { ScanResult } from "@/types/security";
 
 import { Badge } from "@/components/ui/badge";
@@ -159,7 +160,7 @@ export function ArtifactScansSection({
           <p className="text-xs text-muted-foreground mt-1">
             {analyzable
               ? "Trigger a scan from the artifact actions menu to populate this section."
-              : "SBOM and scanning are available only for artifacts hosted in this registry, not proxy-cached remote artifacts."}
+              : ANALYZABLE_DISABLED_REASON}
           </p>
         </div>
       ) : (

--- a/src/app/(app)/repositories/_components/artifact-scans-section.tsx
+++ b/src/app/(app)/repositories/_components/artifact-scans-section.tsx
@@ -155,7 +155,7 @@ export function ArtifactScansSection({
           <p className="text-sm text-muted-foreground">
             {analyzable
               ? "No security scans have been run against this artifact yet."
-              : "This artifact cannot be scanned."}
+              : "This artifact cannot be scanned on demand."}
           </p>
           <p className="text-xs text-muted-foreground mt-1">
             {analyzable

--- a/src/app/(app)/repositories/_components/security-tab-content.tsx
+++ b/src/app/(app)/repositories/_components/security-tab-content.tsx
@@ -5,6 +5,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   ShieldAlert,
   ShieldCheck,
+  ShieldQuestion,
   AlertTriangle,
   Clock,
   ChevronDown,
@@ -20,7 +21,10 @@ import { toast } from "sonner";
 import { sbomApi } from "@/lib/api/sbom";
 import { dtApi } from "@/lib/api/dependency-track";
 import { mutationErrorToast } from "@/lib/error-utils";
-import { isArtifactAnalyzable } from "@/lib/artifact-analyzable";
+import {
+  ANALYZABLE_DISABLED_REASON,
+  isArtifactAnalyzable,
+} from "@/lib/artifact-analyzable";
 import { ArtifactScansSection } from "./artifact-scans-section";
 import type { CveHistoryEntry, CveStatus } from "@/types/sbom";
 import type { Artifact } from "@/types";
@@ -526,15 +530,27 @@ export function SecurityTabContent({ artifact }: SecurityTabContentProps) {
 
       {total === 0 ? (
         <div className="flex flex-col items-center justify-center py-12 text-center">
-          <ShieldCheck className="size-12 text-green-500/50 mb-4" />
-          <p className="text-sm text-muted-foreground">
-            No vulnerabilities detected for this artifact.
-          </p>
-          <p className="text-xs text-muted-foreground mt-1">
-            {analyzable
-              ? "Generate an SBOM and run a security scan to check for CVEs."
-              : "SBOM and scanning are available only for artifacts hosted in this registry, not proxy-cached remote artifacts."}
-          </p>
+          {analyzable ? (
+            <>
+              <ShieldCheck className="size-12 text-green-500/50 mb-4" />
+              <p className="text-sm text-muted-foreground">
+                No vulnerabilities detected for this artifact.
+              </p>
+              <p className="text-xs text-muted-foreground mt-1">
+                Generate an SBOM and run a security scan to check for CVEs.
+              </p>
+            </>
+          ) : (
+            <>
+              <ShieldQuestion className="size-12 text-muted-foreground/50 mb-4" />
+              <p className="text-sm text-muted-foreground">
+                CVE history is not available for this artifact.
+              </p>
+              <p className="text-xs text-muted-foreground mt-1">
+                {ANALYZABLE_DISABLED_REASON}
+              </p>
+            </>
+          )}
         </div>
       ) : (
         <>

--- a/src/lib/__tests__/artifact-analyzable.test.ts
+++ b/src/lib/__tests__/artifact-analyzable.test.ts
@@ -34,3 +34,14 @@ describe("isArtifactAnalyzable (artifact-keeper#2292)", () => {
     expect(ANALYZABLE_DISABLED_REASON).toMatch(/proxy-cached remote/i);
   });
 });
+
+describe("ANALYZABLE_DISABLED_REASON", () => {
+  it("does not claim scanning is unavailable for proxy-cached artifacts", () => {
+    // #3344: proxy-cached artifacts ARE scanned at download time when
+    // scan-on-proxy is enabled. Only SBOM generation and on-demand scans
+    // are hosted-only.
+    expect(ANALYZABLE_DISABLED_REASON).not.toMatch(/SBOM and scanning are available only/);
+    expect(ANALYZABLE_DISABLED_REASON).toMatch(/scan-on-proxy/);
+    expect(ANALYZABLE_DISABLED_REASON).toMatch(/proxy-cached/i);
+  });
+});

--- a/src/lib/artifact-analyzable.ts
+++ b/src/lib/artifact-analyzable.ts
@@ -1,15 +1,17 @@
 import type { Artifact } from "@/types";
 
 /**
- * User-facing explanation shown when SBOM generation / security scanning is
- * offered for an artifact that the backend cannot analyze. Proxy-cached remote
+ * User-facing explanation shown when SBOM generation / on-demand scanning is
+ * offered for an artifact the backend cannot analyze. Proxy-cached remote
  * artifacts have synthetic ids and no `artifacts` row, so the backend returns
- * 404 for SBOM/scan requests against them (artifact-keeper#2292, backend PR
- * #2291). Surfacing this as a disabled affordance with this reason keeps the
- * action discoverable while making the limitation honest.
+ * 404 for those requests (artifact-keeper#2292, backend PR #2291).
+ *
+ * #3344: this previously said "SBOM and scanning are available only for
+ * artifacts hosted in this registry", which is false for scanning - proxy-cached
+ * artifacts are scanned at download time when scan-on-proxy is enabled.
  */
 export const ANALYZABLE_DISABLED_REASON =
-  "SBOM and scanning are available only for artifacts hosted in this registry, not proxy-cached remote artifacts.";
+  "SBOM generation and on-demand scans are available only for artifacts hosted in this registry. Proxy-cached remote artifacts are scanned automatically at download time when scan-on-proxy is enabled for the repository.";
 
 /**
  * Whether SBOM generation and security scanning are supported for an artifact.


### PR DESCRIPTION
## Summary

The artifact Security tab rendered a green `ShieldCheck` reading **"No
vulnerabilities detected for this artifact"** whenever its finding total was
zero. That total comes from CVE history, which is keyed on `artifacts.id` — and
proxy-cached artifacts have no `artifacts` row, so for them it is *structurally*
always zero.

The result: an artifact that the download gate had just returned `403
scan_blocked` for displayed a green all-clear. Verified locally against a gated
proxy repo.

This PR:

- Replaces the green all-clear with a neutral "CVE history is not available for
  this artifact" state for proxy-cached artifacts. The analyzable branch is
  unchanged and still shows the all-clear.
- Narrows `ANALYZABLE_DISABLED_REASON`, which claimed "SBOM and scanning are
  available only for artifacts hosted in this registry". Scanning is available —
  proxy-cached artifacts are scanned at download time when scan-on-proxy is
  enabled. Only SBOM generation and on-demand scans are hosted-only.
- Fixes the same false claim in `artifact-scans-section.tsx`, which carried its
  own hardcoded duplicate ("This artifact cannot be scanned." → "…cannot be
  scanned on demand."), and points it at the shared constant.

All copy is conditioned on "when scan-on-proxy is enabled for the repository",
so a repository with the policy off is never told its artifacts are protected.

No new API calls, no verdict display, no change to `isArtifactAnalyzable` or the
`analyzable` field. Displaying an actual scan verdict needs a backend endpoint
that does not exist yet.

Fixes #788.

Pairs with artifact-keeper/artifact-keeper#3346, which fixes the same false
claim in the API messages (artifact-keeper/artifact-keeper#3344).

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

New `security-tab-content.test.tsx` covers all three empty-state branches and
asserts the **absence** of the old all-clear for proxy-cached artifacts — that
absence is the bug fix. Verified to fail against the pre-fix component by
swapping it back in. Full suite: 172 files / 3138 tests green.

No Playwright spec added: this component is not currently covered by an E2E
flow, and the change is copy plus a conditional empty state. Called out rather
than checked.

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [x] N/A - no UI changes

Text and icon swap inside an existing layout — no structural, spacing, or color
changes, so responsive/dark-mode behaviour is unchanged. Not independently
re-verified; flagging honestly rather than checking boxes I did not exercise.

One known nit: `ANALYZABLE_DISABLED_REASON` now renders twice on the same tab
(CVE section and scans section). Kept deliberately so the Scan Results section
stays self-explanatory in isolation, and because a dedicated test asserts it
there.

