### PR TITLE
feat(security): proxy-cached artifact scan verdicts and SBOM viewer

### DIFF
--- a/src/app/(app)/repositories/_components/__tests__/artifact-scans-section.test.tsx
+++ b/src/app/(app)/repositories/_components/__tests__/artifact-scans-section.test.tsx
@@ -159,8 +159,27 @@ describe("ArtifactScansSection (#368)", () => {
       isError: false,
     });
     render(<ArtifactScansSection artifactId="a1" analyzable={false} />);
-    expect(screen.getByText(/cannot be scanned/i)).toBeDefined();
-    expect(screen.getByText(/proxy-cached remote artifacts/i)).toBeDefined();
+    // #3344: pin the exact new headline. Both this AND the pre-#3344
+    // headline ("This artifact cannot be scanned.") match a loose
+    // /cannot be scanned/i, so assert the full "on demand" phrasing to
+    // catch a silent revert of the headline copy.
+    expect(
+      screen.getByText(/cannot be scanned on demand/i),
+    ).toBeDefined();
+    // #3344 (finding 4): the subtext renders only the second sentence of
+    // ANALYZABLE_DISABLED_REASON (the headline already states the
+    // limitation) — pin that scan-on-proxy specific wording.
+    expect(
+      screen.getByText(
+        /can be scanned at download time when scan-on-proxy is enabled/i,
+      ),
+    ).toBeDefined();
+    // Must not have regressed to the pre-#3344 blanket claim that scanning
+    // (not just SBOM generation) is hosted-only — that's false for
+    // PyPI/npm/Docker proxy repos with scan-on-proxy enabled.
+    expect(
+      screen.queryByText(/SBOM and scanning are available only/i),
+    ).toBeNull();
     // Must NOT tell the user to trigger a scan they cannot run.
     expect(
       screen.queryByText(/Trigger a scan from the artifact actions menu/i),

--- a/src/app/(app)/repositories/_components/__tests__/proxy-sbom-panel.test.tsx
+++ b/src/app/(app)/repositories/_components/__tests__/proxy-sbom-panel.test.tsx
@@ -82,6 +82,28 @@ afterEach(() => cleanup());
 // ---------------------------------------------------------------------------
 
 describe("ProxySbomPanel — an empty inventory is not an empty SBOM", () => {
+  it("REGRESSION: an empty inventory never renders as an empty or complete SBOM", () => {
+    // The named regression. A zero-component response must render the explicit
+    // not-recorded state — never a component table, never a component count,
+    // never anything a reader could take as "this artifact has no components".
+    // Same class of bug as the green all-clear shield: absence of evidence
+    // presented as evidence of absence.
+    stubQuery({ data: { bomFormat: "CycloneDX", components: [] } });
+
+    renderPanel();
+
+    expect(screen.getByTestId("proxy-sbom-empty")).toHaveTextContent(
+      /No SBOM recorded for this artifact yet/i,
+    );
+    expectNoEmptyComponentTable();
+    // No count badge asserting a total of zero.
+    expect(screen.queryByText(/0 components?/i)).toBeNull();
+    // No download of a document that catalogs nothing.
+    expect(screen.queryByRole("button", { name: /download/i })).toBeNull();
+    // And nothing claiming the (absent) inventory is complete.
+    expect(screen.queryByText(/complete/i)).toBeNull();
+  });
+
   it("renders the explicit not-recorded state for a document with no components", () => {
     stubQuery({ data: { bomFormat: "CycloneDX", components: [] } });
 
@@ -90,8 +112,23 @@ describe("ProxySbomPanel — an empty inventory is not an empty SBOM", () => {
     expect(screen.getByTestId("proxy-sbom-empty")).toHaveTextContent(
       /No SBOM recorded for this artifact yet/i,
     );
-    expect(screen.getByText(/next time it is pulled/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/next time the artifact is pulled/i),
+    ).toBeInTheDocument();
     expectNoEmptyComponentTable();
+  });
+
+  it("says a missing inventory on an older cache entry is expected, not a fault", () => {
+    // On any existing deployment this is the state most users meet first,
+    // because only digests pulled after recording shipped have an inventory.
+    stubQuery({ error: new ApiError(404, "not found") });
+
+    renderPanel();
+
+    expect(screen.getByText(/cached before/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/does not indicate a problem with the artifact/i),
+    ).toBeInTheDocument();
   });
 
   it("renders the not-recorded state when the endpoint has nothing for this path", () => {
@@ -204,6 +241,45 @@ describe("ProxySbomPanel — inventory", () => {
     renderPanel();
 
     expect(screen.getByText(/Declared licenses \(1\)/)).toBeInTheDocument();
+  });
+
+  it("surfaces a scan-reported partial catalog instead of presenting it as complete", () => {
+    stubQuery({
+      data: {
+        ...CYCLONEDX,
+        metadata: {
+          properties: [
+            { name: "artifact-keeper:inventory_completeness", value: "partial" },
+          ],
+        },
+      },
+    });
+
+    renderPanel();
+
+    expect(screen.getByTestId("proxy-sbom-partial-banner")).toBeInTheDocument();
+    expect(screen.getByText(/reported this inventory as incomplete/i)).toBeInTheDocument();
+    expect(screen.getByText(/partial list/i)).toBeInTheDocument();
+    // The components it did catalog are still shown — a partial list beats none.
+    expect(screen.getByText("jinja2")).toBeInTheDocument();
+  });
+
+  it("does not warn when the scan reported the catalog complete", () => {
+    stubQuery({ data: { ...CYCLONEDX, inventory_completeness: "complete" } });
+
+    renderPanel();
+
+    expect(screen.queryByTestId("proxy-sbom-partial-banner")).toBeNull();
+  });
+
+  it("does not warn when the document makes no completeness claim", () => {
+    // A backend that never emits the field must not put a warning on every
+    // SBOM; the standing caveat already says what the document is.
+    stubQuery({ data: CYCLONEDX });
+
+    renderPanel();
+
+    expect(screen.queryByTestId("proxy-sbom-partial-banner")).toBeNull();
   });
 
   it("does not describe the inventory as a dependency tree", () => {

--- a/src/app/(app)/repositories/_components/__tests__/proxy-sbom-panel.test.tsx
+++ b/src/app/(app)/repositories/_components/__tests__/proxy-sbom-panel.test.tsx
@@ -1,0 +1,314 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ApiError } from "@/lib/api/fetch";
+
+const mockUseQuery = vi.hoisted(() => vi.fn());
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (opts: unknown) => mockUseQuery(opts),
+}));
+
+const mockGet = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/api/proxy-sbom", () => ({
+  proxySbomApi: { get: mockGet },
+}));
+
+import { ProxySbomPanel } from "../proxy-sbom-panel";
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+  Element.prototype.scrollIntoView = vi.fn();
+  Element.prototype.hasPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+});
+
+const CYCLONEDX = {
+  bomFormat: "CycloneDX",
+  specVersion: "1.5",
+  components: [
+    {
+      name: "jinja2",
+      version: "2.11.2",
+      purl: "pkg:pypi/jinja2@2.11.2",
+      licenses: [{ license: { id: "BSD-3-Clause" } }],
+    },
+    { name: "markupsafe", version: "1.1.1" },
+  ],
+};
+
+function stubQuery(result: {
+  data?: unknown;
+  isLoading?: boolean;
+  error?: unknown;
+}) {
+  mockUseQuery.mockReturnValue({
+    data: result.data,
+    isLoading: result.isLoading ?? false,
+    error: result.error ?? null,
+  });
+}
+
+function renderPanel(format = "pypi") {
+  return render(
+    <ProxySbomPanel
+      repositoryKey="pypi-remote"
+      path="jinja2/Jinja2-2.11.2-py2.py3-none-any.whl"
+      artifactName="Jinja2-2.11.2-py2.py3-none-any.whl"
+      repositoryFormat={format}
+    />,
+  );
+}
+
+/** No state may present itself as "this artifact has no dependencies". */
+function expectNoEmptyComponentTable() {
+  expect(screen.queryByText("No components cataloged")).toBeNull();
+  expect(screen.queryByRole("columnheader", { name: /component/i })).toBeNull();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => cleanup());
+
+// ---------------------------------------------------------------------------
+// The rule this panel exists to uphold.
+// ---------------------------------------------------------------------------
+
+describe("ProxySbomPanel — an empty inventory is not an empty SBOM", () => {
+  it("renders the explicit not-recorded state for a document with no components", () => {
+    stubQuery({ data: { bomFormat: "CycloneDX", components: [] } });
+
+    renderPanel();
+
+    expect(screen.getByTestId("proxy-sbom-empty")).toHaveTextContent(
+      /No SBOM recorded for this artifact yet/i,
+    );
+    expect(screen.getByText(/next time it is pulled/i)).toBeInTheDocument();
+    expectNoEmptyComponentTable();
+  });
+
+  it("renders the not-recorded state when the endpoint has nothing for this path", () => {
+    stubQuery({ error: new ApiError(404, "not found") });
+
+    renderPanel();
+
+    expect(screen.getByTestId("proxy-sbom-empty")).toHaveTextContent(
+      /No SBOM recorded/i,
+    );
+    expectNoEmptyComponentTable();
+  });
+
+  it("renders the not-recorded state rather than throwing on an unparseable body", () => {
+    stubQuery({ data: "<html>gateway error</html>" });
+
+    renderPanel();
+
+    expect(screen.getByTestId("proxy-sbom-empty")).toBeInTheDocument();
+    expectNoEmptyComponentTable();
+  });
+});
+
+describe("ProxySbomPanel — access", () => {
+  it("tells an anonymous viewer to sign in rather than showing an empty SBOM", () => {
+    stubQuery({ error: new ApiError(401, "unauthorized") });
+
+    renderPanel();
+
+    expect(screen.getByText("Sign in to view scan status.")).toBeInTheDocument();
+    expect(screen.queryByTestId("proxy-sbom-empty")).toBeNull();
+    expectNoEmptyComponentTable();
+  });
+
+  it("does not tell an already signed-in user to sign in", () => {
+    stubQuery({ error: new ApiError(403, "forbidden") });
+
+    renderPanel();
+
+    expect(screen.getByText(/do not have access/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("proxy-sbom-empty")).toBeNull();
+  });
+
+  it("reports a transport failure as a failure, not as an absent SBOM", () => {
+    stubQuery({ error: new ApiError(500, "boom") });
+
+    renderPanel();
+
+    expect(screen.getByTestId("proxy-scan-access-notice")).toBeInTheDocument();
+    expect(screen.queryByTestId("proxy-sbom-empty")).toBeNull();
+  });
+
+  it("shows a skeleton while the document is in flight", () => {
+    stubQuery({ isLoading: true });
+
+    renderPanel();
+
+    expect(screen.queryByTestId("proxy-sbom-empty")).toBeNull();
+    expectNoEmptyComponentTable();
+  });
+});
+
+describe("ProxySbomPanel — unsupported formats", () => {
+  it("says so plainly instead of querying an endpoint with nothing to return", () => {
+    stubQuery({ data: undefined });
+
+    renderPanel("maven");
+
+    expect(screen.getByTestId("proxy-sbom-empty")).toHaveTextContent(
+      /only recorded for PyPI, npm and Docker\/OCI/i,
+    );
+    const opts = mockUseQuery.mock.calls[0][0] as { enabled: boolean };
+    expect(opts.enabled).toBe(false);
+  });
+
+  it("enables the query for a format that does run an inline scan", () => {
+    stubQuery({ data: CYCLONEDX });
+
+    renderPanel("npm");
+
+    const opts = mockUseQuery.mock.calls[0][0] as { enabled: boolean };
+    expect(opts.enabled).toBe(true);
+  });
+});
+
+describe("ProxySbomPanel — inventory", () => {
+  it("renders the component inventory with version, license and purl", () => {
+    stubQuery({ data: CYCLONEDX });
+
+    renderPanel();
+
+    expect(screen.getByText("jinja2")).toBeInTheDocument();
+    expect(screen.getByText("2.11.2")).toBeInTheDocument();
+    expect(screen.getByText("pkg:pypi/jinja2@2.11.2")).toBeInTheDocument();
+    expect(screen.getByText("markupsafe")).toBeInTheDocument();
+    expect(screen.getByText("2 components")).toBeInTheDocument();
+  });
+
+  it("labels a component with no declared license as Unknown, not as unrestricted", () => {
+    stubQuery({ data: CYCLONEDX });
+
+    renderPanel();
+
+    expect(screen.getByText("Unknown")).toBeInTheDocument();
+  });
+
+  it("summarizes the distinct declared licenses", () => {
+    stubQuery({ data: CYCLONEDX });
+
+    renderPanel();
+
+    expect(screen.getByText(/Declared licenses \(1\)/)).toBeInTheDocument();
+  });
+
+  it("does not describe the inventory as a dependency tree", () => {
+    stubQuery({ data: CYCLONEDX });
+
+    renderPanel();
+
+    // For npm the scan can catalog declared transitives the tarball does not
+    // vendor, and it never resolves a graph. Saying "dependency tree" would
+    // overstate what the document is.
+    expect(
+      screen.getByText(/not a resolved transitive dependency tree/i),
+    ).toBeInTheDocument();
+  });
+
+  it("names how a proxy SBOM comes to exist, since it cannot be generated on demand", () => {
+    stubQuery({ data: CYCLONEDX });
+
+    renderPanel();
+
+    expect(
+      screen.getByText(/cannot be generated on demand/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /generate/i })).toBeNull();
+  });
+
+  it("offers the raw document behind a disclosure", async () => {
+    stubQuery({ data: CYCLONEDX });
+
+    renderPanel();
+
+    expect(screen.queryByTestId("proxy-sbom-raw")).toBeNull();
+    await userEvent.click(
+      screen.getByRole("button", { name: /view raw cyclonedx document/i }),
+    );
+
+    const raw = screen.getByTestId("proxy-sbom-raw");
+    expect(raw).toBeInTheDocument();
+    expect(JSON.parse(raw.textContent ?? "")).toEqual(CYCLONEDX);
+  });
+
+  it("labels the raw disclosure by the format the document declares", async () => {
+    stubQuery({
+      data: {
+        spdxVersion: "SPDX-2.3",
+        packages: [{ name: "left-pad", versionInfo: "1.3.0" }],
+      },
+    });
+
+    renderPanel("npm");
+
+    expect(
+      screen.getByRole("button", { name: /view raw spdx document/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("offers a download only when there is a document to download", () => {
+    stubQuery({ data: CYCLONEDX });
+    renderPanel();
+    expect(screen.getByRole("button", { name: /download/i })).toBeInTheDocument();
+
+    cleanup();
+    stubQuery({ data: { bomFormat: "CycloneDX", components: [] } });
+    renderPanel();
+    expect(screen.queryByRole("button", { name: /download/i })).toBeNull();
+  });
+});
+
+describe("ProxySbomPanel — query wiring", () => {
+  it("keys the query by repository, path and format, and does not retry a 401", () => {
+    stubQuery({ data: CYCLONEDX });
+
+    renderPanel();
+
+    const opts = mockUseQuery.mock.calls[0][0] as {
+      queryKey: unknown[];
+      retry: boolean;
+      queryFn: () => unknown;
+    };
+    expect(opts.queryKey).toEqual([
+      "proxy-sbom",
+      "pypi-remote",
+      "jinja2/Jinja2-2.11.2-py2.py3-none-any.whl",
+      "cyclonedx",
+    ]);
+    expect(opts.retry).toBe(false);
+
+    opts.queryFn();
+    expect(mockGet).toHaveBeenCalledWith(
+      "pypi-remote",
+      "jinja2/Jinja2-2.11.2-py2.py3-none-any.whl",
+      "cyclonedx",
+    );
+  });
+
+  it("refetches under a new key when the format is switched", async () => {
+    stubQuery({ data: CYCLONEDX });
+
+    renderPanel();
+    await userEvent.click(screen.getByRole("combobox", { name: /sbom format/i }));
+    await userEvent.click(screen.getByRole("option", { name: "SPDX" }));
+
+    const lastKey = (
+      mockUseQuery.mock.calls.at(-1)![0] as { queryKey: unknown[] }
+    ).queryKey;
+    expect(lastKey.at(-1)).toBe("spdx");
+  });
+});

--- a/src/app/(app)/repositories/_components/__tests__/proxy-sbom-panel.test.tsx
+++ b/src/app/(app)/repositories/_components/__tests__/proxy-sbom-panel.test.tsx
@@ -260,6 +260,54 @@ describe("ProxySbomPanel — inventory", () => {
     ).toBeInTheDocument();
   });
 
+  it("sorts by every column without throwing on absent versions and purls", async () => {
+    // markupsafe has neither a license nor a purl, so the sort accessors have
+    // to tolerate nulls rather than producing an invalid comparison.
+    stubQuery({ data: CYCLONEDX });
+
+    renderPanel();
+
+    for (const header of ["Component", "Version", "License"]) {
+      await userEvent.click(
+        screen.getByRole("button", { name: `Sort by ${header}` }),
+      );
+    }
+
+    expect(screen.getByText("jinja2")).toBeInTheDocument();
+    expect(screen.getByText("markupsafe")).toBeInTheDocument();
+  });
+
+  it("downloads the raw document under a name that identifies the artifact and format", async () => {
+    const createObjectURL = vi.fn((_blob: Blob) => "blob:sbom");
+    const revokeObjectURL = vi.fn((_url: string) => {});
+    Object.assign(URL, { createObjectURL, revokeObjectURL });
+    const clicks: HTMLAnchorElement[] = [];
+    const realClick = HTMLAnchorElement.prototype.click;
+    HTMLAnchorElement.prototype.click = function (this: HTMLAnchorElement) {
+      clicks.push(this);
+    };
+
+    try {
+      stubQuery({ data: CYCLONEDX });
+      renderPanel();
+
+      await userEvent.click(screen.getByRole("button", { name: /download/i }));
+
+      expect(clicks).toHaveLength(1);
+      expect(clicks[0].download).toBe(
+        "Jinja2-2.11.2-py2.py3-none-any.whl-proxy-sbom-cyclonedx.json",
+      );
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
+      // The blob carries the unwrapped document, not the response envelope.
+      const blob = createObjectURL.mock.calls[0][0];
+      expect(JSON.parse(await blob.text())).toEqual(CYCLONEDX);
+      // The object URL is released rather than leaked.
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:sbom");
+    } finally {
+      HTMLAnchorElement.prototype.click = realClick;
+    }
+  });
+
   it("offers a download only when there is a document to download", () => {
     stubQuery({ data: CYCLONEDX });
     renderPanel();

--- a/src/app/(app)/repositories/_components/__tests__/proxy-scan-panel.test.tsx
+++ b/src/app/(app)/repositories/_components/__tests__/proxy-scan-panel.test.tsx
@@ -1,0 +1,308 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+import { ApiError } from "@/lib/api/fetch";
+import type { ProxyScanEntry, ProxyScanPathResponse } from "@/types/proxy-scans";
+
+const mockUseQuery = vi.hoisted(() => vi.fn());
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (opts: unknown) => mockUseQuery(opts),
+}));
+
+const mockGetByPath = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/api/proxy-scans", () => ({
+  proxyScansApi: { getByPath: mockGetByPath, list: vi.fn() },
+}));
+
+import { ProxyScanPanel } from "../proxy-scan-panel";
+
+function entry(overrides: Partial<ProxyScanEntry> = {}): ProxyScanEntry {
+  return {
+    path: "left-pad/-/left-pad-1.3.0.tgz",
+    state: "clean",
+    reason: null,
+    critical_count: 0,
+    high_count: 0,
+    medium_count: 0,
+    low_count: 0,
+    findings_count: 0,
+    scanned_at: "2026-08-01T12:00:00Z",
+    ...overrides,
+  };
+}
+
+function stubQuery(result: {
+  data?: Partial<ProxyScanPathResponse>;
+  isLoading?: boolean;
+  error?: unknown;
+}) {
+  mockUseQuery.mockReturnValue({
+    data: result.data,
+    isLoading: result.isLoading ?? false,
+    error: result.error ?? null,
+  });
+}
+
+function renderPanel() {
+  return render(
+    <ProxyScanPanel
+      repositoryKey="npm-remote"
+      path="left-pad/-/left-pad-1.3.0.tgz"
+    />,
+  );
+}
+
+/** Any wording that would let a viewer read the panel as an all-clear. */
+function expectNoImpliedAllClear() {
+  expect(screen.queryByText(/no vulnerabilities detected/i)).toBeNull();
+  // Absent is fine; present-and-clean is the bug. `queryByTestId` returns null
+  // when the callout is not rendered at all, so assert on the attribute.
+  expect(
+    screen.queryByTestId("proxy-scan-verdict")?.getAttribute("data-tone"),
+  ).not.toBe("clean");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => cleanup());
+
+// ---------------------------------------------------------------------------
+// The named regression test. This is the bug the feature exists to fix, for
+// its largest audience.
+// ---------------------------------------------------------------------------
+
+describe("ProxyScanPanel — anonymous viewer regression", () => {
+  it("renders 'Sign in to view scan status.' for an anonymous viewer on a public proxy repository, never a green all-clear", () => {
+    // The repositories pages sit outside the (protected) route group and the
+    // artifact Security tab has no auth gating, so this component renders for
+    // anonymous users on public repositories. The endpoint 401s them by
+    // design. If that failure were treated as zero findings, the green
+    // all-clear would come back for exactly this audience.
+    stubQuery({ error: new ApiError(401, "unauthorized") });
+
+    renderPanel();
+
+    expect(screen.getByText("Sign in to view scan status.")).toBeInTheDocument();
+    expect(screen.getByTestId("proxy-scan-access-notice")).toHaveAttribute(
+      "data-failure",
+      "unauthenticated",
+    );
+    expectNoImpliedAllClear();
+  });
+});
+
+describe("ProxyScanPanel — access failures", () => {
+  it("does not tell an already signed-in user to sign in", () => {
+    stubQuery({ error: new ApiError(403, "forbidden") });
+
+    renderPanel();
+
+    expect(screen.queryByText("Sign in to view scan status.")).toBeNull();
+    expect(
+      screen.getByText(/do not have access to scan status/i),
+    ).toBeInTheDocument();
+    expectNoImpliedAllClear();
+  });
+
+  it("says plainly that a transport failure is not a clean result", () => {
+    stubQuery({ error: new ApiError(500, "boom") });
+
+    renderPanel();
+
+    expect(screen.getByText(/not a clean result/i)).toBeInTheDocument();
+    expectNoImpliedAllClear();
+  });
+
+  it("shows a skeleton while the verdict is in flight", () => {
+    stubQuery({ isLoading: true });
+
+    renderPanel();
+
+    expect(screen.queryByTestId("proxy-scan-verdict")).toBeNull();
+    expectNoImpliedAllClear();
+  });
+});
+
+describe("ProxyScanPanel — unresolvable path", () => {
+  it("renders a 404 as unknown rather than clean", () => {
+    // A repository with zero catalog rows falls back to storage enumeration
+    // for its listing, so a modal click there can produce a path the
+    // catalog-backed endpoint cannot resolve.
+    stubQuery({ error: new ApiError(404, "not found") });
+
+    renderPanel();
+
+    expect(screen.getByTestId("proxy-scan-verdict")).toHaveAttribute(
+      "data-tone",
+      "neutral",
+    );
+    expect(screen.getByText(/Unknown is not clean/)).toBeInTheDocument();
+  });
+
+  it("renders a resolved-but-empty response as unknown rather than clean", () => {
+    // Placeholder rows whose checksum_sha256 is NULL join to nothing.
+    stubQuery({
+      data: { scan_on_proxy: true, proxy_scan_action: "fail_closed", entry: null },
+    });
+
+    renderPanel();
+
+    expect(screen.getByText(/Scan status unknown for this path/i)).toBeInTheDocument();
+    expectNoImpliedAllClear();
+  });
+});
+
+describe("ProxyScanPanel — verdicts", () => {
+  it("renders a clean verdict as a statement about when, not a guarantee about now", () => {
+    stubQuery({
+      data: {
+        scan_on_proxy: true,
+        proxy_scan_action: "fail_closed",
+        entry: entry({ state: "clean" }),
+      },
+    });
+
+    renderPanel();
+
+    expect(screen.getByTestId("proxy-scan-verdict")).toHaveAttribute(
+      "data-tone",
+      "clean",
+    );
+    expect(screen.getByText(/^Clean as of /)).toBeInTheDocument();
+    expect(screen.getByText(/database may have changed/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("proxy-scan-enforcement-banner")).toBeNull();
+  });
+
+  it("renders a vulnerable verdict with its severity breakdown", () => {
+    stubQuery({
+      data: {
+        scan_on_proxy: true,
+        proxy_scan_action: "fail_closed",
+        entry: entry({
+          state: "vulnerable",
+          critical_count: 1,
+          high_count: 2,
+          findings_count: 3,
+        }),
+      },
+    });
+
+    renderPanel();
+
+    expect(screen.getByTestId("proxy-scan-verdict")).toHaveAttribute(
+      "data-tone",
+      "danger",
+    );
+    expect(screen.getByText("3 findings")).toBeInTheDocument();
+    expect(screen.getByText("1 critical")).toBeInTheDocument();
+    expect(screen.getByText("2 high")).toBeInTheDocument();
+  });
+
+  it("does not claim a vulnerable artifact was blocked on a fail-open repository", () => {
+    stubQuery({
+      data: {
+        scan_on_proxy: true,
+        proxy_scan_action: "fail_open",
+        entry: entry({ state: "vulnerable", findings_count: 1, high_count: 1 }),
+      },
+    });
+
+    renderPanel();
+
+    expect(screen.getByText(/may still be served/i)).toBeInTheDocument();
+    expect(screen.queryByText(/downloads are blocked/i)).toBeNull();
+  });
+
+  it("shows the enforcement banner when a non-scanning repository displays an inherited verdict", () => {
+    // Verdicts are global by digest. This repository did not record it and
+    // does not enforce it.
+    stubQuery({
+      data: {
+        scan_on_proxy: false,
+        proxy_scan_action: "fail_open",
+        entry: entry({ state: "vulnerable", findings_count: 1, critical_count: 1 }),
+      },
+    });
+
+    renderPanel();
+
+    expect(screen.getByTestId("proxy-scan-enforcement-banner")).toBeInTheDocument();
+    expect(
+      screen.getByText(/verdicts shown were recorded elsewhere/i),
+    ).toBeInTheDocument();
+    // And it must not claim this repository did the scanning.
+    expect(screen.queryByText(/this repository scanned/i)).toBeNull();
+  });
+
+  it("renders not_scanned neutrally and never as clean", () => {
+    stubQuery({
+      data: {
+        scan_on_proxy: false,
+        proxy_scan_action: "fail_open",
+        entry: entry({
+          state: "not_scanned",
+          reason: "scanning_disabled",
+          scanned_at: null,
+        }),
+      },
+    });
+
+    renderPanel();
+
+    expect(screen.getByTestId("proxy-scan-verdict")).toHaveAttribute(
+      "data-tone",
+      "neutral",
+    );
+    expect(screen.getByText(/scanning is disabled/i)).toBeInTheDocument();
+    expect(screen.getByText(/not evidence of safety/i)).toBeInTheDocument();
+    // not_scanned is not an inherited verdict, so no enforcement banner.
+    expect(screen.queryByTestId("proxy-scan-enforcement-banner")).toBeNull();
+  });
+
+  it("names the remedy whenever a verdict is on screen", () => {
+    stubQuery({
+      data: {
+        scan_on_proxy: true,
+        proxy_scan_action: "fail_closed",
+        entry: entry({ state: "vulnerable", findings_count: 1, high_count: 1 }),
+      },
+    });
+
+    renderPanel();
+
+    expect(
+      screen.getByText(/Per-CVE detail is not available for proxy-cached content/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/ingest this artifact into a hosted repository/i),
+    ).toBeInTheDocument();
+  });
+
+  it("queries by cache path, scoped to the repository", () => {
+    stubQuery({ data: { entry: entry() } });
+
+    renderPanel();
+
+    const opts = mockUseQuery.mock.calls[0][0] as {
+      queryKey: unknown[];
+      retry: boolean;
+      queryFn: () => unknown;
+    };
+    expect(opts.queryKey).toEqual([
+      "proxy-scan",
+      "npm-remote",
+      "left-pad/-/left-pad-1.3.0.tgz",
+    ]);
+    // A 401 must surface as the sign-in state immediately, not after retries.
+    expect(opts.retry).toBe(false);
+
+    opts.queryFn();
+    expect(mockGetByPath).toHaveBeenCalledWith(
+      "npm-remote",
+      "left-pad/-/left-pad-1.3.0.tgz",
+    );
+  });
+});

--- a/src/app/(app)/repositories/_components/__tests__/proxy-scan-summary.test.tsx
+++ b/src/app/(app)/repositories/_components/__tests__/proxy-scan-summary.test.tsx
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { ApiError } from "@/lib/api/fetch";
 import type {
@@ -205,6 +206,38 @@ describe("ProxyScanSummarySection — listing", () => {
 
     opts.queryFn();
     expect(mockList).toHaveBeenCalledWith("npm-remote", { page: 1, per_page: 20 });
+  });
+
+  it("sorts by every column without throwing on a null scanned_at", async () => {
+    // `not_scanned` rows carry no timestamp, so the sort accessors have to
+    // tolerate null rather than producing an invalid comparison.
+    stubQuery({
+      data: response({
+        items: [
+          entry({ path: "b.tgz", state: "vulnerable", findings_count: 2, high_count: 2 }),
+          entry({
+            path: "a.tgz",
+            state: "not_scanned",
+            reason: "unknown",
+            scanned_at: null,
+          }),
+        ],
+        total: 2,
+      }),
+    });
+
+    render(<ProxyScanSummarySection repositoryKey="npm-remote" />);
+
+    for (const header of ["Cache path", "Status", "Findings", "Scanned"]) {
+      await userEvent.click(
+        screen.getByRole("button", { name: `Sort by ${header}` }),
+      );
+    }
+
+    expect(screen.getByText("a.tgz")).toBeInTheDocument();
+    expect(screen.getByText("b.tgz")).toBeInTheDocument();
+    // The row with no verdict still renders a placeholder, never a clean date.
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
   });
 
   it("shows a skeleton before the first page arrives", () => {

--- a/src/app/(app)/repositories/_components/__tests__/proxy-scan-summary.test.tsx
+++ b/src/app/(app)/repositories/_components/__tests__/proxy-scan-summary.test.tsx
@@ -1,0 +1,217 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+import { ApiError } from "@/lib/api/fetch";
+import type {
+  ProxyScanEntry,
+  ProxyScanListResponse,
+} from "@/types/proxy-scans";
+
+const mockUseQuery = vi.hoisted(() => vi.fn());
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (opts: unknown) => mockUseQuery(opts),
+}));
+
+const mockList = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/api/proxy-scans", () => ({
+  proxyScansApi: { list: mockList, getByPath: vi.fn() },
+}));
+
+import { ProxyScanSummarySection } from "../proxy-scan-summary";
+
+function entry(overrides: Partial<ProxyScanEntry> = {}): ProxyScanEntry {
+  return {
+    path: "left-pad/-/left-pad-1.3.0.tgz",
+    state: "clean",
+    reason: null,
+    critical_count: 0,
+    high_count: 0,
+    medium_count: 0,
+    low_count: 0,
+    findings_count: 0,
+    scanned_at: "2026-08-01T12:00:00Z",
+    ...overrides,
+  };
+}
+
+function response(
+  overrides: Partial<ProxyScanListResponse> = {},
+): ProxyScanListResponse {
+  return {
+    scan_on_proxy: true,
+    proxy_scan_action: "fail_closed",
+    summary: { clean: 4, vulnerable: 2, not_scanned: 1, pending_ingest: 3 },
+    items: [entry()],
+    total: 1,
+    page: 1,
+    per_page: 20,
+    ...overrides,
+  };
+}
+
+function stubQuery(result: {
+  data?: ProxyScanListResponse;
+  isLoading?: boolean;
+  error?: unknown;
+}) {
+  mockUseQuery.mockReturnValue({
+    data: result.data,
+    isLoading: result.isLoading ?? false,
+    error: result.error ?? null,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => cleanup());
+
+describe("ProxyScanSummarySection — access", () => {
+  it("renders the sign-in copy for an anonymous viewer, not an empty table", () => {
+    // An empty table would read as "nothing cached, nothing wrong" — the same
+    // implied all-clear the per-artifact panel had to remove.
+    stubQuery({ error: new ApiError(401, "unauthorized") });
+
+    render(<ProxyScanSummarySection repositoryKey="npm-remote" />);
+
+    expect(screen.getByText("Sign in to view scan status.")).toBeInTheDocument();
+    expect(screen.queryByTestId("proxy-summary-clean")).toBeNull();
+  });
+
+  it("says the endpoint is unavailable rather than reporting a scan failure on a 404", () => {
+    stubQuery({ error: new ApiError(404, "not found") });
+
+    render(<ProxyScanSummarySection repositoryKey="npm-remote" />);
+
+    expect(screen.getByTestId("proxy-scan-unavailable")).toBeInTheDocument();
+    expect(screen.queryByText(/not a clean result/i)).toBeNull();
+  });
+});
+
+describe("ProxyScanSummarySection — summary", () => {
+  it("renders counts by state plus the pending-ingest count", () => {
+    stubQuery({ data: response() });
+
+    render(<ProxyScanSummarySection repositoryKey="npm-remote" />);
+
+    expect(screen.getByTestId("proxy-summary-clean")).toHaveTextContent("4");
+    expect(screen.getByTestId("proxy-summary-vulnerable")).toHaveTextContent("2");
+    expect(screen.getByTestId("proxy-summary-not-scanned")).toHaveTextContent("1");
+    // NULL-checksum placeholder rows are excluded from the state counts, so
+    // they are reported separately for the totals to reconcile with the
+    // artifact listing.
+    expect(screen.getByTestId("proxy-summary-pending-ingest")).toHaveTextContent(
+      "3",
+    );
+  });
+
+  it("labels the counts as distinct digests, not cache paths", () => {
+    stubQuery({ data: response() });
+
+    render(<ProxyScanSummarySection repositoryKey="npm-remote" />);
+
+    expect(
+      screen.getByText(/distinct content digests, not cache paths/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the enforcement banner when a non-scanning repository displays verdicts", () => {
+    stubQuery({
+      data: response({ scan_on_proxy: false, proxy_scan_action: "fail_open" }),
+    });
+
+    render(<ProxyScanSummarySection repositoryKey="npm-remote" />);
+
+    expect(screen.getByTestId("proxy-scan-enforcement-banner")).toBeInTheDocument();
+  });
+
+  it("omits the enforcement banner when the repository scans its own downloads", () => {
+    stubQuery({ data: response() });
+
+    render(<ProxyScanSummarySection repositoryKey="npm-remote" />);
+
+    expect(screen.queryByTestId("proxy-scan-enforcement-banner")).toBeNull();
+  });
+
+  it("omits the enforcement banner when there is no verdict to attribute", () => {
+    stubQuery({
+      data: response({
+        scan_on_proxy: false,
+        summary: { clean: 0, vulnerable: 0, not_scanned: 9, pending_ingest: 0 },
+      }),
+    });
+
+    render(<ProxyScanSummarySection repositoryKey="npm-remote" />);
+
+    expect(screen.queryByTestId("proxy-scan-enforcement-banner")).toBeNull();
+  });
+});
+
+describe("ProxyScanSummarySection — listing", () => {
+  it("names which digests are affected, not only how many", () => {
+    // Counts alone answer "2 vulnerable digests" but not which ones, forcing a
+    // click through every artifact modal to find them.
+    stubQuery({
+      data: response({
+        items: [
+          entry({
+            path: "jinja2/jinja2-2.11.2.tar.gz",
+            state: "vulnerable",
+            critical_count: 1,
+            high_count: 4,
+            findings_count: 5,
+          }),
+          entry({ path: "requests/requests-2.32.5-py3-none-any.whl" }),
+        ],
+        total: 2,
+      }),
+    });
+
+    render(<ProxyScanSummarySection repositoryKey="npm-remote" />);
+
+    expect(screen.getByText("jinja2/jinja2-2.11.2.tar.gz")).toBeInTheDocument();
+    expect(
+      screen.getByText("requests/requests-2.32.5-py3-none-any.whl"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Vulnerable")).toBeInTheDocument();
+    expect(screen.getByText("Clean")).toBeInTheDocument();
+    expect(screen.getByText("5 findings")).toBeInTheDocument();
+  });
+
+  it("names the remedy for missing per-CVE detail", () => {
+    stubQuery({ data: response() });
+
+    render(<ProxyScanSummarySection repositoryKey="npm-remote" />);
+
+    expect(
+      screen.getByText(/ingest this artifact into a hosted repository/i),
+    ).toBeInTheDocument();
+  });
+
+  it("requests the repository-scoped page without retrying a 401", () => {
+    stubQuery({ data: response() });
+
+    render(<ProxyScanSummarySection repositoryKey="npm-remote" />);
+
+    const opts = mockUseQuery.mock.calls[0][0] as {
+      queryKey: unknown[];
+      retry: boolean;
+      queryFn: () => unknown;
+    };
+    expect(opts.queryKey).toEqual(["proxy-scans", "npm-remote", 1]);
+    expect(opts.retry).toBe(false);
+
+    opts.queryFn();
+    expect(mockList).toHaveBeenCalledWith("npm-remote", { page: 1, per_page: 20 });
+  });
+
+  it("shows a skeleton before the first page arrives", () => {
+    stubQuery({ isLoading: true });
+
+    render(<ProxyScanSummarySection repositoryKey="npm-remote" />);
+
+    expect(screen.queryByTestId("proxy-summary-clean")).toBeNull();
+  });
+});

--- a/src/app/(app)/repositories/_components/__tests__/repo-detail-proxy-scan.test.tsx
+++ b/src/app/(app)/repositories/_components/__tests__/repo-detail-proxy-scan.test.tsx
@@ -1,0 +1,232 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// ---------------------------------------------------------------------------
+// Repository Security tab audience (proxy scan visibility).
+//
+// The tab used to be admin-only and rendered nothing but the scan-config form.
+// The proxy verdict endpoint authorizes any authenticated user with repository
+// visibility, so gating the summary behind `is_admin` would leave non-admin
+// developers with the per-artifact panel and no way to see which digests are
+// affected. This suite pins that decision, plus the fact that the config form
+// stays admin-only.
+//
+// Kept out of repo-detail-content.test.tsx because that suite hardcodes an
+// admin viewer and a virtual/generic repository at module scope.
+// ---------------------------------------------------------------------------
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+  Element.prototype.scrollIntoView = vi.fn();
+  Element.prototype.hasPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  // No `?tab=` override: the default tab is format-driven and the Security
+  // panel is opened by click below.
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+// Mutable per-test knobs.
+let repository: Record<string, unknown> = {
+  id: "11111111-1111-1111-1111-111111111111",
+  key: "npm-remote",
+  name: "npm remote",
+  format: "npm",
+  repo_type: "remote",
+  storage_backend: "filesystem",
+  versioning_enabled: false,
+};
+let isAdmin = false;
+let isAuthenticated = true;
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (opts: { queryKey: unknown[] }) => {
+    const key = Array.isArray(opts.queryKey) ? opts.queryKey[0] : undefined;
+    if (key === "repository") {
+      return { data: repository, isLoading: false, isFetching: false };
+    }
+    if (key === "artifacts") {
+      return {
+        data: {
+          items: [],
+          pagination: { page: 1, per_page: 20, total: 0, total_pages: 0 },
+        },
+        isLoading: false,
+        isFetching: false,
+      };
+    }
+    return { data: undefined, isLoading: false, isFetching: false };
+  },
+  useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock("@/providers/auth-provider", () => ({
+  useAuth: () => ({ isAuthenticated, user: { is_admin: isAdmin } }),
+}));
+
+vi.mock("@/providers/system-config-provider", () => ({
+  useSystemConfig: () => ({ config: { max_upload_size_bytes: 1_000_000 } }),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+vi.mock("@/lib/api/repositories", () => ({ repositoriesApi: { get: vi.fn() } }));
+vi.mock("@/lib/api/artifacts", () => ({
+  artifactsApi: {
+    listGrouped: vi.fn(),
+    getAbsoluteDownloadUrl: () => "http://localhost/download",
+    getDownloadUrl: () => "/download",
+    createDownloadTicket: vi.fn(),
+    get: vi.fn(),
+    delete: vi.fn(),
+    invalidateCache: vi.fn(),
+    upload: vi.fn(),
+  },
+}));
+vi.mock("@/lib/api/security", () => ({
+  securityApi: {
+    getRepoSecurity: vi.fn(),
+    triggerScan: vi.fn(),
+    updateRepoSecurity: vi.fn(),
+  },
+}));
+vi.mock("@/lib/api/quarantine", () => ({
+  quarantineApi: {
+    getStatus: vi.fn(),
+    release: vi.fn(),
+    reject: vi.fn(),
+    quarantine: vi.fn(),
+  },
+}));
+
+// The section under observation is stubbed: it has its own suite
+// (proxy-scan-summary.test.tsx). Here we assert only where it is mounted.
+const summaryProps = vi.hoisted(() => vi.fn());
+vi.mock("../proxy-scan-summary", () => ({
+  ProxyScanSummarySection: (props: { repositoryKey: string }) => {
+    summaryProps(props);
+    return <div data-testid="stub-proxy-scan-summary" />;
+  },
+}));
+
+vi.mock("../artifact-versions-section", () => ({ ArtifactVersionsSection: () => <div /> }));
+vi.mock("../sbom-tab-content", () => ({ SbomTabContent: () => <div /> }));
+vi.mock("../security-tab-content", () => ({ SecurityTabContent: () => <div /> }));
+vi.mock("../health-tab-content", () => ({ HealthTabContent: () => <div /> }));
+vi.mock("../notifications-tab-content", () => ({ NotificationsTabContent: () => <div /> }));
+vi.mock("../virtual-members-panel", () => ({ VirtualMembersPanel: () => <div /> }));
+vi.mock("../packages-tab-content", () => ({ PackagesTabContent: () => <div /> }));
+vi.mock("../repo-settings-tab", () => ({ RepoSettingsTab: () => <div /> }));
+vi.mock("../repo-labels-panel", () => ({ RepoLabelsPanel: () => <div /> }));
+vi.mock("../repo-storage-panel", () => ({ RepoStoragePanel: () => <div /> }));
+vi.mock("../repo-folder-storage-panel", () => ({ RepoFolderStoragePanel: () => <div /> }));
+vi.mock("../pypi-tracks-panel", () => ({ PypiTracksPanel: () => <div /> }));
+vi.mock("../maven-component-list", () => ({ MavenComponentList: () => <div /> }));
+vi.mock("../docker-tag-list", () => ({ DockerTagList: () => <div /> }));
+vi.mock("../artifact-folder-tree", () => ({ ArtifactFolderTree: () => <div /> }));
+vi.mock("../artifact-browser-toggle", () => ({
+  ArtifactBrowserToggle: () => <div />,
+  supportsGrouping: () => false,
+  supportsTree: () => false,
+}));
+vi.mock("@/components/common/data-table", () => ({ DataTable: () => <div /> }));
+vi.mock("@/components/common/file-upload", () => ({ FileUpload: () => <div /> }));
+vi.mock("@/components/common/copy-button", () => ({ CopyButton: () => <div /> }));
+
+import { RepoDetailContent } from "../repo-detail-content";
+
+const REMOTE_NPM = {
+  id: "11111111-1111-1111-1111-111111111111",
+  key: "npm-remote",
+  name: "npm remote",
+  format: "npm",
+  repo_type: "remote",
+  storage_backend: "filesystem",
+  versioning_enabled: false,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  repository = { ...REMOTE_NPM };
+  isAdmin = false;
+  isAuthenticated = true;
+});
+afterEach(() => cleanup());
+
+/**
+ * Radix only mounts the active tab panel, and the format-driven default tab
+ * (#2793) is only ever Artifacts or Packages, so the Security panel has to be
+ * opened before its contents can be asserted.
+ */
+async function openSecurityTab() {
+  render(<RepoDetailContent repoKey="npm-remote" />);
+  await userEvent.click(screen.getByRole("tab", { name: /security/i }));
+}
+
+describe("Repository Security tab — proxy scan audience", () => {
+  it("gives a non-admin authenticated user the Security tab and the proxy summary", async () => {
+    await openSecurityTab();
+
+    expect(screen.getByTestId("stub-proxy-scan-summary")).toBeInTheDocument();
+    expect(summaryProps).toHaveBeenCalledWith({ repositoryKey: "npm-remote" });
+  });
+
+  it("does not give a non-admin the scan-config form", async () => {
+    await openSecurityTab();
+
+    expect(screen.queryByLabelText(/Scan on Proxy/i)).toBeNull();
+    expect(screen.queryByRole("button", { name: /save settings/i })).toBeNull();
+  });
+
+  it("gives an admin both the summary and the config form", async () => {
+    isAdmin = true;
+
+    await openSecurityTab();
+
+    expect(screen.getByTestId("stub-proxy-scan-summary")).toBeInTheDocument();
+    expect(screen.getByLabelText(/Scan on Proxy/i)).toBeInTheDocument();
+  });
+
+  it("keeps the tab hidden from anonymous non-admin viewers", () => {
+    // The endpoint 401s them, so there is nothing to show; the per-artifact
+    // panel is where they get the sign-in prompt.
+    isAuthenticated = false;
+
+    render(<RepoDetailContent repoKey="npm-remote" />);
+
+    expect(screen.queryByRole("tab", { name: /security/i })).toBeNull();
+    expect(screen.queryByTestId("stub-proxy-scan-summary")).toBeNull();
+  });
+
+  it("does not mount the summary on a repository with no proxy cache", async () => {
+    repository = { ...REMOTE_NPM, repo_type: "local" };
+    isAdmin = true;
+
+    await openSecurityTab();
+
+    expect(screen.queryByTestId("stub-proxy-scan-summary")).toBeNull();
+    // The admin config form is unaffected.
+    expect(screen.getByLabelText(/Scan on Proxy/i)).toBeInTheDocument();
+  });
+
+  it("does not mount the summary on a Remote repository whose format has no proxy gate", async () => {
+    repository = { ...REMOTE_NPM, format: "maven" };
+    isAdmin = true;
+
+    await openSecurityTab();
+
+    expect(screen.queryByTestId("stub-proxy-scan-summary")).toBeNull();
+  });
+});

--- a/src/app/(app)/repositories/_components/__tests__/sbom-tab-content.test.tsx
+++ b/src/app/(app)/repositories/_components/__tests__/sbom-tab-content.test.tsx
@@ -129,7 +129,7 @@ describe("SbomTabContent — analyzable gating (artifact-keeper#2292)", () => {
     const generateButtons = screen.getAllByRole("button", { name: /generate/i });
     expect(generateButtons.length).toBeGreaterThan(0);
     for (const btn of generateButtons) expect(btn).toBeDisabled();
-    expect(screen.getByText(/proxy-cached remote artifacts/i)).toBeInTheDocument();
+    expect(screen.getByText(/proxy-cached artifacts/i)).toBeInTheDocument();
     expect(mockMutate).not.toHaveBeenCalled();
   });
 

--- a/src/app/(app)/repositories/_components/__tests__/sbom-tab-content.test.tsx
+++ b/src/app/(app)/repositories/_components/__tests__/sbom-tab-content.test.tsx
@@ -124,12 +124,14 @@ describe("SbomTabContent — analyzable gating (artifact-keeper#2292)", () => {
   });
   afterEach(() => cleanup());
 
-  it("disables every Generate action and explains why for a non-analyzable artifact", () => {
+  it("offers no Generate action at all for a non-analyzable artifact", () => {
+    // #2292's guarantee — never offer an action that 404s — is now met by
+    // removing the button rather than disabling it: proxy-cached artifacts get
+    // the proxy SBOM panel, which serves the inventory the download-time scan
+    // recorded and explains that it cannot be generated on demand.
     render(<SbomTabContent artifact={art({ analyzable: false })} />);
-    const generateButtons = screen.getAllByRole("button", { name: /generate/i });
-    expect(generateButtons.length).toBeGreaterThan(0);
-    for (const btn of generateButtons) expect(btn).toBeDisabled();
-    expect(screen.getByText(/proxy-cached artifacts/i)).toBeInTheDocument();
+    expect(screen.queryAllByRole("button", { name: /generate/i })).toHaveLength(0);
+    expect(screen.getByText(/Proxy Cache SBOM/i)).toBeInTheDocument();
     expect(mockMutate).not.toHaveBeenCalled();
   });
 

--- a/src/app/(app)/repositories/_components/__tests__/sbom-tab-proxy.test.tsx
+++ b/src/app/(app)/repositories/_components/__tests__/sbom-tab-proxy.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+import type { Artifact } from "@/types";
+
+// ---------------------------------------------------------------------------
+// Which SBOM the artifact SBOM tab serves.
+//
+// Proxy-cached artifacts have no `artifacts` row, so the hosted SBOM queries
+// are structurally empty for them and generation 404s. The tab used to render
+// a permanently disabled Generate button over "SBOM is unavailable"; it now
+// serves the inventory the download-time scan recorded instead.
+// ---------------------------------------------------------------------------
+
+const mockUseQuery = vi.hoisted(() => vi.fn());
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (opts: unknown) => mockUseQuery(opts),
+  useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock("@/lib/api/sbom", () => ({
+  sbomApi: {
+    list: vi.fn(),
+    get: vi.fn(),
+    getComponents: vi.fn(),
+    getCveHistory: vi.fn(),
+    generate: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/error-utils", () => ({ mutationErrorToast: () => () => {} }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+const panelProps = vi.hoisted(() => vi.fn());
+vi.mock("../proxy-sbom-panel", () => ({
+  ProxySbomPanel: (props: Record<string, unknown>) => {
+    panelProps(props);
+    return <div data-testid="stub-proxy-sbom-panel" />;
+  },
+}));
+
+import { SbomTabContent } from "../sbom-tab-content";
+
+function art(overrides: Partial<Artifact> = {}): Artifact {
+  return {
+    id: "a1",
+    repository_key: "pypi-remote",
+    path: "jinja2/Jinja2-2.11.2-py2.py3-none-any.whl",
+    name: "Jinja2-2.11.2-py2.py3-none-any.whl",
+    size_bytes: 1024,
+    checksum_sha256: "deadbeef",
+    content_type: "application/octet-stream",
+    download_count: 0,
+    created_at: "2026-06-01T10:00:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // No hosted SBOMs and no CVE history — the state a proxy artifact is always
+  // in, and the state a hosted artifact starts in.
+  mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+});
+afterEach(() => cleanup());
+
+describe("SbomTabContent — proxy-cached artifacts", () => {
+  it("serves the proxy SBOM panel, keyed by cache path", () => {
+    render(
+      <SbomTabContent
+        artifact={art({ analyzable: false })}
+        repositoryFormat="pypi"
+      />,
+    );
+
+    expect(screen.getByTestId("stub-proxy-sbom-panel")).toBeInTheDocument();
+    expect(panelProps).toHaveBeenCalledWith({
+      repositoryKey: "pypi-remote",
+      path: "jinja2/Jinja2-2.11.2-py2.py3-none-any.whl",
+      artifactName: "Jinja2-2.11.2-py2.py3-none-any.whl",
+      repositoryFormat: "pypi",
+    });
+  });
+
+  it("stops claiming SBOMs are unavailable for proxy-cached artifacts", () => {
+    render(
+      <SbomTabContent
+        artifact={art({ analyzable: false })}
+        repositoryFormat="pypi"
+      />,
+    );
+
+    expect(screen.queryByText(/available only for artifacts hosted/i)).toBeNull();
+    // And no permanently disabled Generate button.
+    expect(screen.queryByRole("button", { name: /generate/i })).toBeNull();
+  });
+});
+
+describe("SbomTabContent — hosted artifacts", () => {
+  it("keeps the hosted SBOM flow untouched", () => {
+    render(<SbomTabContent artifact={art({ analyzable: true })} />);
+
+    expect(screen.queryByTestId("stub-proxy-sbom-panel")).toBeNull();
+    expect(panelProps).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(/No SBOM generated for this artifact yet/i),
+    ).toBeInTheDocument();
+    // Two: the header action and the empty-state call to action.
+    expect(screen.getAllByRole("button", { name: /generate/i })).not.toHaveLength(
+      0,
+    );
+  });
+
+  it("treats a missing analyzable flag as hosted (safe default for older responses)", () => {
+    render(<SbomTabContent artifact={art()} />);
+
+    expect(screen.queryByTestId("stub-proxy-sbom-panel")).toBeNull();
+  });
+});

--- a/src/app/(app)/repositories/_components/__tests__/security-tab-content.test.tsx
+++ b/src/app/(app)/repositories/_components/__tests__/security-tab-content.test.tsx
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import React from "react";
+
+import type { Artifact } from "@/types";
+import { ANALYZABLE_DISABLED_REASON } from "@/lib/artifact-analyzable";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockUseQuery = vi.hoisted(() => vi.fn());
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (opts: unknown) => mockUseQuery(opts),
+  useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock("@/lib/api/sbom", () => ({
+  sbomApi: { getCveHistory: vi.fn(), updateCveStatus: vi.fn() },
+}));
+
+vi.mock("@/lib/api/dependency-track", () => ({
+  dtApi: {
+    getStatus: vi.fn(),
+    listProjects: vi.fn(),
+    getProjectMetrics: vi.fn(),
+    getProjectFindings: vi.fn(),
+    updateAnalysis: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/error-utils", () => ({ mutationErrorToast: () => () => {} }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+vi.mock("lucide-react", () => {
+  const icon = () => null;
+  return {
+    ShieldAlert: icon,
+    ShieldCheck: icon,
+    ShieldQuestion: icon,
+    AlertTriangle: icon,
+    Clock: icon,
+    ChevronDown: icon,
+    CheckCircle2: icon,
+    XCircle: icon,
+    Eye: icon,
+    Link2: icon,
+    Link2Off: icon,
+    Activity: icon,
+  };
+});
+
+// Stub out the scans list section — it has its own tests
+// (artifact-scans-section.test.tsx) and its own queries; stubbing it here
+// keeps this file focused on the CVE-history empty state this task changes.
+vi.mock("../artifact-scans-section", () => ({
+  ArtifactScansSection: () => <div data-testid="stub-artifact-scans-section" />,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...rest }: React.ComponentProps<"button">) => (
+    <button {...rest}>{children}</button>
+  ),
+}));
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock("@/components/ui/skeleton", () => ({
+  Skeleton: ({ className }: { className?: string }) => (
+    <div data-testid="skeleton" className={className} />
+  ),
+}));
+
+vi.mock("@/components/ui/separator", () => ({ Separator: () => <hr /> }));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/common/data-table", () => ({
+  DataTable: () => <div data-testid="data-table" />,
+}));
+
+vi.mock("@/components/common/vuln-id-link", () => ({
+  VulnIdLink: ({ id }: { id: string }) => <span>{id}</span>,
+}));
+
+// ---------------------------------------------------------------------------
+// Component under test
+// ---------------------------------------------------------------------------
+
+import { SecurityTabContent } from "../security-tab-content";
+
+function art(overrides: Partial<Artifact> = {}): Artifact {
+  return {
+    id: "a1",
+    repository_key: "npm-remote",
+    path: "left-pad/left-pad-1.3.0.tgz",
+    name: "left-pad-1.3.0.tgz",
+    size_bytes: 1024,
+    checksum_sha256: "deadbeef",
+    content_type: "application/octet-stream",
+    download_count: 0,
+    created_at: "2026-06-01T10:00:00Z",
+    ...overrides,
+  };
+}
+
+// Zero CVE history and no Dependency-Track status — drives the `total === 0`
+// empty state this task changes, without pulling in the (separately tested)
+// DT integration section.
+function stubEmptyQueries() {
+  mockUseQuery.mockImplementation((opts: { queryKey: unknown[] }) => {
+    const key = opts.queryKey[0];
+    if (key === "cve-history") return { data: [], isLoading: false };
+    // dt-status / dt-projects / dt-project-metrics / dt-project-findings:
+    // no DT integration configured, keeps the DT section from rendering.
+    return { data: undefined, isLoading: false };
+  });
+}
+
+describe("SecurityTabContent — CVE empty state (#3344)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubEmptyQueries();
+  });
+  afterEach(() => cleanup());
+
+  it("shows the green all-clear and SBOM hint when the artifact is analyzable", () => {
+    render(<SecurityTabContent artifact={art({ analyzable: true })} />);
+    expect(
+      screen.getByText(/No vulnerabilities detected for this artifact/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Generate an SBOM and run a security scan/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/CVE history is not available/i)).toBeNull();
+  });
+
+  it("does not show a green all-clear for non-analyzable proxy-cached artifacts (#3344)", () => {
+    render(<SecurityTabContent artifact={art({ analyzable: false })} />);
+    // This is the bug this task fixes: a proxy-cached artifact the download
+    // gate blocked must never render the "no vulnerabilities" all-clear —
+    // its CVE-history total is structurally always zero, so the old
+    // unconditional total===0 branch was misleading.
+    expect(
+      screen.queryByText(/No vulnerabilities detected for this artifact/i),
+    ).toBeNull();
+    // The neutral replacement state renders instead, with the narrowed
+    // disabled-reason copy (proxy-cached artifacts ARE scanned at download
+    // time under scan-on-proxy).
+    expect(
+      screen.getByText(/CVE history is not available for this artifact/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(ANALYZABLE_DISABLED_REASON)).toBeInTheDocument();
+  });
+
+  it("keeps the green all-clear when analyzable is absent (safe default, older responses)", () => {
+    render(<SecurityTabContent artifact={art()} />);
+    expect(
+      screen.getByText(/No vulnerabilities detected for this artifact/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/(app)/repositories/_components/__tests__/security-tab-content.test.tsx
+++ b/src/app/(app)/repositories/_components/__tests__/security-tab-content.test.tsx
@@ -60,6 +60,17 @@ vi.mock("../artifact-scans-section", () => ({
   ArtifactScansSection: () => <div data-testid="stub-artifact-scans-section" />,
 }));
 
+// Same rationale for the proxy verdict panel — it has its own query and its
+// own tests (proxy-scan-panel.test.tsx). Here we only assert that it is
+// mounted for proxy-cached artifacts and given the right lookup key.
+const proxyPanelProps = vi.hoisted(() => vi.fn());
+vi.mock("../proxy-scan-panel", () => ({
+  ProxyScanPanel: (props: { repositoryKey: string; path: string }) => {
+    proxyPanelProps(props);
+    return <div data-testid="stub-proxy-scan-panel" />;
+  },
+}));
+
 vi.mock("@/components/ui/button", () => ({
   Button: ({ children, ...rest }: React.ComponentProps<"button">) => (
     <button {...rest}>{children}</button>
@@ -168,5 +179,32 @@ describe("SecurityTabContent — CVE empty state (#3344)", () => {
     expect(
       screen.getByText(/No vulnerabilities detected for this artifact/i),
     ).toBeInTheDocument();
+  });
+});
+
+describe("SecurityTabContent — proxy verdict panel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubEmptyQueries();
+  });
+  afterEach(() => cleanup());
+
+  it("mounts the proxy verdict panel for proxy-cached artifacts, keyed by cache path", () => {
+    // Every artifact-keyed source on this tab is structurally empty for proxy
+    // content, so the digest-keyed verdict is the only real answer. Lookup is
+    // by cache path — a digest parameter would be a cross-tenant oracle.
+    render(<SecurityTabContent artifact={art({ analyzable: false })} />);
+
+    expect(screen.getByTestId("stub-proxy-scan-panel")).toBeInTheDocument();
+    expect(proxyPanelProps).toHaveBeenCalledWith({
+      repositoryKey: "npm-remote",
+      path: "left-pad/left-pad-1.3.0.tgz",
+    });
+  });
+
+  it("does not mount the proxy verdict panel for hosted artifacts", () => {
+    render(<SecurityTabContent artifact={art({ analyzable: true })} />);
+    expect(screen.queryByTestId("stub-proxy-scan-panel")).toBeNull();
+    expect(proxyPanelProps).not.toHaveBeenCalled();
   });
 });

--- a/src/app/(app)/repositories/_components/artifact-scans-section.tsx
+++ b/src/app/(app)/repositories/_components/artifact-scans-section.tsx
@@ -5,7 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { ShieldAlert, AlertTriangle, Clock } from "lucide-react";
 
 import { securityApi } from "@/lib/api/security";
-import { ANALYZABLE_DISABLED_REASON } from "@/lib/artifact-analyzable";
+import { PROXY_SCAN_AVAILABILITY_NOTE } from "@/lib/artifact-analyzable";
 import type { ScanResult } from "@/types/security";
 
 import { Badge } from "@/components/ui/badge";
@@ -160,7 +160,7 @@ export function ArtifactScansSection({
           <p className="text-xs text-muted-foreground mt-1">
             {analyzable
               ? "Trigger a scan from the artifact actions menu to populate this section."
-              : ANALYZABLE_DISABLED_REASON}
+              : PROXY_SCAN_AVAILABILITY_NOTE}
           </p>
         </div>
       ) : (

--- a/src/app/(app)/repositories/_components/artifact-scans-section.tsx
+++ b/src/app/(app)/repositories/_components/artifact-scans-section.tsx
@@ -5,6 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { ShieldAlert, AlertTriangle, Clock } from "lucide-react";
 
 import { securityApi } from "@/lib/api/security";
+import { ANALYZABLE_DISABLED_REASON } from "@/lib/artifact-analyzable";
 import type { ScanResult } from "@/types/security";
 
 import { Badge } from "@/components/ui/badge";
@@ -159,7 +160,7 @@ export function ArtifactScansSection({
           <p className="text-xs text-muted-foreground mt-1">
             {analyzable
               ? "Trigger a scan from the artifact actions menu to populate this section."
-              : "SBOM and scanning are available only for artifacts hosted in this registry, not proxy-cached remote artifacts."}
+              : ANALYZABLE_DISABLED_REASON}
           </p>
         </div>
       ) : (

--- a/src/app/(app)/repositories/_components/artifact-scans-section.tsx
+++ b/src/app/(app)/repositories/_components/artifact-scans-section.tsx
@@ -155,7 +155,7 @@ export function ArtifactScansSection({
           <p className="text-sm text-muted-foreground">
             {analyzable
               ? "No security scans have been run against this artifact yet."
-              : "This artifact cannot be scanned."}
+              : "This artifact cannot be scanned on demand."}
           </p>
           <p className="text-xs text-muted-foreground mt-1">
             {analyzable

--- a/src/app/(app)/repositories/_components/proxy-sbom-panel.tsx
+++ b/src/app/(app)/repositories/_components/proxy-sbom-panel.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  ChevronDown,
+  ChevronRight,
+  Download,
+  FileText,
+  Package,
+  Scale,
+} from "lucide-react";
+
+import { proxySbomApi } from "@/lib/api/proxy-sbom";
+import { classifyProxyScanError } from "@/lib/proxy-scan";
+import {
+  PROXY_SBOM_FORMAT_UNSUPPORTED_COPY,
+  PROXY_SBOM_GENERATION_NOTE,
+  PROXY_SBOM_INVENTORY_CAVEAT,
+  PROXY_SBOM_NOT_RECORDED_COPY,
+  formatHasProxySbom,
+  formatSbomDocument,
+  parseProxySbom,
+  sbomLicenseSummary,
+} from "@/lib/proxy-sbom";
+import type { ProxySbomComponent, ProxySbomFormat } from "@/types/proxy-sbom";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { DataTable, type DataTableColumn } from "@/components/common/data-table";
+import { CopyButton } from "@/components/common/copy-button";
+
+import { ProxyScanAccessNotice } from "./proxy-scan-panel";
+
+/**
+ * SBOM viewer for proxy-cached artifacts.
+ *
+ * Until now the SBOM tab could only tell a user that SBOMs are unavailable for
+ * proxy content. They are not: every inline proxy scan catalogs the archive
+ * while it runs, and this renders that inventory.
+ *
+ * The rule that shapes the states below: **an empty inventory is not an empty
+ * SBOM.** A zero-row component table would assert the artifact has no
+ * dependencies, which nothing in the data supports. Missing, unparseable and
+ * empty documents all render as "no SBOM recorded", never as a table.
+ */
+
+const PAGE_SIZE = 20;
+
+function componentColumns(): DataTableColumn<ProxySbomComponent>[] {
+  return [
+    {
+      id: "name",
+      header: "Component",
+      accessor: (c) => c.name,
+      sortable: true,
+      cell: (c) => (
+        <div className="flex items-center gap-2">
+          <Package className="size-3.5 text-muted-foreground shrink-0" />
+          <span className="text-sm font-medium break-all">{c.name}</span>
+        </div>
+      ),
+    },
+    {
+      id: "version",
+      header: "Version",
+      accessor: (c) => c.version ?? "",
+      sortable: true,
+      cell: (c) =>
+        c.version ? (
+          <Badge variant="outline" className="text-xs font-mono">
+            {c.version}
+          </Badge>
+        ) : (
+          <span className="text-xs text-muted-foreground">—</span>
+        ),
+    },
+    {
+      id: "license",
+      header: "License",
+      accessor: (c) => c.license ?? "",
+      sortable: true,
+      cell: (c) =>
+        c.license ? (
+          <Badge variant="secondary" className="text-xs">
+            <Scale className="size-3 mr-1" />
+            {c.license}
+          </Badge>
+        ) : (
+          // The document asserted nothing. "Unknown" is the honest label; an
+          // empty cell would read as "no license restrictions".
+          <span className="text-xs text-muted-foreground">Unknown</span>
+        ),
+    },
+    {
+      id: "purl",
+      header: "Package URL",
+      accessor: (c) => c.purl ?? "",
+      cell: (c) =>
+        c.purl ? (
+          <div className="flex items-center gap-1 max-w-[260px]">
+            <code className="text-xs text-muted-foreground truncate" title={c.purl}>
+              {c.purl}
+            </code>
+            <CopyButton value={c.purl} />
+          </div>
+        ) : (
+          <span className="text-xs text-muted-foreground">—</span>
+        ),
+    },
+  ];
+}
+
+/** Explicit "nothing recorded" state. Never a zero-row table. */
+export function ProxySbomEmptyState({ message }: { message: string }) {
+  return (
+    <div
+      className="flex flex-col items-center justify-center rounded-lg border border-dashed py-10 text-center"
+      data-testid="proxy-sbom-empty"
+    >
+      <FileText className="size-10 text-muted-foreground/50 mb-3" />
+      <p className="text-sm text-muted-foreground max-w-md">{message}</p>
+    </div>
+  );
+}
+
+export function ProxySbomPanel({
+  repositoryKey,
+  path,
+  artifactName,
+  repositoryFormat,
+}: {
+  repositoryKey: string;
+  /** Cache path within the repository. Lookup is by path, never by digest. */
+  path: string;
+  /** Used to name the downloaded file. */
+  artifactName: string;
+  /**
+   * Repository format. Only PyPI, npm and Docker/OCI proxies run an inline
+   * scan, so other formats are told that plainly rather than being sent to an
+   * endpoint that has nothing to return.
+   */
+  repositoryFormat?: string | null;
+}) {
+  const [format, setFormat] = useState<ProxySbomFormat>("cyclonedx");
+  const [page, setPage] = useState(1);
+  const [rawExpanded, setRawExpanded] = useState(false);
+
+  const supported = formatHasProxySbom(repositoryFormat);
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["proxy-sbom", repositoryKey, path, format],
+    queryFn: () => proxySbomApi.get(repositoryKey, path, format),
+    enabled: supported,
+    // A 401 must surface as the sign-in state immediately rather than being
+    // retried behind a spinner.
+    retry: false,
+  });
+
+  const inventory = parseProxySbom(data);
+  const rawDocument = formatSbomDocument(data);
+
+  const handleDownload = () => {
+    if (!rawDocument) return;
+    const blob = new Blob([rawDocument], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `${artifactName}-proxy-sbom-${format}.json`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  const failure = error != null ? classifyProxyScanError(error) : null;
+  const licenses =
+    inventory.kind === "present" ? sbomLicenseSummary(inventory.components) : [];
+
+  return (
+    <div className="space-y-4" data-testid="proxy-sbom-panel">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <FileText className="size-5 text-muted-foreground" />
+          <h3 className="text-sm font-medium">Proxy Cache SBOM</h3>
+          {inventory.kind === "present" && (
+            <Badge variant="secondary" className="text-xs">
+              {inventory.components.length} component
+              {inventory.components.length === 1 ? "" : "s"}
+            </Badge>
+          )}
+        </div>
+        {supported && (
+          <div className="flex items-center gap-2">
+            <Select
+              value={format}
+              onValueChange={(v) => {
+                setFormat(v as ProxySbomFormat);
+                setPage(1);
+              }}
+            >
+              <SelectTrigger className="w-[140px]" aria-label="SBOM format">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="cyclonedx">CycloneDX</SelectItem>
+                <SelectItem value="spdx">SPDX</SelectItem>
+              </SelectContent>
+            </Select>
+            {inventory.kind === "present" && (
+              <Button variant="outline" size="sm" onClick={handleDownload}>
+                <Download className="size-4" />
+                Download
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* What this document is. Stated before the table, because the table
+          would otherwise read as a resolved dependency graph. */}
+      <p className="text-xs text-muted-foreground">
+        {PROXY_SBOM_INVENTORY_CAVEAT}
+      </p>
+
+      {!supported ? (
+        <ProxySbomEmptyState message={PROXY_SBOM_FORMAT_UNSUPPORTED_COPY} />
+      ) : isLoading ? (
+        <Skeleton className="h-40 w-full" />
+      ) : failure === "unauthenticated" || failure === "forbidden" ? (
+        // Same rule as the verdict panel: never implied-empty for the audience
+        // the endpoint refuses.
+        <ProxyScanAccessNotice failure={failure} />
+      ) : failure === "error" ? (
+        <ProxyScanAccessNotice failure="error" />
+      ) : inventory.kind === "absent" ? (
+        // Covers a 404, an empty document, and an unparseable one. All three
+        // mean "we have no inventory to show", which is not the same claim as
+        // "this artifact has no dependencies".
+        <ProxySbomEmptyState message={PROXY_SBOM_NOT_RECORDED_COPY} />
+      ) : (
+        <div className="space-y-4">
+          {licenses.length > 0 && (
+            <div className="space-y-2">
+              <p className="text-xs font-medium text-muted-foreground">
+                Declared licenses ({licenses.length})
+              </p>
+              <div className="flex flex-wrap gap-1">
+                {licenses.map((license) => (
+                  <Badge key={license} variant="secondary" className="text-xs">
+                    {license}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <DataTable
+            columns={componentColumns()}
+            data={inventory.components}
+            page={page}
+            pageSize={PAGE_SIZE}
+            total={inventory.components.length}
+            onPageChange={setPage}
+            emptyMessage="No components cataloged"
+            rowKey={(c) => `${c.name}@${c.version ?? ""}|${c.purl ?? ""}`}
+          />
+
+          <Collapsible open={rawExpanded} onOpenChange={setRawExpanded}>
+            <CollapsibleTrigger asChild>
+              <Button variant="ghost" size="sm" className="gap-2 px-0">
+                {rawExpanded ? (
+                  <ChevronDown className="size-4" />
+                ) : (
+                  <ChevronRight className="size-4" />
+                )}
+                <span className="text-xs font-medium text-muted-foreground">
+                  View raw {inventory.format === "spdx" ? "SPDX" : "CycloneDX"}{" "}
+                  document
+                </span>
+              </Button>
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <div className="mt-2 flex justify-end">
+                <CopyButton value={rawDocument} label="Copy document" />
+              </div>
+              <pre
+                className="mt-1 max-h-64 overflow-auto rounded-md bg-muted p-4 font-mono text-xs"
+                data-testid="proxy-sbom-raw"
+              >
+                {rawDocument}
+              </pre>
+            </CollapsibleContent>
+          </Collapsible>
+        </div>
+      )}
+
+      <p className="text-xs text-muted-foreground">
+        {PROXY_SBOM_GENERATION_NOTE}
+      </p>
+    </div>
+  );
+}

--- a/src/app/(app)/repositories/_components/proxy-sbom-panel.tsx
+++ b/src/app/(app)/repositories/_components/proxy-sbom-panel.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
+  AlertTriangle,
   ChevronDown,
   ChevronRight,
   Download,
@@ -18,6 +19,8 @@ import {
   PROXY_SBOM_GENERATION_NOTE,
   PROXY_SBOM_INVENTORY_CAVEAT,
   PROXY_SBOM_NOT_RECORDED_COPY,
+  PROXY_SBOM_NOT_RECORDED_REASON,
+  PROXY_SBOM_PARTIAL_COPY,
   formatHasProxySbom,
   formatSbomDocument,
   parseProxySbom,
@@ -126,7 +129,18 @@ function componentColumns(): DataTableColumn<ProxySbomComponent>[] {
 }
 
 /** Explicit "nothing recorded" state. Never a zero-row table. */
-export function ProxySbomEmptyState({ message }: { message: string }) {
+export function ProxySbomEmptyState({
+  message,
+  detail,
+}: {
+  message: string;
+  /**
+   * Optional second line. Used to say that a missing inventory is expected on
+   * artifacts cached before recording was enabled — without it, the most
+   * common state on an existing deployment reads as a fault.
+   */
+  detail?: string;
+}) {
   return (
     <div
       className="flex flex-col items-center justify-center rounded-lg border border-dashed py-10 text-center"
@@ -134,6 +148,28 @@ export function ProxySbomEmptyState({ message }: { message: string }) {
     >
       <FileText className="size-10 text-muted-foreground/50 mb-3" />
       <p className="text-sm text-muted-foreground max-w-md">{message}</p>
+      {detail && (
+        <p className="mt-2 max-w-md text-xs text-muted-foreground">{detail}</p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Raised only when the scan explicitly reported an incomplete catalog.
+ * Silence here means "no claim was made", which the standing caveat already
+ * covers — it does not mean the inventory is certified complete.
+ */
+export function ProxySbomPartialBanner() {
+  return (
+    <div
+      className="flex items-start gap-3 rounded-lg border border-yellow-300 bg-yellow-50 p-3 dark:border-yellow-800 dark:bg-yellow-950/30"
+      data-testid="proxy-sbom-partial-banner"
+    >
+      <AlertTriangle className="size-4 shrink-0 mt-0.5 text-yellow-600 dark:text-yellow-500" />
+      <p className="text-xs text-yellow-800 dark:text-yellow-400">
+        {PROXY_SBOM_PARTIAL_COPY}
+      </p>
     </div>
   );
 }
@@ -251,9 +287,14 @@ export function ProxySbomPanel({
         // Covers a 404, an empty document, and an unparseable one. All three
         // mean "we have no inventory to show", which is not the same claim as
         // "this artifact has no dependencies".
-        <ProxySbomEmptyState message={PROXY_SBOM_NOT_RECORDED_COPY} />
+        <ProxySbomEmptyState
+          message={PROXY_SBOM_NOT_RECORDED_COPY}
+          detail={PROXY_SBOM_NOT_RECORDED_REASON}
+        />
       ) : (
         <div className="space-y-4">
+          {inventory.completeness === "partial" && <ProxySbomPartialBanner />}
+
           {licenses.length > 0 && (
             <div className="space-y-2">
               <p className="text-xs font-medium text-muted-foreground">

--- a/src/app/(app)/repositories/_components/proxy-sbom-panel.tsx
+++ b/src/app/(app)/repositories/_components/proxy-sbom-panel.tsx
@@ -108,7 +108,8 @@ function componentColumns(): DataTableColumn<ProxySbomComponent>[] {
     {
       id: "purl",
       header: "Package URL",
-      accessor: (c) => c.purl ?? "",
+      // No accessor: the column is not sortable, and DataTable reads accessors
+      // only when sorting.
       cell: (c) =>
         c.purl ? (
           <div className="flex items-center gap-1 max-w-[260px]">

--- a/src/app/(app)/repositories/_components/proxy-scan-panel.tsx
+++ b/src/app/(app)/repositories/_components/proxy-scan-panel.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import {
+  AlertTriangle,
+  LockKeyhole,
+  ShieldAlert,
+  ShieldCheck,
+  ShieldQuestion,
+} from "lucide-react";
+
+import { proxyScansApi } from "@/lib/api/proxy-scans";
+import {
+  PROXY_SCAN_FORBIDDEN_COPY,
+  PROXY_SCAN_NOT_ENFORCED_COPY,
+  PROXY_SCAN_NO_CVE_DETAIL_COPY,
+  PROXY_SCAN_SIGN_IN_COPY,
+  describeProxyVerdict,
+  describeUnresolvedPath,
+  resolveProxyScanView,
+  severityBuckets,
+  showsInheritedVerdict,
+  type ProxyVerdictCopy,
+  type ProxyVerdictTone,
+} from "@/lib/proxy-scan";
+import type { ProxyScanEnforcement } from "@/types/proxy-scans";
+
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * Verdict panel for a single proxy-cached artifact.
+ *
+ * Replaces the green `ShieldCheck` all-clear that `security-tab-content.tsx`
+ * used to render for proxy content. That shield was driven by artifact-keyed
+ * CVE history, which is structurally empty for proxy-cached artifacts — so an
+ * artifact the download gate returned 403 for displayed "No vulnerabilities
+ * detected".
+ *
+ * Every non-verdict state here is deliberately neutral or negative. There is
+ * no code path in which a failed fetch, an unresolvable path, or a missing
+ * verdict reads as clean.
+ */
+
+const TONE_STYLES: Record<
+  ProxyVerdictTone,
+  { container: string; heading: string; body: string }
+> = {
+  clean: {
+    container:
+      "border-emerald-300 bg-emerald-50 dark:border-emerald-800 dark:bg-emerald-950/30",
+    heading: "text-emerald-800 dark:text-emerald-400",
+    body: "text-emerald-700 dark:text-emerald-500",
+  },
+  danger: {
+    container: "border-red-300 bg-red-50 dark:border-red-800 dark:bg-red-950/30",
+    heading: "text-red-800 dark:text-red-400",
+    body: "text-red-700 dark:text-red-500",
+  },
+  neutral: {
+    container: "border-border bg-muted/40",
+    heading: "text-foreground",
+    body: "text-muted-foreground",
+  },
+};
+
+const SEVERITY_BADGE: Record<string, string> = {
+  critical: "text-red-600 bg-red-100 dark:bg-red-950/40",
+  high: "text-orange-600 bg-orange-100 dark:bg-orange-950/40",
+  medium: "text-yellow-600 bg-yellow-100 dark:bg-yellow-950/40",
+  low: "text-blue-600 bg-blue-100 dark:bg-blue-950/40",
+};
+
+function ToneIcon({ tone, className }: { tone: ProxyVerdictTone; className?: string }) {
+  if (tone === "clean") return <ShieldCheck className={className} />;
+  if (tone === "danger") return <ShieldAlert className={className} />;
+  return <ShieldQuestion className={className} />;
+}
+
+/** Verdict callout. Exported for the repository-level summary to reuse. */
+export function ProxyVerdictCallout({
+  copy,
+  children,
+}: {
+  copy: ProxyVerdictCopy;
+  children?: React.ReactNode;
+}) {
+  const styles = TONE_STYLES[copy.tone];
+  return (
+    <div
+      className={`flex items-start gap-3 rounded-lg border p-4 ${styles.container}`}
+      data-testid="proxy-scan-verdict"
+      data-tone={copy.tone}
+    >
+      <ToneIcon tone={copy.tone} className={`size-5 shrink-0 mt-0.5 ${styles.heading}`} />
+      <div className="min-w-0 space-y-1">
+        <p className={`text-sm font-medium ${styles.heading}`}>{copy.headline}</p>
+        <p className={`text-xs ${styles.body}`}>{copy.detail}</p>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * "Recorded elsewhere, not enforced here." Verdicts are global by content
+ * digest, so a repository with scan-on-proxy off can display a verdict another
+ * repository recorded for byte-identical content. Hiding it would re-create
+ * the original bug; the honest fix is saying it is not enforced here.
+ */
+export function ProxyEnforcementBanner() {
+  return (
+    <div
+      className="flex items-start gap-3 rounded-lg border border-yellow-300 bg-yellow-50 p-3 dark:border-yellow-800 dark:bg-yellow-950/30"
+      data-testid="proxy-scan-enforcement-banner"
+    >
+      <AlertTriangle className="size-4 shrink-0 mt-0.5 text-yellow-600 dark:text-yellow-500" />
+      <p className="text-xs text-yellow-800 dark:text-yellow-400">
+        {PROXY_SCAN_NOT_ENFORCED_COPY}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Sign-in / access-denied state. The repositories pages sit outside the
+ * `(protected)` route group, so this renders for anonymous viewers on public
+ * repositories — the audience the green all-clear misled.
+ */
+export function ProxyScanAccessNotice({
+  failure,
+}: {
+  failure: "unauthenticated" | "forbidden" | "error";
+}) {
+  const copy =
+    failure === "unauthenticated"
+      ? PROXY_SCAN_SIGN_IN_COPY
+      : failure === "forbidden"
+        ? PROXY_SCAN_FORBIDDEN_COPY
+        : "Scan status could not be loaded. This is not a clean result.";
+  return (
+    <div
+      className="flex items-start gap-3 rounded-lg border bg-muted/40 p-4"
+      data-testid="proxy-scan-access-notice"
+      data-failure={failure}
+    >
+      <LockKeyhole className="size-5 shrink-0 mt-0.5 text-muted-foreground" />
+      <div className="space-y-1">
+        <p className="text-sm font-medium">{copy}</p>
+        <p className="text-xs text-muted-foreground">
+          Scan verdicts for proxy-cached content are only shown to signed-in
+          users with access to this repository.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function ProxySeverityBadges({
+  buckets,
+  findingsCount,
+}: {
+  buckets: Array<{ key: string; count: number }>;
+  findingsCount: number;
+}) {
+  if (findingsCount <= 0) return null;
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 pt-1">
+      <span className="text-xs font-medium tabular-nums">
+        {findingsCount} finding{findingsCount === 1 ? "" : "s"}
+      </span>
+      {buckets.map((bucket) => (
+        <Badge
+          key={bucket.key}
+          variant="outline"
+          className={`text-xs uppercase ${SEVERITY_BADGE[bucket.key] ?? ""}`}
+        >
+          {bucket.count} {bucket.key}
+        </Badge>
+      ))}
+    </div>
+  );
+}
+
+export function ProxyScanPanel({
+  repositoryKey,
+  path,
+}: {
+  repositoryKey: string;
+  /** Cache path within the repository. Lookup is by path, never by digest. */
+  path: string;
+}) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["proxy-scan", repositoryKey, path],
+    queryFn: () => proxyScansApi.getByPath(repositoryKey, path),
+    // A 401 must surface immediately as the sign-in state rather than being
+    // retried three times behind a spinner.
+    retry: false,
+  });
+
+  const enforcement: ProxyScanEnforcement = {
+    scan_on_proxy: data?.scan_on_proxy ?? false,
+    proxy_scan_action: data?.proxy_scan_action ?? "fail_open",
+  };
+
+  const view = resolveProxyScanView({
+    isLoading,
+    error,
+    entry: data?.entry,
+  });
+
+  return (
+    <div className="space-y-3" data-testid="proxy-scan-panel">
+      <div className="flex items-center gap-3">
+        <ShieldQuestion className="size-5 text-muted-foreground" />
+        <h3 className="text-sm font-medium">Proxy Scan Status</h3>
+      </div>
+
+      {view.kind === "loading" && <Skeleton className="h-24 w-full" />}
+
+      {view.kind === "failure" && <ProxyScanAccessNotice failure={view.failure} />}
+
+      {view.kind === "unresolved" && (
+        <ProxyVerdictCallout copy={describeUnresolvedPath()} />
+      )}
+
+      {view.kind === "verdict" && (
+        <>
+          <ProxyVerdictCallout
+            copy={describeProxyVerdict(view.entry, enforcement)}
+          >
+            <ProxySeverityBadges
+              buckets={severityBuckets(view.entry)}
+              findingsCount={view.entry.findings_count}
+            />
+          </ProxyVerdictCallout>
+          {showsInheritedVerdict(view.entry.state, enforcement) && (
+            <ProxyEnforcementBanner />
+          )}
+        </>
+      )}
+
+      {/* The remedy. Without it the panel reports a problem and offers no way
+          to act on it: proxy scans reduce findings to a verdict and counts and
+          never persist them per-CVE. */}
+      {view.kind !== "failure" && view.kind !== "loading" && (
+        <p className="text-xs text-muted-foreground">
+          {PROXY_SCAN_NO_CVE_DETAIL_COPY}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/repositories/_components/proxy-scan-summary.tsx
+++ b/src/app/(app)/repositories/_components/proxy-scan-summary.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Clock, ShieldQuestion } from "lucide-react";
+
+import { proxyScansApi } from "@/lib/api/proxy-scans";
+import {
+  PROXY_SCAN_DISTINCT_DIGESTS_COPY,
+  PROXY_SCAN_NO_CVE_DETAIL_COPY,
+  PROXY_SCAN_PENDING_INGEST_COPY,
+  PROXY_SCAN_UNAVAILABLE_COPY,
+  describeProxyVerdict,
+  formatScannedDate,
+  resolveProxyScanListView,
+  severityBuckets,
+  showsInheritedVerdict,
+} from "@/lib/proxy-scan";
+import type {
+  ProxyScanEnforcement,
+  ProxyScanEntry,
+  ProxyScanSummary,
+} from "@/types/proxy-scans";
+
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { DataTable, type DataTableColumn } from "@/components/common/data-table";
+
+import {
+  ProxyEnforcementBanner,
+  ProxyScanAccessNotice,
+  ProxySeverityBadges,
+} from "./proxy-scan-panel";
+
+/**
+ * Repository-level proxy scan summary and cached-path listing.
+ *
+ * The list is not optional. Counts alone answer "3 vulnerable digests" but not
+ * *which* ones — the operator's first question — which would force a click
+ * through every artifact modal to find them. The per-row badge in the artifact
+ * *listing* is deferred because that listing is anonymous-readable on public
+ * repositories; that rationale does not apply here, behind the endpoint's own
+ * authentication bar.
+ *
+ * Visible to any authenticated user with repository visibility, matching the
+ * endpoint's authorization. It is deliberately not admin-gated: the scan
+ * *config* form on the same tab is an admin control, but the verdicts are a
+ * read that every developer pulling from this repository has a stake in.
+ */
+
+const PAGE_SIZE = 20;
+
+const STATE_BADGE: Record<string, string> = {
+  clean: "text-emerald-600 bg-emerald-100 dark:bg-emerald-950/40",
+  vulnerable: "text-red-600 bg-red-100 dark:bg-red-950/40",
+  not_scanned: "text-muted-foreground bg-muted",
+};
+
+const STATE_LABEL: Record<string, string> = {
+  clean: "Clean",
+  vulnerable: "Vulnerable",
+  not_scanned: "Not scanned",
+};
+
+function SummaryTile({
+  label,
+  count,
+  hint,
+  className,
+  testId,
+}: {
+  label: string;
+  count: number;
+  hint?: string;
+  className?: string;
+  testId: string;
+}) {
+  return (
+    <div
+      className={`rounded-lg border bg-card p-3 ${className ?? ""}`}
+      data-testid={testId}
+    >
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-lg font-semibold tabular-nums">{count}</p>
+      {hint && <p className="text-xs text-muted-foreground mt-1">{hint}</p>}
+    </div>
+  );
+}
+
+export function ProxyScanSummaryTiles({ summary }: { summary: ProxyScanSummary }) {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      <SummaryTile
+        testId="proxy-summary-clean"
+        label="Clean digests"
+        count={summary.clean}
+      />
+      <SummaryTile
+        testId="proxy-summary-vulnerable"
+        label="Vulnerable digests"
+        count={summary.vulnerable}
+      />
+      <SummaryTile
+        testId="proxy-summary-not-scanned"
+        label="Not scanned"
+        count={summary.not_scanned}
+      />
+      {/* Placeholder rows are excluded from the state counts because they have
+          no digest to join on. Reported separately so the totals reconcile
+          with the artifact listing instead of silently undercounting. */}
+      <SummaryTile
+        testId="proxy-summary-pending-ingest"
+        label="Pending ingest"
+        count={summary.pending_ingest}
+        hint={PROXY_SCAN_PENDING_INGEST_COPY}
+      />
+    </div>
+  );
+}
+
+function pathColumns(
+  enforcement: ProxyScanEnforcement,
+): DataTableColumn<ProxyScanEntry>[] {
+  return [
+    {
+      id: "path",
+      header: "Cache path",
+      accessor: (e) => e.path,
+      sortable: true,
+      cell: (e) => (
+        <span className="text-sm break-all" title={e.path}>
+          {e.path}
+        </span>
+      ),
+    },
+    {
+      id: "state",
+      header: "Status",
+      accessor: (e) => e.state,
+      sortable: true,
+      cell: (e) => (
+        <div className="space-y-1">
+          <Badge
+            variant="outline"
+            className={`text-xs ${STATE_BADGE[e.state] ?? ""}`}
+          >
+            {STATE_LABEL[e.state] ?? e.state}
+          </Badge>
+          <p className="text-xs text-muted-foreground">
+            {describeProxyVerdict(e, enforcement).detail}
+          </p>
+        </div>
+      ),
+    },
+    {
+      id: "findings",
+      header: "Findings",
+      accessor: (e) => e.findings_count,
+      sortable: true,
+      cell: (e) =>
+        e.findings_count > 0 ? (
+          <ProxySeverityBadges
+            buckets={severityBuckets(e)}
+            findingsCount={e.findings_count}
+          />
+        ) : (
+          <span className="text-xs text-muted-foreground">—</span>
+        ),
+    },
+    {
+      id: "scanned_at",
+      header: "Scanned",
+      accessor: (e) => e.scanned_at ?? "",
+      sortable: true,
+      cell: (e) => {
+        const date = formatScannedDate(e.scanned_at);
+        return (
+          <div className="flex items-center gap-1 text-xs text-muted-foreground">
+            <Clock className="size-3" />
+            {date ?? "—"}
+          </div>
+        );
+      },
+    },
+  ];
+}
+
+export function ProxyScanSummarySection({
+  repositoryKey,
+}: {
+  repositoryKey: string;
+}) {
+  const [page, setPage] = useState(1);
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["proxy-scans", repositoryKey, page],
+    queryFn: () => proxyScansApi.list(repositoryKey, { page, per_page: PAGE_SIZE }),
+    retry: false,
+  });
+
+  const enforcement: ProxyScanEnforcement = {
+    scan_on_proxy: data?.scan_on_proxy ?? false,
+    proxy_scan_action: data?.proxy_scan_action ?? "fail_open",
+  };
+
+  // A 401 must render the same sign-in copy the per-artifact panel uses, not
+  // an empty table that reads as "nothing cached, nothing wrong".
+  const view = resolveProxyScanListView({ isLoading, error });
+
+  const summary: ProxyScanSummary = data?.summary ?? {
+    clean: 0,
+    vulnerable: 0,
+    not_scanned: 0,
+    pending_ingest: 0,
+  };
+  const items = data?.items ?? [];
+
+  // A repository that does not scan its own proxy downloads but is displaying
+  // verdicts is showing verdicts another repository recorded for
+  // byte-identical content.
+  const inherited =
+    showsInheritedVerdict("clean", enforcement) &&
+    summary.clean + summary.vulnerable > 0;
+
+  return (
+    <div className="space-y-4" data-testid="proxy-scan-summary">
+      <div className="flex items-center gap-3">
+        <ShieldQuestion className="size-5 text-muted-foreground" />
+        <h3 className="text-sm font-medium">Proxy Cache Scan Status</h3>
+      </div>
+
+      {view.kind === "loading" ? (
+        <Skeleton className="h-40 w-full" />
+      ) : view.kind === "failure" ? (
+        <ProxyScanAccessNotice failure={view.failure} />
+      ) : view.kind === "unavailable" ? (
+        <p className="text-sm text-muted-foreground" data-testid="proxy-scan-unavailable">
+          {PROXY_SCAN_UNAVAILABLE_COPY}
+        </p>
+      ) : (
+        <>
+          <ProxyScanSummaryTiles summary={summary} />
+          <p className="text-xs text-muted-foreground">
+            {PROXY_SCAN_DISTINCT_DIGESTS_COPY}
+          </p>
+
+          {inherited && <ProxyEnforcementBanner />}
+
+          <DataTable
+            columns={pathColumns(enforcement)}
+            data={items}
+            page={page}
+            pageSize={PAGE_SIZE}
+            total={data?.total ?? items.length}
+            onPageChange={setPage}
+            emptyMessage="No proxy-cached content in this repository yet."
+            rowKey={(e) => e.path}
+          />
+
+          <p className="text-xs text-muted-foreground">
+            {PROXY_SCAN_NO_CVE_DETAIL_COPY}
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/repositories/_components/repo-detail-content.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.tsx
@@ -634,18 +634,24 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
           {user?.is_admin && (
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  onClick={() => scanArtifactMutation.mutate(a.id)}
-                  disabled={
-                    scanArtifactMutation.isPending || !isArtifactAnalyzable(a)
-                  }
-                >
-                  <Shield className="size-3.5" />
-                </Button>
+                {/* Wrapped: a disabled button emits no pointer events, so the
+                    tooltip explaining why proxy-cached artifacts can't be
+                    scanned would never open. */}
+                <span>
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
+                    onClick={() => scanArtifactMutation.mutate(a.id)}
+                    disabled={
+                      scanArtifactMutation.isPending ||
+                      !isArtifactAnalyzable(a)
+                    }
+                  >
+                    <Shield className="size-3.5" />
+                  </Button>
+                </span>
               </TooltipTrigger>
-              <TooltipContent>
+              <TooltipContent className="max-w-sm">
                 {isArtifactAnalyzable(a) ? "Scan" : ANALYZABLE_DISABLED_REASON}
               </TooltipContent>
             </Tooltip>

--- a/src/app/(app)/repositories/_components/repo-detail-content.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.tsx
@@ -54,6 +54,7 @@ import { supportsVersioning } from "@/lib/api/versions";
 import { ArtifactVersionsSection } from "./artifact-versions-section";
 import { SbomTabContent } from "./sbom-tab-content";
 import { SecurityTabContent } from "./security-tab-content";
+import { ProxyScanSummarySection } from "./proxy-scan-summary";
 import { HealthTabContent } from "./health-tab-content";
 import { NotificationsTabContent } from "./notifications-tab-content";
 import { VirtualMembersPanel } from "./virtual-members-panel";
@@ -75,6 +76,7 @@ import { RepoSettingsTab } from "./repo-settings-tab";
 import { RepoStoragePanel } from "./repo-storage-panel";
 import { RepoFolderStoragePanel } from "./repo-folder-storage-panel";
 import { resolveInitialRepoTab } from "@/lib/repo-tabs";
+import { hasProxyScanSummary } from "@/lib/proxy-scan";
 import { formatBytes, REPO_TYPE_COLORS } from "@/lib/utils";
 import { useAuth } from "@/providers/auth-provider";
 import { useSystemConfig } from "@/providers/system-config-provider";
@@ -86,6 +88,7 @@ import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Separator } from "@/components/ui/separator";
 import {
   Select,
   SelectTrigger,
@@ -312,6 +315,15 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
     severity_threshold: repoSecurity?.config?.severity_threshold ?? "high",
   };
   const currentSecForm = secForm ?? securityDefaults;
+
+  // Proxy-cache scan verdicts are readable by any authenticated user with
+  // repository visibility, matching the endpoint's own authorization — the
+  // scan-config form on this tab is the admin control, the verdicts are not.
+  // So the Security tab is no longer admin-only: a non-admin developer gets
+  // the summary, and only admins additionally get the form.
+  const showProxyScanSummary =
+    isAuthenticated && hasProxyScanSummary(repository);
+  const showSecurityTab = !!user?.is_admin || showProxyScanSummary;
 
   // --- mutations ---
   const deleteMutation = useMutation({
@@ -880,7 +892,7 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
                 Tracks
               </TabsTrigger>
             )}
-          {user?.is_admin && (
+          {showSecurityTab && (
             <TabsTrigger value="security">
               <Shield className="size-3.5 mr-1" />
               Security
@@ -1078,9 +1090,19 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
           )}
 
         {/* --- Security Tab --- */}
-        {user?.is_admin && (
-          <TabsContent value="security" className="mt-4">
-            {securityLoading ? (
+        {showSecurityTab && (
+          <TabsContent value="security" className="mt-4 space-y-6">
+            {/* Proxy-cache verdicts. Not admin-gated: the endpoint authorizes
+                any authenticated user with repository visibility, and gating
+                it here would leave non-admin developers with the per-artifact
+                panel and no way to see which digests are affected. */}
+            {showProxyScanSummary && (
+              <>
+                <ProxyScanSummarySection repositoryKey={repoKey} />
+                {user?.is_admin && <Separator />}
+              </>
+            )}
+            {!user?.is_admin ? null : securityLoading ? (
               <div className="space-y-3 max-w-md">
                 <Skeleton className="h-8 w-full" />
                 <Skeleton className="h-8 w-full" />

--- a/src/app/(app)/repositories/_components/repo-detail-content.tsx
+++ b/src/app/(app)/repositories/_components/repo-detail-content.tsx
@@ -1367,7 +1367,10 @@ export function RepoDetailContent({ repoKey, standalone = false }: RepoDetailCon
               )}
 
               <TabsContent value="sbom" className="flex-1 overflow-y-auto mt-4">
-                <SbomTabContent artifact={selectedArtifact} />
+                <SbomTabContent
+                  artifact={selectedArtifact}
+                  repositoryFormat={repoFormat}
+                />
               </TabsContent>
 
               <TabsContent value="security" className="flex-1 overflow-y-auto mt-4">

--- a/src/app/(app)/repositories/_components/sbom-tab-content.tsx
+++ b/src/app/(app)/repositories/_components/sbom-tab-content.tsx
@@ -44,12 +44,22 @@ import {
 } from "@/components/ui/collapsible";
 import { DataTable, type DataTableColumn } from "@/components/common/data-table";
 import { CopyButton } from "@/components/common/copy-button";
+import { ProxySbomPanel } from "./proxy-sbom-panel";
 
 interface SbomTabContentProps {
   artifact: Artifact;
+  /**
+   * Repository format, used to decide whether a proxy-cached artifact can have
+   * a recorded SBOM at all. Optional so existing callers keep working; the
+   * proxy panel degrades to "not supported for this format" without it.
+   */
+  repositoryFormat?: string | null;
 }
 
-export function SbomTabContent({ artifact }: SbomTabContentProps) {
+export function SbomTabContent({
+  artifact,
+  repositoryFormat,
+}: SbomTabContentProps) {
   const queryClient = useQueryClient();
   // Proxy-cached remote artifacts have no artifacts row on the backend, so
   // SBOM generation returns 404 (artifact-keeper#2292). Gate the Generate /
@@ -189,6 +199,24 @@ export function SbomTabContent({ artifact }: SbomTabContentProps) {
         ),
     },
   ];
+
+  // Proxy-cached artifacts get the proxy SBOM instead of the hosted one.
+  //
+  // Everything above is artifact-keyed and therefore structurally empty for
+  // them, so the hosted UI could only ever render a permanently disabled
+  // Generate button over the "SBOM is unavailable" message. That message was
+  // also wrong: every inline proxy scan catalogs the archive it downloads, so
+  // there is a real inventory to show.
+  if (!analyzable) {
+    return (
+      <ProxySbomPanel
+        repositoryKey={artifact.repository_key}
+        path={artifact.path}
+        artifactName={artifact.name}
+        repositoryFormat={repositoryFormat}
+      />
+    );
+  }
 
   if (sbomsLoading) {
     return (

--- a/src/app/(app)/repositories/_components/security-tab-content.tsx
+++ b/src/app/(app)/repositories/_components/security-tab-content.tsx
@@ -5,6 +5,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   ShieldAlert,
   ShieldCheck,
+  ShieldQuestion,
   AlertTriangle,
   Clock,
   ChevronDown,
@@ -20,7 +21,10 @@ import { toast } from "sonner";
 import { sbomApi } from "@/lib/api/sbom";
 import { dtApi } from "@/lib/api/dependency-track";
 import { mutationErrorToast } from "@/lib/error-utils";
-import { isArtifactAnalyzable } from "@/lib/artifact-analyzable";
+import {
+  ANALYZABLE_DISABLED_REASON,
+  isArtifactAnalyzable,
+} from "@/lib/artifact-analyzable";
 import { ArtifactScansSection } from "./artifact-scans-section";
 import type { CveHistoryEntry, CveStatus } from "@/types/sbom";
 import type { Artifact } from "@/types";
@@ -526,15 +530,27 @@ export function SecurityTabContent({ artifact }: SecurityTabContentProps) {
 
       {total === 0 ? (
         <div className="flex flex-col items-center justify-center py-12 text-center">
-          <ShieldCheck className="size-12 text-green-500/50 mb-4" />
-          <p className="text-sm text-muted-foreground">
-            No vulnerabilities detected for this artifact.
-          </p>
-          <p className="text-xs text-muted-foreground mt-1">
-            {analyzable
-              ? "Generate an SBOM and run a security scan to check for CVEs."
-              : "SBOM and scanning are available only for artifacts hosted in this registry, not proxy-cached remote artifacts."}
-          </p>
+          {analyzable ? (
+            <>
+              <ShieldCheck className="size-12 text-green-500/50 mb-4" />
+              <p className="text-sm text-muted-foreground">
+                No vulnerabilities detected for this artifact.
+              </p>
+              <p className="text-xs text-muted-foreground mt-1">
+                Generate an SBOM and run a security scan to check for CVEs.
+              </p>
+            </>
+          ) : (
+            <>
+              <ShieldQuestion className="size-12 text-muted-foreground/50 mb-4" />
+              <p className="text-sm text-muted-foreground">
+                CVE history is not available for this artifact.
+              </p>
+              <p className="text-xs text-muted-foreground mt-1">
+                {ANALYZABLE_DISABLED_REASON}
+              </p>
+            </>
+          )}
         </div>
       ) : (
         <>

--- a/src/app/(app)/repositories/_components/security-tab-content.tsx
+++ b/src/app/(app)/repositories/_components/security-tab-content.tsx
@@ -26,6 +26,7 @@ import {
   isArtifactAnalyzable,
 } from "@/lib/artifact-analyzable";
 import { ArtifactScansSection } from "./artifact-scans-section";
+import { ProxyScanPanel } from "./proxy-scan-panel";
 import type { CveHistoryEntry, CveStatus } from "@/types/sbom";
 import type { Artifact } from "@/types";
 import type {
@@ -513,6 +514,26 @@ export function SecurityTabContent({ artifact }: SecurityTabContentProps) {
           url={dtStatus.url}
           projectLinked={dtProjectUuid != null}
         />
+      )}
+
+      {/* ----------------------------------------------------------------- */}
+      {/* Proxy scan verdict (proxy-cached artifacts only) */}
+      {/* ----------------------------------------------------------------- */}
+      {/* Proxy-cached artifacts have no `artifacts` row, so every
+          artifact-keyed source below — CVE history, scan_findings,
+          Dependency-Track — is structurally empty for them. Reading that
+          emptiness as "no vulnerabilities" is exactly the bug: a download the
+          gate returned 403 for showed a green all-clear. The digest-keyed
+          proxy verdict is the authoritative answer for this content, so it
+          leads. */}
+      {!analyzable && (
+        <>
+          <ProxyScanPanel
+            repositoryKey={artifact.repository_key}
+            path={artifact.path}
+          />
+          <Separator />
+        </>
       )}
 
       {/* ----------------------------------------------------------------- */}

--- a/src/lib/__tests__/artifact-analyzable.test.ts
+++ b/src/lib/__tests__/artifact-analyzable.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 
 import {
   ANALYZABLE_DISABLED_REASON,
+  PROXY_SCAN_AVAILABILITY_NOTE,
   isArtifactAnalyzable,
 } from "@/lib/artifact-analyzable";
 import type { Artifact } from "@/types";
@@ -30,12 +31,18 @@ describe("isArtifactAnalyzable (artifact-keeper#2292)", () => {
     expect(isArtifactAnalyzable(undefined)).toBe(true);
   });
 
-  it("exposes a user-facing disabled reason mentioning proxy-cached remote artifacts", () => {
-    expect(ANALYZABLE_DISABLED_REASON).toMatch(/proxy-cached remote/i);
+  it("exposes a user-facing disabled reason mentioning proxy-cached artifacts", () => {
+    expect(ANALYZABLE_DISABLED_REASON).toMatch(/proxy-cached/i);
   });
 });
 
 describe("ANALYZABLE_DISABLED_REASON", () => {
+  it("keeps the first (SBOM/scan hosted-only) sentence unchanged", () => {
+    expect(ANALYZABLE_DISABLED_REASON).toMatch(
+      /^SBOM generation and on-demand scans are available only for artifacts hosted in this registry\./,
+    );
+  });
+
   it("does not claim scanning is unavailable for proxy-cached artifacts", () => {
     // #3344: proxy-cached artifacts ARE scanned at download time when
     // scan-on-proxy is enabled. Only SBOM generation and on-demand scans
@@ -43,5 +50,24 @@ describe("ANALYZABLE_DISABLED_REASON", () => {
     expect(ANALYZABLE_DISABLED_REASON).not.toMatch(/SBOM and scanning are available only/);
     expect(ANALYZABLE_DISABLED_REASON).toMatch(/scan-on-proxy/);
     expect(ANALYZABLE_DISABLED_REASON).toMatch(/proxy-cached/i);
+  });
+
+  it("names exactly the formats scan-on-proxy is wired up for (PyPI, npm, Docker/OCI)", () => {
+    // #3344 finding 1: scan-at-download-time is only wired for these three
+    // formats; for everything else (Maven, Go, NuGet, ...) scan_on_proxy is
+    // a no-op. The reason text must not overstate coverage.
+    expect(ANALYZABLE_DISABLED_REASON).toMatch(/PyPI, npm and Docker\/OCI/);
+    expect(ANALYZABLE_DISABLED_REASON).not.toMatch(/Maven|NuGet|\bGo\b/);
+  });
+
+  it("second sentence matches the companion backend PR's wording verbatim", () => {
+    // Must stay identical to the backend copy (#3344) so the two surfaces
+    // never drift apart.
+    expect(PROXY_SCAN_AVAILABILITY_NOTE).toBe(
+      "Proxy-cached artifacts in PyPI, npm and Docker/OCI repositories can be scanned at download time when scan-on-proxy is enabled for the repository.",
+    );
+    expect(ANALYZABLE_DISABLED_REASON.endsWith(PROXY_SCAN_AVAILABILITY_NOTE)).toBe(
+      true,
+    );
   });
 });

--- a/src/lib/__tests__/artifact-analyzable.test.ts
+++ b/src/lib/__tests__/artifact-analyzable.test.ts
@@ -34,3 +34,14 @@ describe("isArtifactAnalyzable (artifact-keeper#2292)", () => {
     expect(ANALYZABLE_DISABLED_REASON).toMatch(/proxy-cached remote/i);
   });
 });
+
+describe("ANALYZABLE_DISABLED_REASON", () => {
+  it("does not claim scanning is unavailable for proxy-cached artifacts", () => {
+    // #3344: proxy-cached artifacts ARE scanned at download time when
+    // scan-on-proxy is enabled. Only SBOM generation and on-demand scans
+    // are hosted-only.
+    expect(ANALYZABLE_DISABLED_REASON).not.toMatch(/SBOM and scanning are available only/);
+    expect(ANALYZABLE_DISABLED_REASON).toMatch(/scan-on-proxy/);
+    expect(ANALYZABLE_DISABLED_REASON).toMatch(/proxy-cached/i);
+  });
+});

--- a/src/lib/__tests__/proxy-sbom.test.ts
+++ b/src/lib/__tests__/proxy-sbom.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 
 import {
   PROXY_SBOM_NOT_RECORDED_COPY,
+  PROXY_SBOM_NOT_RECORDED_REASON,
+  detectInventoryCompleteness,
   detectSbomFormat,
   formatHasProxySbom,
   formatSbomDocument,
@@ -119,6 +121,7 @@ describe("parseProxySbom — CycloneDX", () => {
     expect(inventory).toEqual({
       kind: "present",
       format: "cyclonedx",
+      completeness: "unknown",
       components: [
         {
           name: "jinja2",
@@ -170,6 +173,7 @@ describe("parseProxySbom — SPDX", () => {
     expect(parseProxySbom(SPDX)).toEqual({
       kind: "present",
       format: "spdx",
+      completeness: "unknown",
       components: [
         {
           name: "left-pad",
@@ -250,7 +254,83 @@ describe("parseProxySbom — an empty inventory is not an empty SBOM", () => {
 
   it("keeps the not-recorded copy forward-looking about how one appears", () => {
     expect(PROXY_SBOM_NOT_RECORDED_COPY).toContain("No SBOM recorded");
-    expect(PROXY_SBOM_NOT_RECORDED_COPY).toMatch(/next time it is pulled/);
+    expect(PROXY_SBOM_NOT_RECORDED_COPY).toMatch(
+      /next time the artifact is pulled/,
+    );
+  });
+
+  it("explains that a missing inventory on an older cache entry is expected", () => {
+    // Only digests pulled after inventory recording shipped have one, so on
+    // any existing deployment this is the state most users meet first. It must
+    // not read as a fault.
+    expect(PROXY_SBOM_NOT_RECORDED_REASON).toMatch(/cached before/i);
+    expect(PROXY_SBOM_NOT_RECORDED_REASON).toMatch(/does not indicate a problem/i);
+  });
+});
+
+describe("detectInventoryCompleteness", () => {
+  it("reads an explicit claim off the response envelope", () => {
+    expect(
+      detectInventoryCompleteness({ inventory_completeness: "partial" }, null),
+    ).toBe("partial");
+    expect(
+      detectInventoryCompleteness({ inventory_completeness: "complete" }, null),
+    ).toBe("complete");
+  });
+
+  it("reads a claim off the document root", () => {
+    expect(
+      detectInventoryCompleteness(null, { inventory_completeness: "partial" }),
+    ).toBe("partial");
+  });
+
+  it("reads a namespaced claim out of CycloneDX metadata.properties", () => {
+    expect(
+      detectInventoryCompleteness(null, {
+        metadata: {
+          properties: [
+            { name: "artifact-keeper:scanner", value: "grype" },
+            { name: "artifact-keeper:inventory_completeness", value: "partial" },
+          ],
+        },
+      }),
+    ).toBe("partial");
+  });
+
+  it("treats any non-complete value as partial rather than guessing", () => {
+    expect(
+      detectInventoryCompleteness({ inventory_completeness: "truncated" }, null),
+    ).toBe("partial");
+  });
+
+  it("reports unknown when nothing claims anything, rather than asserting complete", () => {
+    // A backend that never emits the field must not put a warning on every
+    // SBOM, and must not have completeness asserted on its behalf either.
+    expect(detectInventoryCompleteness(null, null)).toBe("unknown");
+    expect(detectInventoryCompleteness({}, {})).toBe("unknown");
+    expect(
+      detectInventoryCompleteness(null, { metadata: { properties: [] } }),
+    ).toBe("unknown");
+    expect(
+      detectInventoryCompleteness(null, {
+        metadata: { properties: [{ name: "other", value: "x" }] },
+      }),
+    ).toBe("unknown");
+  });
+
+  it("is carried on the parsed inventory", () => {
+    const inventory = parseProxySbom({
+      bomFormat: "CycloneDX",
+      metadata: {
+        properties: [{ name: "inventory_completeness", value: "partial" }],
+      },
+      components: [{ name: "x", version: "1.0" }],
+    });
+    expect(inventory).toMatchObject({ kind: "present", completeness: "partial" });
+  });
+
+  it("defaults a parsed inventory with no claim to unknown", () => {
+    expect(parseProxySbom(CYCLONEDX)).toMatchObject({ completeness: "unknown" });
   });
 });
 

--- a/src/lib/__tests__/proxy-sbom.test.ts
+++ b/src/lib/__tests__/proxy-sbom.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  PROXY_SBOM_NOT_RECORDED_COPY,
+  detectSbomFormat,
+  formatHasProxySbom,
+  formatSbomDocument,
+  parseProxySbom,
+  sbomLicenseSummary,
+  unwrapSbomDocument,
+} from "@/lib/proxy-sbom";
+
+const CYCLONEDX = {
+  bomFormat: "CycloneDX",
+  specVersion: "1.5",
+  components: [
+    {
+      type: "library",
+      name: "jinja2",
+      version: "2.11.2",
+      purl: "pkg:pypi/jinja2@2.11.2",
+      licenses: [{ license: { id: "BSD-3-Clause" } }],
+    },
+    {
+      type: "library",
+      name: "markupsafe",
+      version: "1.1.1",
+      purl: "pkg:pypi/markupsafe@1.1.1",
+      licenses: [{ expression: "BSD-3-Clause OR MIT" }],
+    },
+  ],
+};
+
+const SPDX = {
+  spdxVersion: "SPDX-2.3",
+  name: "left-pad",
+  packages: [
+    {
+      name: "left-pad",
+      versionInfo: "1.3.0",
+      licenseConcluded: "WTFPL",
+      externalRefs: [
+        {
+          referenceCategory: "PACKAGE-MANAGER",
+          referenceType: "purl",
+          referenceLocator: "pkg:npm/left-pad@1.3.0",
+        },
+      ],
+    },
+  ],
+};
+
+describe("formatHasProxySbom", () => {
+  it("is true for the formats whose proxy path runs an inline scan", () => {
+    for (const format of ["npm", "pypi", "docker", "oci", "podman", "oras"]) {
+      expect(formatHasProxySbom(format)).toBe(true);
+    }
+  });
+
+  it("is false for formats with no inline proxy scan", () => {
+    // Maven and Go proxies never catalog anything, so there is no inventory to
+    // fetch and the panel says so rather than erroring on an empty response.
+    expect(formatHasProxySbom("maven")).toBe(false);
+    expect(formatHasProxySbom("go")).toBe(false);
+    expect(formatHasProxySbom(null)).toBe(false);
+    expect(formatHasProxySbom(undefined)).toBe(false);
+  });
+});
+
+describe("unwrapSbomDocument", () => {
+  it("accepts a bare document", () => {
+    expect(unwrapSbomDocument(CYCLONEDX)).toEqual(CYCLONEDX);
+  });
+
+  it("accepts an envelope around the document", () => {
+    expect(unwrapSbomDocument({ document: CYCLONEDX })).toEqual(CYCLONEDX);
+    expect(unwrapSbomDocument({ sbom: SPDX })).toEqual(SPDX);
+  });
+
+  it("accepts a document delivered as a JSON string", () => {
+    expect(unwrapSbomDocument(JSON.stringify(CYCLONEDX))).toEqual(CYCLONEDX);
+  });
+
+  it("returns null for an envelope with an explicitly absent document", () => {
+    // Must not fall through and parse the envelope itself as the document.
+    expect(unwrapSbomDocument({ document: null })).toBeNull();
+    expect(unwrapSbomDocument({ sbom: undefined })).toBeNull();
+  });
+
+  it("returns null for bodies that are not documents at all", () => {
+    expect(unwrapSbomDocument(null)).toBeNull();
+    expect(unwrapSbomDocument(undefined)).toBeNull();
+    expect(unwrapSbomDocument("")).toBeNull();
+    expect(unwrapSbomDocument("not json")).toBeNull();
+    expect(unwrapSbomDocument([1, 2, 3])).toBeNull();
+    expect(unwrapSbomDocument(42)).toBeNull();
+  });
+});
+
+describe("detectSbomFormat", () => {
+  it("reads the document's own marker", () => {
+    expect(detectSbomFormat(CYCLONEDX)).toBe("cyclonedx");
+    expect(detectSbomFormat(SPDX)).toBe("spdx");
+  });
+
+  it("falls back to the shape when the marker is missing", () => {
+    expect(detectSbomFormat({ components: [] })).toBe("cyclonedx");
+    expect(detectSbomFormat({ packages: [] })).toBe("spdx");
+  });
+
+  it("reports unknown rather than guessing", () => {
+    expect(detectSbomFormat({ metadata: {} })).toBe("unknown");
+  });
+});
+
+describe("parseProxySbom — CycloneDX", () => {
+  it("normalizes name, version, license and purl", () => {
+    const inventory = parseProxySbom(CYCLONEDX);
+    expect(inventory).toEqual({
+      kind: "present",
+      format: "cyclonedx",
+      components: [
+        {
+          name: "jinja2",
+          version: "2.11.2",
+          license: "BSD-3-Clause",
+          purl: "pkg:pypi/jinja2@2.11.2",
+        },
+        {
+          name: "markupsafe",
+          version: "1.1.1",
+          license: "BSD-3-Clause OR MIT",
+          purl: "pkg:pypi/markupsafe@1.1.1",
+        },
+      ],
+    });
+  });
+
+  it("falls back to the license name when there is no id", () => {
+    const inventory = parseProxySbom({
+      bomFormat: "CycloneDX",
+      components: [{ name: "x", licenses: [{ license: { name: "Custom EULA" } }] }],
+    });
+    expect(inventory).toMatchObject({
+      components: [{ name: "x", license: "Custom EULA" }],
+    });
+  });
+
+  it("reports a missing license as null rather than inventing one", () => {
+    const inventory = parseProxySbom({
+      bomFormat: "CycloneDX",
+      components: [{ name: "x", version: "1.0" }],
+    });
+    expect(inventory).toMatchObject({
+      components: [{ name: "x", version: "1.0", license: null, purl: null }],
+    });
+  });
+
+  it("drops entries with no usable name", () => {
+    const inventory = parseProxySbom({
+      bomFormat: "CycloneDX",
+      components: [{ name: "" }, { version: "1.0" }, { name: "  keep  " }],
+    });
+    expect(inventory).toMatchObject({ components: [{ name: "keep" }] });
+  });
+});
+
+describe("parseProxySbom — SPDX", () => {
+  it("reads versionInfo, licenseConcluded and the purl external ref", () => {
+    expect(parseProxySbom(SPDX)).toEqual({
+      kind: "present",
+      format: "spdx",
+      components: [
+        {
+          name: "left-pad",
+          version: "1.3.0",
+          license: "WTFPL",
+          purl: "pkg:npm/left-pad@1.3.0",
+        },
+      ],
+    });
+  });
+
+  it("falls back to licenseDeclared when nothing is concluded", () => {
+    const inventory = parseProxySbom({
+      spdxVersion: "SPDX-2.2",
+      packages: [
+        { name: "x", licenseConcluded: "NOASSERTION", licenseDeclared: "MIT" },
+      ],
+    });
+    expect(inventory).toMatchObject({ components: [{ license: "MIT" }] });
+  });
+
+  it("treats NOASSERTION and NONE as unknown, not as a license", () => {
+    const inventory = parseProxySbom({
+      spdxVersion: "SPDX-2.3",
+      packages: [
+        { name: "x", licenseConcluded: "NOASSERTION", licenseDeclared: "NONE" },
+      ],
+    });
+    expect(inventory).toMatchObject({ components: [{ license: null }] });
+  });
+
+  it("ignores external refs that are not purls", () => {
+    const inventory = parseProxySbom({
+      spdxVersion: "SPDX-2.3",
+      packages: [
+        {
+          name: "x",
+          externalRefs: [
+            { referenceType: "cpe23Type", referenceLocator: "cpe:2.3:a:x" },
+            { referenceType: "purl", referenceLocator: "pkg:npm/x@1" },
+          ],
+        },
+      ],
+    });
+    expect(inventory).toMatchObject({ components: [{ purl: "pkg:npm/x@1" }] });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The rule this module exists to enforce.
+// ---------------------------------------------------------------------------
+
+describe("parseProxySbom — an empty inventory is not an empty SBOM", () => {
+  it("reports a document with zero components as absent, never as present-and-empty", () => {
+    // Rendering a zero-row table would assert the artifact has no
+    // dependencies. Nothing in the data supports that claim — the same class
+    // of bug as the green all-clear shield.
+    expect(parseProxySbom({ bomFormat: "CycloneDX", components: [] })).toEqual({
+      kind: "absent",
+    });
+    expect(parseProxySbom({ spdxVersion: "SPDX-2.3", packages: [] })).toEqual({
+      kind: "absent",
+    });
+  });
+
+  it("reports a missing document as absent", () => {
+    expect(parseProxySbom(undefined)).toEqual({ kind: "absent" });
+    expect(parseProxySbom(null)).toEqual({ kind: "absent" });
+    expect(parseProxySbom({ document: null })).toEqual({ kind: "absent" });
+  });
+
+  it("reports an unparseable body as absent rather than throwing", () => {
+    expect(parseProxySbom("<html>gateway error</html>")).toEqual({
+      kind: "absent",
+    });
+    expect(parseProxySbom({ unexpected: "shape" })).toEqual({ kind: "absent" });
+  });
+
+  it("keeps the not-recorded copy forward-looking about how one appears", () => {
+    expect(PROXY_SBOM_NOT_RECORDED_COPY).toContain("No SBOM recorded");
+    expect(PROXY_SBOM_NOT_RECORDED_COPY).toMatch(/next time it is pulled/);
+  });
+});
+
+describe("formatSbomDocument", () => {
+  it("pretty-prints the unwrapped document", () => {
+    const text = formatSbomDocument({ document: CYCLONEDX });
+    expect(text).toContain('"bomFormat": "CycloneDX"');
+    expect(JSON.parse(text)).toEqual(CYCLONEDX);
+  });
+
+  it("returns an empty string when there is no document", () => {
+    expect(formatSbomDocument(null)).toBe("");
+    expect(formatSbomDocument("not json")).toBe("");
+  });
+});
+
+describe("sbomLicenseSummary", () => {
+  it("deduplicates and sorts, dropping unknowns", () => {
+    expect(
+      sbomLicenseSummary([
+        { name: "a", version: null, license: "MIT", purl: null },
+        { name: "b", version: null, license: "Apache-2.0", purl: null },
+        { name: "c", version: null, license: "MIT", purl: null },
+        { name: "d", version: null, license: null, purl: null },
+      ]),
+    ).toEqual(["Apache-2.0", "MIT"]);
+  });
+
+  it("is empty when nothing declared a license", () => {
+    expect(
+      sbomLicenseSummary([{ name: "a", version: null, license: null, purl: null }]),
+    ).toEqual([]);
+  });
+});

--- a/src/lib/__tests__/proxy-scan.test.ts
+++ b/src/lib/__tests__/proxy-scan.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect } from "vitest";
+
+import { ApiError } from "@/lib/api/fetch";
+import {
+  PROXY_SCAN_SIGN_IN_COPY,
+  classifyProxyScanError,
+  describeProxyVerdict,
+  describeUnresolvedPath,
+  formatScannedDate,
+  resolveProxyScanView,
+  severityBuckets,
+  showsInheritedVerdict,
+} from "@/lib/proxy-scan";
+import type {
+  ProxyScanEnforcement,
+  ProxyScanEntry,
+} from "@/types/proxy-scans";
+
+function entry(overrides: Partial<ProxyScanEntry> = {}): ProxyScanEntry {
+  return {
+    path: "left-pad/-/left-pad-1.3.0.tgz",
+    state: "clean",
+    reason: null,
+    critical_count: 0,
+    high_count: 0,
+    medium_count: 0,
+    low_count: 0,
+    findings_count: 0,
+    scanned_at: "2026-08-01T12:00:00Z",
+    ...overrides,
+  };
+}
+
+const ENFORCING: ProxyScanEnforcement = {
+  scan_on_proxy: true,
+  proxy_scan_action: "fail_closed",
+};
+const FAIL_OPEN: ProxyScanEnforcement = {
+  scan_on_proxy: true,
+  proxy_scan_action: "fail_open",
+};
+const NOT_SCANNING: ProxyScanEnforcement = {
+  scan_on_proxy: false,
+  proxy_scan_action: "fail_open",
+};
+
+describe("classifyProxyScanError", () => {
+  it("maps 401 to the anonymous case", () => {
+    expect(classifyProxyScanError(new ApiError(401, "unauthorized"))).toBe(
+      "unauthenticated",
+    );
+  });
+
+  it("maps 403 to forbidden, not to sign-in", () => {
+    // A signed-in user without repository visibility is a different audience:
+    // telling them to sign in is a dead end.
+    expect(classifyProxyScanError(new ApiError(403, "forbidden"))).toBe(
+      "forbidden",
+    );
+  });
+
+  it("maps 404 to an unresolvable path", () => {
+    expect(classifyProxyScanError(new ApiError(404, "not found"))).toBe(
+      "unresolvable",
+    );
+  });
+
+  it("maps anything else to a generic failure", () => {
+    expect(classifyProxyScanError(new ApiError(500, "boom"))).toBe("error");
+    expect(classifyProxyScanError(new TypeError("network"))).toBe("error");
+    expect(classifyProxyScanError("not an error")).toBe("error");
+  });
+});
+
+describe("resolveProxyScanView", () => {
+  it("reports loading before an answer arrives", () => {
+    expect(
+      resolveProxyScanView({ isLoading: true, error: null, entry: undefined }),
+    ).toEqual({ kind: "loading" });
+  });
+
+  it("never resolves a 401 into a verdict", () => {
+    // The regression this whole feature exists to prevent: a failed fetch
+    // treated as zero findings renders the green all-clear.
+    const view = resolveProxyScanView({
+      isLoading: false,
+      error: new ApiError(401, ""),
+      entry: undefined,
+    });
+    expect(view).toEqual({ kind: "failure", failure: "unauthenticated" });
+  });
+
+  it("renders a 404 as unresolved rather than as an error", () => {
+    // A repository with zero catalog rows falls back to storage enumeration
+    // for its listing, so a modal click there produces a path the
+    // catalog-backed endpoint cannot resolve. That is an answer, not a fault.
+    expect(
+      resolveProxyScanView({
+        isLoading: false,
+        error: new ApiError(404, ""),
+        entry: undefined,
+      }),
+    ).toEqual({ kind: "unresolved" });
+  });
+
+  it("renders a missing entry as unresolved, not clean", () => {
+    expect(
+      resolveProxyScanView({ isLoading: false, error: null, entry: null }),
+    ).toEqual({ kind: "unresolved" });
+  });
+
+  it("prefers the error over a stale cached entry", () => {
+    const view = resolveProxyScanView({
+      isLoading: false,
+      error: new ApiError(500, ""),
+      entry: entry(),
+    });
+    expect(view).toEqual({ kind: "failure", failure: "error" });
+  });
+
+  it("returns the verdict when one is available", () => {
+    const e = entry({ state: "vulnerable" });
+    expect(
+      resolveProxyScanView({ isLoading: false, error: null, entry: e }),
+    ).toEqual({ kind: "verdict", entry: e });
+  });
+});
+
+describe("formatScannedDate", () => {
+  it("returns null for absent or unparseable timestamps", () => {
+    expect(formatScannedDate(null)).toBeNull();
+    expect(formatScannedDate(undefined)).toBeNull();
+    expect(formatScannedDate("")).toBeNull();
+    expect(formatScannedDate("not-a-date")).toBeNull();
+  });
+
+  it("renders at date granularity", () => {
+    const formatted = formatScannedDate("2026-08-01T12:00:00Z");
+    expect(formatted).toBe(new Date("2026-08-01T12:00:00Z").toLocaleDateString());
+    expect(formatted).not.toMatch(/:/);
+  });
+});
+
+describe("describeProxyVerdict — clean", () => {
+  it("states when it was clean rather than guaranteeing it is clean now", () => {
+    // A verdict inside the reuse window can still have been scanned against an
+    // outdated vulnerability database (#3287).
+    const copy = describeProxyVerdict(entry({ state: "clean" }), ENFORCING);
+    expect(copy.tone).toBe("clean");
+    expect(copy.headline).toMatch(/^Clean as of /);
+    expect(copy.detail).toMatch(/database may have changed/i);
+    expect(copy.headline).not.toMatch(/no vulnerabilities/i);
+  });
+
+  it("falls back when the verdict carries no timestamp", () => {
+    const copy = describeProxyVerdict(
+      entry({ state: "clean", scanned_at: null }),
+      ENFORCING,
+    );
+    expect(copy.headline).toBe("Clean — no findings recorded");
+  });
+});
+
+describe("describeProxyVerdict — vulnerable", () => {
+  it("does not claim the download was blocked on a fail-open repository", () => {
+    const copy = describeProxyVerdict(entry({ state: "vulnerable" }), FAIL_OPEN);
+    expect(copy.tone).toBe("danger");
+    expect(copy.detail).toMatch(/fail-open/);
+    expect(copy.detail).toMatch(/may still be served/i);
+    expect(copy.detail).not.toMatch(/blocked/i);
+  });
+
+  it("says downloads are withheld on a fail-closed scanning repository", () => {
+    const copy = describeProxyVerdict(entry({ state: "vulnerable" }), ENFORCING);
+    expect(copy.detail).toMatch(/withholds downloads/i);
+  });
+
+  it("says the verdict is not enforced when the repository does not scan", () => {
+    // Verdicts are global by digest, so a non-scanning repository can display
+    // one another repository recorded. It serves the artifact regardless.
+    const copy = describeProxyVerdict(
+      entry({ state: "vulnerable" }),
+      NOT_SCANNING,
+    );
+    expect(copy.detail).toMatch(/not\s+enforced here/i);
+    expect(copy.detail).toMatch(/served/i);
+  });
+
+  it("still renders a headline without a timestamp", () => {
+    const copy = describeProxyVerdict(
+      entry({ state: "vulnerable", scanned_at: null }),
+      ENFORCING,
+    );
+    expect(copy.headline).toBe("Vulnerable — findings recorded");
+    expect(copy.tone).toBe("danger");
+  });
+});
+
+describe("describeProxyVerdict — not_scanned", () => {
+  it("never reads as clean and never implies safety", () => {
+    const copy = describeProxyVerdict(
+      entry({ state: "not_scanned", reason: "unknown", scanned_at: null }),
+      FAIL_OPEN,
+    );
+    expect(copy.tone).toBe("neutral");
+    expect(copy.headline).toBe(
+      "Not scanned — this artifact has no scan verdict on record",
+    );
+    expect(copy.detail).toMatch(/not evidence of safety/i);
+    expect(copy.detail).toMatch(/may have been served unscanned/i);
+  });
+
+  it("only says scanning is disabled when that is the derived reason", () => {
+    const disabled = describeProxyVerdict(
+      entry({ state: "not_scanned", reason: "scanning_disabled", scanned_at: null }),
+      NOT_SCANNING,
+    );
+    expect(disabled.headline).toMatch(/scanning is disabled/i);
+
+    const unknown = describeProxyVerdict(
+      entry({ state: "not_scanned", reason: "unknown", scanned_at: null }),
+      ENFORCING,
+    );
+    expect(unknown.headline).not.toMatch(/scanning is disabled/i);
+    // Fail-closed changes what "no verdict" implies about what the user got.
+    expect(unknown.detail).toMatch(/may have been withheld/i);
+  });
+});
+
+describe("describeUnresolvedPath", () => {
+  it("renders as unknown and says so", () => {
+    const copy = describeUnresolvedPath();
+    expect(copy.tone).toBe("neutral");
+    expect(copy.detail).toMatch(/Unknown is not clean/);
+  });
+});
+
+describe("showsInheritedVerdict", () => {
+  it("is false whenever the repository scans its own proxy downloads", () => {
+    expect(showsInheritedVerdict("vulnerable", ENFORCING)).toBe(false);
+    expect(showsInheritedVerdict("clean", FAIL_OPEN)).toBe(false);
+  });
+
+  it("is true when a non-scanning repository displays a verdict", () => {
+    expect(showsInheritedVerdict("clean", NOT_SCANNING)).toBe(true);
+    expect(showsInheritedVerdict("vulnerable", NOT_SCANNING)).toBe(true);
+  });
+
+  it("is false when there is no verdict to attribute", () => {
+    expect(showsInheritedVerdict("not_scanned", NOT_SCANNING)).toBe(false);
+    expect(showsInheritedVerdict(null, NOT_SCANNING)).toBe(false);
+    expect(showsInheritedVerdict(undefined, NOT_SCANNING)).toBe(false);
+  });
+});
+
+describe("severityBuckets", () => {
+  it("drops empty buckets and keeps descending severity order", () => {
+    const buckets = severityBuckets(
+      entry({
+        state: "vulnerable",
+        critical_count: 2,
+        high_count: 0,
+        medium_count: 5,
+        low_count: 1,
+        findings_count: 8,
+      }),
+    );
+    expect(buckets).toEqual([
+      { key: "critical", count: 2 },
+      { key: "medium", count: 5 },
+      { key: "low", count: 1 },
+    ]);
+  });
+
+  it("is empty for a clean verdict", () => {
+    expect(severityBuckets(entry())).toEqual([]);
+  });
+});
+
+describe("copy constants", () => {
+  it("keeps the required anonymous string exact", () => {
+    expect(PROXY_SCAN_SIGN_IN_COPY).toBe("Sign in to view scan status.");
+  });
+});

--- a/src/lib/__tests__/proxy-scan.test.ts
+++ b/src/lib/__tests__/proxy-scan.test.ts
@@ -7,6 +7,8 @@ import {
   describeProxyVerdict,
   describeUnresolvedPath,
   formatScannedDate,
+  hasProxyScanSummary,
+  resolveProxyScanListView,
   resolveProxyScanView,
   severityBuckets,
   showsInheritedVerdict,
@@ -274,6 +276,66 @@ describe("severityBuckets", () => {
 
   it("is empty for a clean verdict", () => {
     expect(severityBuckets(entry())).toEqual([]);
+  });
+});
+
+describe("resolveProxyScanListView", () => {
+  it("reads a 404 as 'not mounted here', not as a scan failure", () => {
+    // On a single path a 404 means the catalog has no such row; on the
+    // collection it means the endpoint is not mounted for this repository.
+    expect(
+      resolveProxyScanListView({ isLoading: false, error: new ApiError(404, "") }),
+    ).toEqual({ kind: "unavailable" });
+  });
+
+  it("keeps the anonymous case distinct so the sign-in copy still renders", () => {
+    expect(
+      resolveProxyScanListView({ isLoading: false, error: new ApiError(401, "") }),
+    ).toEqual({ kind: "failure", failure: "unauthenticated" });
+  });
+
+  it("is ready only once an answer has arrived", () => {
+    expect(resolveProxyScanListView({ isLoading: true, error: null })).toEqual({
+      kind: "loading",
+    });
+    expect(resolveProxyScanListView({ isLoading: false, error: null })).toEqual({
+      kind: "ready",
+    });
+  });
+});
+
+describe("hasProxyScanSummary", () => {
+  it("is true for Remote repositories in formats with proxy gate wiring", () => {
+    expect(hasProxyScanSummary({ repo_type: "remote", format: "npm" })).toBe(true);
+    expect(hasProxyScanSummary({ repo_type: "remote", format: "pypi" })).toBe(true);
+  });
+
+  it("is false for repositories that have no proxy cache", () => {
+    expect(hasProxyScanSummary({ repo_type: "local", format: "npm" })).toBe(false);
+    expect(hasProxyScanSummary({ repo_type: "virtual", format: "pypi" })).toBe(
+      false,
+    );
+    expect(hasProxyScanSummary({ repo_type: "staging", format: "npm" })).toBe(
+      false,
+    );
+  });
+
+  it("is false for Remote repositories whose format has no gate", () => {
+    // An always-empty proxy-cache panel is noise, and claiming coverage a
+    // format does not have would be worse.
+    expect(hasProxyScanSummary({ repo_type: "remote", format: "maven" })).toBe(
+      false,
+    );
+    expect(hasProxyScanSummary({ repo_type: "remote", format: "docker" })).toBe(
+      false,
+    );
+  });
+
+  it("tolerates a repository that has not loaded yet", () => {
+    expect(hasProxyScanSummary(null)).toBe(false);
+    expect(hasProxyScanSummary(undefined)).toBe(false);
+    expect(hasProxyScanSummary({})).toBe(false);
+    expect(hasProxyScanSummary({ repo_type: "remote" })).toBe(false);
   });
 });
 

--- a/src/lib/api/__tests__/proxy-sbom.test.ts
+++ b/src/lib/api/__tests__/proxy-sbom.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockApiFetch = vi.fn();
+vi.mock("../fetch", async () => {
+  const actual = await vi.importActual<typeof import("../fetch")>("../fetch");
+  return { ...actual, apiFetch: (...args: unknown[]) => mockApiFetch(...args) };
+});
+
+import { proxySbomApi } from "../proxy-sbom";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("proxySbomApi.get", () => {
+  it("defaults to CycloneDX and looks the document up by cache path", async () => {
+    mockApiFetch.mockResolvedValue({ bomFormat: "CycloneDX", components: [] });
+
+    await proxySbomApi.get("npm-remote", "left-pad/-/left-pad-1.3.0.tgz");
+
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      "/api/v1/repositories/npm-remote/security/proxy-sbom" +
+        "?path=left-pad%2F-%2Fleft-pad-1.3.0.tgz&format=cyclonedx",
+    );
+  });
+
+  it("requests SPDX when asked", async () => {
+    mockApiFetch.mockResolvedValue({});
+
+    await proxySbomApi.get("npm-remote", "a.tgz", "spdx");
+
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      "/api/v1/repositories/npm-remote/security/proxy-sbom?path=a.tgz&format=spdx",
+    );
+  });
+
+  it("percent-encodes the repository key", async () => {
+    mockApiFetch.mockResolvedValue({});
+
+    await proxySbomApi.get("team/npm remote", "a.tgz");
+
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/repositories/team%2Fnpm%20remote/security/proxy-sbom"),
+    );
+  });
+
+  it("propagates the error instead of reporting an absent inventory", async () => {
+    // Swallowing this would let the caller render "no SBOM recorded" for a
+    // viewer who is merely signed out.
+    mockApiFetch.mockRejectedValue(new Error("API error 401: unauthorized"));
+
+    await expect(proxySbomApi.get("npm-remote", "a.tgz")).rejects.toThrow(/401/);
+  });
+
+  it("returns the body unparsed for the shared normalizer", async () => {
+    const doc = { bomFormat: "CycloneDX", components: [{ name: "x" }] };
+    mockApiFetch.mockResolvedValue(doc);
+
+    await expect(proxySbomApi.get("npm-remote", "a.tgz")).resolves.toBe(doc);
+  });
+});

--- a/src/lib/api/__tests__/proxy-scans.test.ts
+++ b/src/lib/api/__tests__/proxy-scans.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockApiFetch = vi.fn();
+vi.mock("../fetch", async () => {
+  const actual = await vi.importActual<typeof import("../fetch")>("../fetch");
+  return { ...actual, apiFetch: (...args: unknown[]) => mockApiFetch(...args) };
+});
+
+import { proxyScansApi, normalizePathResponse } from "../proxy-scans";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("proxyScansApi.list", () => {
+  it("GETs the repository-scoped endpoint", async () => {
+    mockApiFetch.mockResolvedValue({ items: [], summary: {}, total: 0 });
+
+    await proxyScansApi.list("npm-remote");
+
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      "/api/v1/repositories/npm-remote/security/proxy-scans",
+    );
+  });
+
+  it("passes pagination through as query parameters", async () => {
+    mockApiFetch.mockResolvedValue({ items: [], summary: {}, total: 0 });
+
+    await proxyScansApi.list("npm-remote", { page: 3, per_page: 25 });
+
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      "/api/v1/repositories/npm-remote/security/proxy-scans?page=3&per_page=25",
+    );
+  });
+
+  it("percent-encodes the repository key", async () => {
+    mockApiFetch.mockResolvedValue({ items: [], summary: {}, total: 0 });
+
+    await proxyScansApi.list("team/npm remote");
+
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      "/api/v1/repositories/team%2Fnpm%20remote/security/proxy-scans",
+    );
+  });
+});
+
+describe("proxyScansApi.getByPath", () => {
+  it("encodes the cache path as a query parameter", async () => {
+    mockApiFetch.mockResolvedValue({
+      scan_on_proxy: true,
+      proxy_scan_action: "fail_closed",
+      entry: { path: "a/b.tgz", state: "clean" },
+    });
+
+    const result = await proxyScansApi.getByPath("npm-remote", "left-pad/-/a b.tgz");
+
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      "/api/v1/repositories/npm-remote/security/proxy-scans?path=left-pad%2F-%2Fa+b.tgz",
+    );
+    expect(result.entry?.state).toBe("clean");
+    expect(result.scan_on_proxy).toBe(true);
+  });
+
+  it("propagates the error rather than reporting an absent verdict", async () => {
+    // Swallowing a failure here would let the caller render "no findings".
+    mockApiFetch.mockRejectedValue(new Error("API error 401: unauthorized"));
+
+    await expect(proxyScansApi.getByPath("npm-remote", "a.tgz")).rejects.toThrow(
+      /401/,
+    );
+  });
+});
+
+describe("normalizePathResponse", () => {
+  it("accepts the inline-entry shape", () => {
+    const result = normalizePathResponse({
+      scan_on_proxy: true,
+      proxy_scan_action: "fail_closed",
+      entry: { path: "a.tgz", state: "vulnerable" },
+    });
+    expect(result.entry?.state).toBe("vulnerable");
+    expect(result.proxy_scan_action).toBe("fail_closed");
+  });
+
+  it("accepts the list-envelope shape with a single item", () => {
+    const result = normalizePathResponse({
+      scan_on_proxy: false,
+      proxy_scan_action: "fail_open",
+      items: [{ path: "a.tgz", state: "clean" }],
+      total: 1,
+    });
+    expect(result.entry?.path).toBe("a.tgz");
+    expect(result.scan_on_proxy).toBe(false);
+  });
+
+  it("returns a null entry for an empty result instead of inventing one", () => {
+    expect(normalizePathResponse({ items: [] }).entry).toBeNull();
+    expect(normalizePathResponse({}).entry).toBeNull();
+    expect(normalizePathResponse(null).entry).toBeNull();
+  });
+
+  it("defaults enforcement conservatively when the fields are missing", () => {
+    // An older backend that does not carry enforcement context must not be
+    // read as "this repository scans and blocks".
+    const result = normalizePathResponse({ items: [] });
+    expect(result.scan_on_proxy).toBe(false);
+    expect(result.proxy_scan_action).toBe("fail_open");
+  });
+});

--- a/src/lib/api/proxy-sbom.ts
+++ b/src/lib/api/proxy-sbom.ts
@@ -1,0 +1,29 @@
+import { apiFetch } from "@/lib/api/fetch";
+import type { ProxySbomFormat } from "@/types/proxy-sbom";
+
+/**
+ * Client for the proxy-cache SBOM endpoint.
+ *
+ * Like the verdict client this goes through `apiFetch` rather than the
+ * generated SDK, so the HTTP status survives on `ApiError.status`: the panel
+ * has to tell a 401 (anonymous viewer — "Sign in to view") apart from a 404
+ * (no inventory recorded for this path), and neither may render as an empty
+ * component table.
+ *
+ * The response is returned unparsed. The document is a CycloneDX or SPDX body
+ * whose exact envelope the backend has not pinned down, so normalization
+ * happens in `@/lib/proxy-sbom` where it can be exercised against every
+ * variant.
+ */
+export const proxySbomApi = {
+  async get(
+    repoKey: string,
+    path: string,
+    format: ProxySbomFormat = "cyclonedx",
+  ): Promise<unknown> {
+    const query = new URLSearchParams({ path, format });
+    return apiFetch<unknown>(
+      `/api/v1/repositories/${encodeURIComponent(repoKey)}/security/proxy-sbom?${query.toString()}`,
+    );
+  },
+};

--- a/src/lib/api/proxy-scans.ts
+++ b/src/lib/api/proxy-scans.ts
@@ -1,0 +1,71 @@
+import { apiFetch } from "@/lib/api/fetch";
+import type {
+  ListProxyScansParams,
+  ProxyScanEntry,
+  ProxyScanListResponse,
+  ProxyScanPathResponse,
+} from "@/types/proxy-scans";
+
+/**
+ * Client for the repository-scoped proxy scan verdict endpoint.
+ *
+ * Not part of the generated SDK, so this goes through `apiFetch`, which
+ * preserves the HTTP status on failure as `ApiError.status`. That matters: the
+ * panel must distinguish a 401 (anonymous viewer — "Sign in to view scan
+ * status") from a 404 (a cache path this repository's catalog cannot resolve)
+ * from a transport failure, and must never collapse any of them into "clean".
+ */
+
+function basePath(repoKey: string): string {
+  return `/api/v1/repositories/${encodeURIComponent(repoKey)}/security/proxy-scans`;
+}
+
+/**
+ * Normalize the single-path response.
+ *
+ * The endpoint is documented as returning "one cached path", which leaves the
+ * envelope shape open: it may return the entry inline, or reuse the list
+ * envelope with a single item. Accept both so the panel is not coupled to that
+ * choice, and treat an empty result as unresolved rather than as clean.
+ */
+export function normalizePathResponse(
+  raw: unknown,
+): ProxyScanPathResponse {
+  const body = (raw ?? {}) as Partial<ProxyScanListResponse> &
+    Partial<ProxyScanPathResponse> & { items?: ProxyScanEntry[] };
+
+  const enforcement = {
+    scan_on_proxy: body.scan_on_proxy === true,
+    proxy_scan_action:
+      body.proxy_scan_action === "fail_closed"
+        ? ("fail_closed" as const)
+        : ("fail_open" as const),
+  };
+
+  if (body.entry != null) return { ...enforcement, entry: body.entry };
+  const first = Array.isArray(body.items) ? body.items[0] : undefined;
+  return { ...enforcement, entry: first ?? null };
+}
+
+export const proxyScansApi = {
+  /** Summary plus the paged list of cached paths for a repository. */
+  async list(
+    repoKey: string,
+    params: ListProxyScansParams = {},
+  ): Promise<ProxyScanListResponse> {
+    const query = new URLSearchParams();
+    if (params.page != null) query.set("page", String(params.page));
+    if (params.per_page != null) query.set("per_page", String(params.per_page));
+    const suffix = query.toString();
+    return apiFetch<ProxyScanListResponse>(
+      suffix ? `${basePath(repoKey)}?${suffix}` : basePath(repoKey),
+    );
+  },
+
+  /** Verdict for a single cache path within a repository. */
+  async getByPath(repoKey: string, path: string): Promise<ProxyScanPathResponse> {
+    const query = new URLSearchParams({ path });
+    const raw = await apiFetch<unknown>(`${basePath(repoKey)}?${query.toString()}`);
+    return normalizePathResponse(raw);
+  },
+};

--- a/src/lib/artifact-analyzable.ts
+++ b/src/lib/artifact-analyzable.ts
@@ -8,10 +8,17 @@ import type { Artifact } from "@/types";
  *
  * #3344: this previously said "SBOM and scanning are available only for
  * artifacts hosted in this registry", which is false for scanning - proxy-cached
- * artifacts are scanned at download time when scan-on-proxy is enabled.
+ * artifacts in PyPI, npm and Docker/OCI repositories can be scanned at
+ * download time when scan-on-proxy is enabled. scan_on_proxy is a no-op for
+ * every other format, and is off by default even where it's wired up, so this
+ * intentionally does not claim scanning happens automatically.
  */
+export const PROXY_SCAN_AVAILABILITY_NOTE =
+  "Proxy-cached artifacts in PyPI, npm and Docker/OCI repositories can be scanned at download time when scan-on-proxy is enabled for the repository.";
+
 export const ANALYZABLE_DISABLED_REASON =
-  "SBOM generation and on-demand scans are available only for artifacts hosted in this registry. Proxy-cached remote artifacts are scanned automatically at download time when scan-on-proxy is enabled for the repository.";
+  "SBOM generation and on-demand scans are available only for artifacts hosted in this registry. " +
+  PROXY_SCAN_AVAILABILITY_NOTE;
 
 /**
  * Whether SBOM generation and security scanning are supported for an artifact.

--- a/src/lib/artifact-analyzable.ts
+++ b/src/lib/artifact-analyzable.ts
@@ -1,15 +1,17 @@
 import type { Artifact } from "@/types";
 
 /**
- * User-facing explanation shown when SBOM generation / security scanning is
- * offered for an artifact that the backend cannot analyze. Proxy-cached remote
+ * User-facing explanation shown when SBOM generation / on-demand scanning is
+ * offered for an artifact the backend cannot analyze. Proxy-cached remote
  * artifacts have synthetic ids and no `artifacts` row, so the backend returns
- * 404 for SBOM/scan requests against them (artifact-keeper#2292, backend PR
- * #2291). Surfacing this as a disabled affordance with this reason keeps the
- * action discoverable while making the limitation honest.
+ * 404 for those requests (artifact-keeper#2292, backend PR #2291).
+ *
+ * #3344: this previously said "SBOM and scanning are available only for
+ * artifacts hosted in this registry", which is false for scanning - proxy-cached
+ * artifacts are scanned at download time when scan-on-proxy is enabled.
  */
 export const ANALYZABLE_DISABLED_REASON =
-  "SBOM and scanning are available only for artifacts hosted in this registry, not proxy-cached remote artifacts.";
+  "SBOM generation and on-demand scans are available only for artifacts hosted in this registry. Proxy-cached remote artifacts are scanned automatically at download time when scan-on-proxy is enabled for the repository.";
 
 /**
  * Whether SBOM generation and security scanning are supported for an artifact.

--- a/src/lib/proxy-sbom.ts
+++ b/src/lib/proxy-sbom.ts
@@ -1,0 +1,249 @@
+import type {
+  ProxySbomComponent,
+  ProxySbomFormat,
+  ProxySbomInventory,
+} from "@/types/proxy-sbom";
+
+/**
+ * Pure parsing and copy for proxy-cache SBOMs.
+ *
+ * The endpoint serves a CycloneDX or SPDX *document*, not a pre-normalized
+ * component list, so the table shape is derived here. Kept out of the
+ * component so every document variant — and the empty cases that must not
+ * render as "no dependencies" — is testable without a rendered tree.
+ */
+
+// ---------------------------------------------------------------------------
+// Copy
+// ---------------------------------------------------------------------------
+
+/**
+ * Shown when the endpoint has no inventory for this path.
+ *
+ * The distinction this copy exists to preserve: **an empty inventory is not an
+ * empty SBOM.** Rendering a zero-row component table would assert that the
+ * artifact has no dependencies, which nothing in the data supports — the same
+ * class of bug as the green all-clear shield.
+ */
+export const PROXY_SBOM_NOT_RECORDED_COPY =
+  "No SBOM recorded for this artifact yet; it will be generated the next time " +
+  "it is pulled.";
+
+/**
+ * What the document actually is. The scan catalogs what it finds inside the
+ * archive; it does not resolve a dependency graph, and for npm it can list
+ * declared transitives the tarball does not vendor. Labelling it as a
+ * dependency tree would overstate it.
+ */
+export const PROXY_SBOM_INVENTORY_CAVEAT =
+  "This is the package inventory the scanner cataloged from the archive at " +
+  "download time, not a resolved transitive dependency tree.";
+
+/** Shown on proxy repositories whose format never runs an inline scan. */
+export const PROXY_SBOM_FORMAT_UNSUPPORTED_COPY =
+  "SBOMs are only recorded for PyPI, npm and Docker/OCI proxy repositories. " +
+  "Other formats have no inline scan to catalog from.";
+
+/**
+ * On-demand generation stays hosted-only: proxy content has no `artifacts`
+ * row, so the generate endpoint 404s for it. Naming the alternative keeps the
+ * panel from reporting a gap with no way to close it.
+ */
+export const PROXY_SBOM_GENERATION_NOTE =
+  "Proxy SBOMs are recorded by the download-time scan and cannot be generated " +
+  "on demand. To produce one now, pull the artifact through this repository, " +
+  "or ingest it into a hosted repository and generate an SBOM there.";
+
+// ---------------------------------------------------------------------------
+// Format helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Formats whose proxy download path runs an inline scan, and therefore have an
+ * inventory to serve. Docker/OCI is included here (unlike the verdict summary)
+ * because the OCI proxy path does scan, even though its verdicts live in a
+ * different store.
+ */
+const PROXY_SBOM_FORMATS: ReadonlySet<string> = new Set([
+  "npm",
+  "pypi",
+  "docker",
+  "oci",
+  "podman",
+  "oras",
+]);
+
+/** Whether this repository's format can have a recorded proxy SBOM. */
+export function formatHasProxySbom(format: string | null | undefined): boolean {
+  return PROXY_SBOM_FORMATS.has(format ?? "");
+}
+
+// ---------------------------------------------------------------------------
+// Document parsing
+// ---------------------------------------------------------------------------
+
+type Json = Record<string, unknown>;
+
+function asObject(value: unknown): Json | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Json)
+    : null;
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+/** Trim, and treat blanks and SPDX's NOASSERTION/NONE sentinels as absent. */
+function cleanString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (trimmed === "NOASSERTION" || trimmed === "NONE") return null;
+  return trimmed;
+}
+
+/**
+ * CycloneDX licenses are an array of either `{license: {id|name}}` or
+ * `{expression}`. Take the first that resolves so the column stays one line.
+ */
+function cycloneDxLicense(component: Json): string | null {
+  for (const raw of asArray(component.licenses)) {
+    const entry = asObject(raw);
+    if (!entry) continue;
+    const expression = cleanString(entry.expression);
+    if (expression) return expression;
+    const license = asObject(entry.license);
+    if (!license) continue;
+    const id = cleanString(license.id) ?? cleanString(license.name);
+    if (id) return id;
+  }
+  return null;
+}
+
+function cycloneDxComponents(doc: Json): ProxySbomComponent[] {
+  return asArray(doc.components)
+    .map(asObject)
+    .filter((c): c is Json => c !== null)
+    .map((c) => ({
+      name: cleanString(c.name) ?? "",
+      version: cleanString(c.version),
+      license: cycloneDxLicense(c),
+      purl: cleanString(c.purl),
+    }))
+    .filter((c) => c.name !== "");
+}
+
+/**
+ * SPDX records the purl as an external reference with
+ * `referenceType: "purl"`. `referenceCategory` spelling varies between SPDX
+ * 2.2 and 2.3 documents, so match on the type alone.
+ */
+function spdxPurl(pkg: Json): string | null {
+  for (const raw of asArray(pkg.externalRefs)) {
+    const ref = asObject(raw);
+    if (!ref) continue;
+    if (cleanString(ref.referenceType)?.toLowerCase() !== "purl") continue;
+    const locator = cleanString(ref.referenceLocator);
+    if (locator) return locator;
+  }
+  return null;
+}
+
+function spdxPackages(doc: Json): ProxySbomComponent[] {
+  return asArray(doc.packages)
+    .map(asObject)
+    .filter((p): p is Json => p !== null)
+    .map((p) => ({
+      name: cleanString(p.name) ?? "",
+      version: cleanString(p.versionInfo),
+      // Concluded is the stronger claim; fall back to declared.
+      license: cleanString(p.licenseConcluded) ?? cleanString(p.licenseDeclared),
+      purl: spdxPurl(p),
+    }))
+    .filter((c) => c.name !== "");
+}
+
+/** Which document format this body is, judged by its own self-description. */
+export function detectSbomFormat(doc: Json): ProxySbomFormat | "unknown" {
+  if (typeof doc.bomFormat === "string" && doc.bomFormat.toLowerCase() === "cyclonedx") {
+    return "cyclonedx";
+  }
+  if (typeof doc.spdxVersion === "string") return "spdx";
+  // Fall back to the shape when the document omits its own marker.
+  if (Array.isArray(doc.components)) return "cyclonedx";
+  if (Array.isArray(doc.packages)) return "spdx";
+  return "unknown";
+}
+
+/**
+ * Unwrap the response body down to the document.
+ *
+ * The endpoint is documented as returning "a CycloneDX or SPDX document",
+ * which leaves open whether it is served bare or inside an envelope. Accept a
+ * bare document, `{document: …}`, and `{sbom: …}`, and accept a document
+ * delivered as a JSON string, so the panel is not coupled to that choice.
+ */
+export function unwrapSbomDocument(raw: unknown): Json | null {
+  let value = raw;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    try {
+      value = JSON.parse(trimmed);
+    } catch {
+      return null;
+    }
+  }
+  const body = asObject(value);
+  if (!body) return null;
+
+  for (const key of ["document", "sbom"] as const) {
+    if (key in body) {
+      const nested = unwrapSbomDocument(body[key]);
+      // An envelope with an explicitly null document is "nothing recorded",
+      // not "fall through and parse the envelope itself".
+      return nested;
+    }
+  }
+  return body;
+}
+
+/**
+ * Normalize a response body into what the panel renders.
+ *
+ * Returns `absent` for a missing document *and* for a document that catalogs
+ * nothing. Those are not distinguishable in the data, and conflating them is
+ * safe in one direction only: reporting "no inventory recorded" when a
+ * document happens to be empty is honest, whereas rendering an empty table
+ * would assert the artifact has no dependencies.
+ */
+export function parseProxySbom(raw: unknown): ProxySbomInventory {
+  const doc = unwrapSbomDocument(raw);
+  if (!doc) return { kind: "absent" };
+
+  const format = detectSbomFormat(doc);
+  const components =
+    format === "spdx" ? spdxPackages(doc) : cycloneDxComponents(doc);
+
+  if (components.length === 0) return { kind: "absent" };
+  return { kind: "present", format, components };
+}
+
+/** Pretty-print the document for the raw viewer and the download. */
+export function formatSbomDocument(raw: unknown): string {
+  const doc = unwrapSbomDocument(raw);
+  if (!doc) return "";
+  return JSON.stringify(doc, null, 2);
+}
+
+/** Distinct licenses across the inventory, sorted, excluding unknowns. */
+export function sbomLicenseSummary(
+  components: ProxySbomComponent[],
+): string[] {
+  const seen = new Set<string>();
+  for (const component of components) {
+    if (component.license) seen.add(component.license);
+  }
+  return [...seen].sort((a, b) => a.localeCompare(b));
+}

--- a/src/lib/proxy-sbom.ts
+++ b/src/lib/proxy-sbom.ts
@@ -1,4 +1,5 @@
 import type {
+  ProxySbomCompleteness,
   ProxySbomComponent,
   ProxySbomFormat,
   ProxySbomInventory,
@@ -26,8 +27,20 @@ import type {
  * class of bug as the green all-clear shield.
  */
 export const PROXY_SBOM_NOT_RECORDED_COPY =
-  "No SBOM recorded for this artifact yet; it will be generated the next time " +
-  "it is pulled.";
+  "No SBOM recorded for this artifact yet — it will be generated the next " +
+  "time the artifact is pulled.";
+
+/**
+ * The reassurance that goes with it.
+ *
+ * Only digests pulled after the inventory feature ships have one recorded, so
+ * on any existing deployment the empty state is what most users meet first.
+ * Without this line it reads as a fault; with it, it reads as a not-yet.
+ */
+export const PROXY_SBOM_NOT_RECORDED_REASON =
+  "Artifacts cached before inventory recording was enabled do not have one " +
+  "until they are pulled again. This is expected and does not indicate a " +
+  "problem with the artifact.";
 
 /**
  * What the document actually is. The scan catalogs what it finds inside the
@@ -38,6 +51,16 @@ export const PROXY_SBOM_NOT_RECORDED_COPY =
 export const PROXY_SBOM_INVENTORY_CAVEAT =
   "This is the package inventory the scanner cataloged from the archive at " +
   "download time, not a resolved transitive dependency tree.";
+
+/**
+ * Shown when the scan itself reported that it did not catalog everything.
+ * Presenting a knowingly-partial inventory as the artifact's full contents is
+ * the same failure mode as an empty table reading as "no dependencies".
+ */
+export const PROXY_SBOM_PARTIAL_COPY =
+  "The scan reported this inventory as incomplete — it is missing components " +
+  "it could not catalog. Treat it as a partial list, not as the artifact's " +
+  "full contents.";
 
 /** Shown on proxy repositories whose format never runs an inline scan. */
 export const PROXY_SBOM_FORMAT_UNSUPPORTED_COPY =
@@ -210,6 +233,52 @@ export function unwrapSbomDocument(raw: unknown): Json | null {
 }
 
 /**
+ * Read a completeness claim out of a CycloneDX `metadata.properties` array,
+ * which is where a generator records non-standard facts about its own output.
+ */
+function completenessFromProperties(doc: Json): string | null {
+  const metadata = asObject(doc.metadata);
+  if (!metadata) return null;
+  for (const raw of asArray(metadata.properties)) {
+    const property = asObject(raw);
+    if (!property) continue;
+    const name = cleanString(property.name)?.toLowerCase();
+    // Generators namespace their properties (`artifact-keeper:…`), so match on
+    // the suffix rather than an exact key.
+    if (!name || !name.includes("completeness")) continue;
+    const value = cleanString(property.value);
+    if (value) return value;
+  }
+  return null;
+}
+
+/**
+ * Whether the scan claimed to have cataloged everything.
+ *
+ * Checked in three places because the backend has not pinned down where it
+ * records this: the response envelope, the document root, and CycloneDX
+ * `metadata.properties`.
+ *
+ * An absent claim is `unknown`, not `complete`. The UI must not assert
+ * completeness the data does not support, and must not warn on every SBOM
+ * served by a backend that never emits the field — so only an explicit
+ * non-complete value raises the banner.
+ */
+export function detectInventoryCompleteness(
+  raw: unknown,
+  doc: Json | null,
+): ProxySbomCompleteness {
+  const envelope = asObject(raw);
+  const claim =
+    cleanString(envelope?.inventory_completeness) ??
+    cleanString(doc?.inventory_completeness) ??
+    (doc ? completenessFromProperties(doc) : null);
+
+  if (!claim) return "unknown";
+  return claim.toLowerCase() === "complete" ? "complete" : "partial";
+}
+
+/**
  * Normalize a response body into what the panel renders.
  *
  * Returns `absent` for a missing document *and* for a document that catalogs
@@ -227,7 +296,12 @@ export function parseProxySbom(raw: unknown): ProxySbomInventory {
     format === "spdx" ? spdxPackages(doc) : cycloneDxComponents(doc);
 
   if (components.length === 0) return { kind: "absent" };
-  return { kind: "present", format, components };
+  return {
+    kind: "present",
+    format,
+    components,
+    completeness: detectInventoryCompleteness(raw, doc),
+  };
 }
 
 /** Pretty-print the document for the raw viewer and the download. */

--- a/src/lib/proxy-scan.ts
+++ b/src/lib/proxy-scan.ts
@@ -133,6 +133,38 @@ export function resolveProxyScanView(input: {
   return { kind: "verdict", entry: input.entry };
 }
 
+/**
+ * View state for the repository-level summary + list.
+ *
+ * Separate from {@link resolveProxyScanView} because a 404 means something
+ * different here: on a single path it means "this repository's catalog has no
+ * such row", but on the collection it means the endpoint is not mounted for
+ * this repository at all. Reporting the latter as a scan failure would be
+ * alarming and wrong.
+ */
+export type ProxyScanListView =
+  | { kind: "loading" }
+  | { kind: "unavailable" }
+  | { kind: "failure"; failure: Exclude<ProxyScanFailure, "unresolvable"> }
+  | { kind: "ready" };
+
+export function resolveProxyScanListView(input: {
+  isLoading: boolean;
+  error: unknown;
+}): ProxyScanListView {
+  if (input.error != null) {
+    const failure = classifyProxyScanError(input.error);
+    return failure === "unresolvable"
+      ? { kind: "unavailable" }
+      : { kind: "failure", failure };
+  }
+  return input.isLoading ? { kind: "loading" } : { kind: "ready" };
+}
+
+/** Shown when the endpoint is not mounted for this repository. */
+export const PROXY_SCAN_UNAVAILABLE_COPY =
+  "Proxy scan status is not available for this repository.";
+
 // ---------------------------------------------------------------------------
 // Verdict copy
 // ---------------------------------------------------------------------------
@@ -263,6 +295,33 @@ export function showsInheritedVerdict(
 ): boolean {
   if (enforcement.scan_on_proxy) return false;
   return state === "clean" || state === "vulnerable";
+}
+
+/**
+ * Formats whose proxy download path has scan-gate wiring.
+ *
+ * There is no authoritative source for this in the backend — the gate is
+ * inline call sites with no registry or capability function — so this is a
+ * hardcoded list scoped to what actually ships, matching the endpoint's own
+ * scope. Extend it in step with the gate rather than guessing wider: showing
+ * an always-empty proxy-cache panel on a format that has no gate is noise, and
+ * a format that gains a gate without gaining a row here silently loses its
+ * summary.
+ */
+const PROXY_SCANNED_FORMATS: ReadonlySet<string> = new Set(["npm", "pypi"]);
+
+/**
+ * Whether the repository Security tab should render the proxy-cache summary.
+ * Only Remote repositories have a proxy cache at all.
+ */
+export function hasProxyScanSummary(
+  repository:
+    | { repo_type?: string | null; format?: string | null }
+    | null
+    | undefined,
+): boolean {
+  if (repository?.repo_type !== "remote") return false;
+  return PROXY_SCANNED_FORMATS.has(repository.format ?? "");
 }
 
 /** Severity buckets, in descending order, dropping empty ones. */

--- a/src/lib/proxy-scan.ts
+++ b/src/lib/proxy-scan.ts
@@ -105,7 +105,15 @@ export function classifyProxyScanError(error: unknown): ProxyScanFailure {
 
 export type ProxyScanView =
   | { kind: "loading" }
-  | { kind: "failure"; failure: ProxyScanFailure }
+  /**
+   * `unresolvable` is deliberately excluded here rather than the access notice
+   * being widened to accept it: an unresolvable path is a *required* state,
+   * but it is rendered by the `unresolved` branch below as unknown-not-clean,
+   * not as an access failure. Widening the notice instead would create an
+   * unreachable branch with no copy of its own, and the type would stop
+   * proving that every failure the notice receives has wording.
+   */
+  | { kind: "failure"; failure: Exclude<ProxyScanFailure, "unresolvable"> }
   /** Resolved, but with no entry for this path — render as unknown, not clean. */
   | { kind: "unresolved" }
   | { kind: "verdict"; entry: ProxyScanEntry };

--- a/src/lib/proxy-scan.ts
+++ b/src/lib/proxy-scan.ts
@@ -1,0 +1,280 @@
+import { ApiError } from "@/lib/api/fetch";
+import type {
+  ProxyScanEnforcement,
+  ProxyScanEntry,
+  ProxyScanState,
+} from "@/types/proxy-scans";
+
+/**
+ * Pure presentation logic for proxy-cache scan verdicts.
+ *
+ * Kept out of the components so every state — including the ones that are hard
+ * to reach through the UI — is unit-testable without a query client or a
+ * rendered tree.
+ *
+ * The rule that governs all of it: **a state we cannot prove is clean must
+ * never render as clean.** The bug this module exists to fix is
+ * `security-tab-content.tsx` rendering a green "No vulnerabilities detected"
+ * whenever its finding total was zero, which for proxy-cached artifacts is
+ * structurally always true (the total is driven by artifact-keyed CVE history,
+ * and proxy content has no `artifacts` row). A 403-blocked artifact showed a
+ * green all-clear.
+ */
+
+// ---------------------------------------------------------------------------
+// Copy
+// ---------------------------------------------------------------------------
+
+/**
+ * Shown to anonymous viewers. The repositories pages sit outside the
+ * `(protected)` route group and the artifact Security tab renders for
+ * unauthenticated users on public repositories — the largest audience for a
+ * public registry — while the endpoint 401s them by design. Treating that
+ * failure as "zero findings" would restore the green all-clear for exactly
+ * that audience.
+ */
+export const PROXY_SCAN_SIGN_IN_COPY = "Sign in to view scan status.";
+
+/**
+ * Shown to an authenticated user the endpoint refuses. Distinct from the
+ * anonymous copy — telling a signed-in user to sign in is a dead end.
+ */
+export const PROXY_SCAN_FORBIDDEN_COPY =
+  "You do not have access to scan status for this repository.";
+
+/**
+ * Per-CVE detail does not exist for proxy-cached content: findings are reduced
+ * to a verdict and counts at scan time and never persisted per-CVE. Naming the
+ * remedy is a hard requirement — without it the panel reports a problem and
+ * offers no way to act on it.
+ */
+export const PROXY_SCAN_NO_CVE_DETAIL_COPY =
+  "Per-CVE detail is not available for proxy-cached content. To see individual " +
+  "findings, ingest this artifact into a hosted repository and scan it there.";
+
+/**
+ * Verdicts are global by content digest, so a repository with scanning off can
+ * display a verdict another repository recorded for byte-identical content.
+ * Suppressing the verdict would re-create the original bug; the mitigation is
+ * saying plainly that it is not enforced here.
+ */
+export const PROXY_SCAN_NOT_ENFORCED_COPY =
+  "Scanning is disabled for this repository — verdicts shown were recorded " +
+  "elsewhere and are not enforced here.";
+
+/** Counts are over distinct digests; one repository can cache a digest at many paths. */
+export const PROXY_SCAN_DISTINCT_DIGESTS_COPY =
+  "Counts are over distinct content digests, not cache paths.";
+
+export const PROXY_SCAN_PENDING_INGEST_COPY =
+  "Cache entries whose content never finished committing. They have no digest " +
+  "to look a verdict up by.";
+
+// ---------------------------------------------------------------------------
+// Error classification
+// ---------------------------------------------------------------------------
+
+/** How a failed verdict lookup should be presented. */
+export type ProxyScanFailure =
+  | "unauthenticated"
+  | "forbidden"
+  | "unresolvable"
+  | "error";
+
+/**
+ * Classify a query error. A 401 is the anonymous case; a 403 is a signed-in
+ * user without visibility; a 404 means the path could not be resolved —
+ * a repository with zero catalog rows falls back to storage enumeration for
+ * its listing, so a modal click there can produce a path the catalog-backed
+ * endpoint does not know, as can a placeholder row with a NULL checksum.
+ *
+ * Anything else is still a failure, and a failure is never clean.
+ */
+export function classifyProxyScanError(error: unknown): ProxyScanFailure {
+  if (error instanceof ApiError) {
+    if (error.status === 401) return "unauthenticated";
+    if (error.status === 403) return "forbidden";
+    if (error.status === 404) return "unresolvable";
+  }
+  return "error";
+}
+
+// ---------------------------------------------------------------------------
+// View state
+// ---------------------------------------------------------------------------
+
+export type ProxyScanView =
+  | { kind: "loading" }
+  | { kind: "failure"; failure: ProxyScanFailure }
+  /** Resolved, but with no entry for this path — render as unknown, not clean. */
+  | { kind: "unresolved" }
+  | { kind: "verdict"; entry: ProxyScanEntry };
+
+/**
+ * Collapse a react-query result into the state the panel renders. Deliberately
+ * total: there is no fall-through that produces a clean verdict.
+ */
+export function resolveProxyScanView(input: {
+  isLoading: boolean;
+  error: unknown;
+  entry: ProxyScanEntry | null | undefined;
+}): ProxyScanView {
+  if (input.error != null) {
+    const failure = classifyProxyScanError(input.error);
+    // A 404 is a resolved answer ("this repository has no such catalog row"),
+    // not a transport failure, so it renders as the unknown state rather than
+    // as an error.
+    return failure === "unresolvable"
+      ? { kind: "unresolved" }
+      : { kind: "failure", failure };
+  }
+  if (input.isLoading) return { kind: "loading" };
+  if (input.entry == null) return { kind: "unresolved" };
+  return { kind: "verdict", entry: input.entry };
+}
+
+// ---------------------------------------------------------------------------
+// Verdict copy
+// ---------------------------------------------------------------------------
+
+/** Visual weight of a verdict. `clean` is the only tone allowed to read green. */
+export type ProxyVerdictTone = "clean" | "danger" | "neutral";
+
+export interface ProxyVerdictCopy {
+  tone: ProxyVerdictTone;
+  headline: string;
+  detail: string;
+}
+
+/** Render a timestamp at date granularity. Verdicts are not minute-accurate. */
+export function formatScannedDate(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toLocaleDateString();
+}
+
+/**
+ * What `vulnerable` means operationally. The same verdict is "pulls are
+ * blocked" in a scanning fail-closed repository and "served anyway" in a
+ * repository with scanning off — same chip, opposite meaning. Copy must never
+ * imply vulnerable ⇒ blocked.
+ */
+function vulnerableDetail(enforcement: ProxyScanEnforcement): string {
+  if (!enforcement.scan_on_proxy) {
+    return (
+      "Scanning is disabled for this repository, so this verdict is not " +
+      "enforced here and downloads are served."
+    );
+  }
+  if (enforcement.proxy_scan_action === "fail_closed") {
+    return "This repository withholds downloads it cannot clear (fail-closed).";
+  }
+  return (
+    "This repository is configured to serve downloads it cannot clear " +
+    "(fail-open), so the artifact may still be served."
+  );
+}
+
+function notScannedDetail(
+  reason: ProxyScanEntry["reason"],
+  enforcement: ProxyScanEnforcement,
+): string {
+  if (reason === "scanning_disabled") {
+    return (
+      "Scan-on-proxy is off for this repository, so downloads are served " +
+      "without being scanned. No verdict is not evidence of safety."
+    );
+  }
+  const posture =
+    enforcement.proxy_scan_action === "fail_closed"
+      ? "This repository withholds downloads it cannot clear, so it may have been withheld."
+      : "This repository serves downloads it cannot clear, so it may have been served unscanned.";
+  return `No verdict is not evidence of safety. ${posture}`;
+}
+
+/**
+ * Headline and supporting line for a verdict.
+ *
+ * A clean verdict says **"Clean as of <date>"** rather than "no
+ * vulnerabilities": a verdict inside the reuse window can still have been
+ * scanned against an outdated vulnerability database (#3287), so this is a
+ * statement about when, not a guarantee about now.
+ */
+export function describeProxyVerdict(
+  entry: ProxyScanEntry,
+  enforcement: ProxyScanEnforcement,
+): ProxyVerdictCopy {
+  switch (entry.state) {
+    case "clean": {
+      const date = formatScannedDate(entry.scanned_at);
+      return {
+        tone: "clean",
+        headline: date ? `Clean as of ${date}` : "Clean — no findings recorded",
+        detail:
+          "No vulnerabilities were found the last time this content was " +
+          "scanned. The vulnerability database may have changed since.",
+      };
+    }
+    case "vulnerable": {
+      const date = formatScannedDate(entry.scanned_at);
+      return {
+        tone: "danger",
+        headline: date
+          ? `Vulnerable as of ${date}`
+          : "Vulnerable — findings recorded",
+        detail: vulnerableDetail(enforcement),
+      };
+    }
+    default:
+      return {
+        tone: "neutral",
+        headline:
+          entry.reason === "scanning_disabled"
+            ? "Not scanned — scanning is disabled for this repository"
+            : "Not scanned — this artifact has no scan verdict on record",
+        detail: notScannedDetail(entry.reason, enforcement),
+      };
+  }
+}
+
+/** Copy for a path the endpoint could not resolve. Unknown, never clean. */
+export function describeUnresolvedPath(): ProxyVerdictCopy {
+  return {
+    tone: "neutral",
+    headline: "Scan status unknown for this path",
+    detail:
+      "This repository has no cache catalog entry for this path, so no scan " +
+      "verdict can be looked up. Unknown is not clean.",
+  };
+}
+
+/**
+ * Whether to show the "recorded elsewhere, not enforced here" banner: the
+ * repository does not scan proxy downloads, yet a verdict is on screen. That
+ * verdict came from another repository that cached byte-identical content.
+ *
+ * Orthogonal to the verdict itself, so it is computed separately rather than
+ * folded into the state.
+ */
+export function showsInheritedVerdict(
+  state: ProxyScanState | null | undefined,
+  enforcement: ProxyScanEnforcement,
+): boolean {
+  if (enforcement.scan_on_proxy) return false;
+  return state === "clean" || state === "vulnerable";
+}
+
+/** Severity buckets, in descending order, dropping empty ones. */
+export function severityBuckets(
+  entry: ProxyScanEntry,
+): Array<{ key: "critical" | "high" | "medium" | "low"; count: number }> {
+  return (
+    [
+      { key: "critical" as const, count: entry.critical_count },
+      { key: "high" as const, count: entry.high_count },
+      { key: "medium" as const, count: entry.medium_count },
+      { key: "low" as const, count: entry.low_count },
+    ] satisfies Array<{ key: "critical" | "high" | "medium" | "low"; count: number }>
+  ).filter((bucket) => bucket.count > 0);
+}

--- a/src/types/proxy-sbom.ts
+++ b/src/types/proxy-sbom.ts
@@ -1,0 +1,48 @@
+/**
+ * Types for the proxy-cache SBOM endpoint.
+ *
+ * ```
+ * GET /api/v1/repositories/:key/security/proxy-sbom?path=…&format=cyclonedx|spdx
+ * ```
+ *
+ * Every inline proxy scan already produces a complete package inventory while
+ * cataloging the archive; this endpoint serves it as a CycloneDX (default) or
+ * SPDX document. Like the verdict endpoint, lookup is by cache path — a digest
+ * parameter would be a cross-tenant lookup oracle — and authentication is
+ * required unconditionally.
+ *
+ * Only PyPI, npm and Docker/OCI proxies run an inline scan, so those are the
+ * only repositories that have an inventory to serve.
+ */
+
+export type ProxySbomFormat = "cyclonedx" | "spdx";
+
+/**
+ * One catalogued package, normalized across both document formats so the table
+ * does not need to know which one it is rendering.
+ */
+export interface ProxySbomComponent {
+  name: string;
+  version: string | null;
+  /** SPDX expression or license id. Null when the document asserts nothing. */
+  license: string | null;
+  purl: string | null;
+}
+
+/**
+ * What the panel actually renders.
+ *
+ * `absent` and `present`-with-components are deliberately the only two
+ * outcomes. A document that parses but catalogues nothing is reported as
+ * `absent`: an empty component table would read as "this artifact has no
+ * dependencies", which is a claim the data cannot support — the same class of
+ * bug as the green all-clear shield.
+ */
+export type ProxySbomInventory =
+  | { kind: "absent" }
+  | {
+      kind: "present";
+      /** The format the document declared, when it declared one. */
+      format: ProxySbomFormat | "unknown";
+      components: ProxySbomComponent[];
+    };

--- a/src/types/proxy-sbom.ts
+++ b/src/types/proxy-sbom.ts
@@ -45,4 +45,15 @@ export type ProxySbomInventory =
       /** The format the document declared, when it declared one. */
       format: ProxySbomFormat | "unknown";
       components: ProxySbomComponent[];
+      completeness: ProxySbomCompleteness;
     };
+
+/**
+ * Whether the scan believes it cataloged everything.
+ *
+ * `unknown` is the honest default when the document says nothing: the UI must
+ * not claim completeness it cannot prove, but it also must not warn about
+ * every SBOM on a backend that never emits the field. Only an explicit
+ * non-complete value raises the banner.
+ */
+export type ProxySbomCompleteness = "complete" | "partial" | "unknown";

--- a/src/types/proxy-scans.ts
+++ b/src/types/proxy-scans.ts
@@ -1,0 +1,112 @@
+/**
+ * Types for the repository-scoped proxy scan verdict endpoint.
+ *
+ * ```
+ * GET /api/v1/repositories/:key/security/proxy-scans          → summary + paged list
+ * GET /api/v1/repositories/:key/security/proxy-scans?path=…   → one cached path
+ * ```
+ *
+ * Proxy-cached artifacts are scanned at download time and blocked on policy
+ * violation, but they have no `artifacts` row and no artifact-keyed CVE
+ * history, so none of it was visible in the UI. Verdicts are keyed by content
+ * digest and looked up **by cache path** — a digest parameter would turn the
+ * endpoint into a cross-tenant lookup oracle, a path is inherently scoped to
+ * the calling repository.
+ *
+ * The endpoint requires authentication unconditionally, including on public
+ * repositories.
+ */
+
+/**
+ * Verdict state for one cached path.
+ *
+ * There is deliberately no `stale` state and no `pending` state: the backend
+ * persists successful verdicts, not scan attempts, so nothing at rest
+ * distinguishes "not scanned yet" from "scan failed" from "over the size cap".
+ * All of those land in `not_scanned` with reason `unknown`.
+ */
+export type ProxyScanState = "clean" | "vulnerable" | "not_scanned";
+
+/**
+ * Why a path has no verdict row.
+ *
+ * `scanning_disabled` also covers the case where the repository has **no**
+ * `scan_configs` row at all — that is the default state for a repository whose
+ * security settings were never saved, and it matches what the download gate
+ * actually does (`unwrap_or(false)`).
+ *
+ * `unknown` is a large bucket: over-cap content, unestablished identity, and
+ * failed scans all land here, including cases where content was served without
+ * ever being scanned. Copy for it must never imply safety.
+ */
+export type ProxyScanNotScannedReason = "scanning_disabled" | "unknown";
+
+/**
+ * What the repository does when a proxy scan cannot produce a usable verdict.
+ * `fail_open` serves the artifact anyway; `fail_closed` withholds it.
+ */
+export type ProxyScanAction = "fail_open" | "fail_closed";
+
+/** Verdict for a single cached path. */
+export interface ProxyScanEntry {
+  /** Cache path within the repository. */
+  path: string;
+  state: ProxyScanState;
+  /** Present only when `state` is `not_scanned`. */
+  reason?: ProxyScanNotScannedReason | null;
+  critical_count: number;
+  high_count: number;
+  medium_count: number;
+  low_count: number;
+  findings_count: number;
+  /**
+   * When the verdict was recorded, floored at this repository's own
+   * `cached_at` so a raw timestamp cannot be used as a tenant-activity oracle.
+   * Null for `not_scanned`.
+   */
+  scanned_at?: string | null;
+}
+
+/**
+ * Counts over **distinct digests**, not paths — one repository can cache the
+ * same digest at many paths.
+ */
+export interface ProxyScanSummary {
+  clean: number;
+  vulnerable: number;
+  not_scanned: number;
+  /**
+   * Placeholder rows with a NULL `checksum_sha256`. `record_proxy_download`
+   * upserts these before content commits, and an aborted tee or a client
+   * disconnect leaves them NULL permanently — there is no cleanup job. They
+   * join to nothing, so they are excluded from the state counts and reported
+   * separately for the totals to reconcile with the artifact listing.
+   */
+  pending_ingest: number;
+}
+
+/** Repository-level enforcement context, carried on every response. */
+export interface ProxyScanEnforcement {
+  /** Whether this repository scans proxy downloads at all. */
+  scan_on_proxy: boolean;
+  proxy_scan_action: ProxyScanAction;
+}
+
+/** Summary + paged list response. */
+export interface ProxyScanListResponse extends ProxyScanEnforcement {
+  summary: ProxyScanSummary;
+  items: ProxyScanEntry[];
+  total: number;
+  page: number;
+  per_page: number;
+}
+
+/** Single-path response: the entry plus the same enforcement context. */
+export interface ProxyScanPathResponse extends ProxyScanEnforcement {
+  entry: ProxyScanEntry | null;
+}
+
+export interface ListProxyScansParams {
+  page?: number;
+  per_page?: number;
+}


### PR DESCRIPTION
## Summary

Removes a green all-clear that was shown for artifacts the download gate had just blocked, and adds the UI for proxy-cached artifact scan verdicts and SBOMs.

Fixes #788
Fixes #790

### The bug

`security-tab-content.tsx` rendered a green `ShieldCheck` reading "No vulnerabilities detected for this artifact" whenever its finding total was zero. For proxy-cached artifacts that total is *structurally always* zero — it is driven by CVE history, which is artifact-keyed and therefore empty for proxy content. So a 403-blocked vulnerable artifact displayed a green all-clear.

### What ships

- Verdict panel replacing the all-clear for proxy-cached artifacts, using the repository's `scan_on_proxy` / `proxy_scan_action` so copy never implies `vulnerable` means blocked (a fail-open repository serves it anyway)
- Repository proxy-cache scan summary and cached-path listing — counts alone answer "3 vulnerable digests" but not *which ones*
- Proxy SBOM viewer in the artifact SBOM tab
- Corrected copy that claimed proxy-cached artifacts cannot be scanned
- Partial-inventory signal surfaced rather than presented as complete

### Contracts pinned by tests

**Anonymous users.** These pages sit outside the `(protected)` route group and the Security tab renders for anonymous viewers on public repositories, which the backend 401s by design. Treating a failed fetch as zero findings would bring the green all-clear back for exactly that audience. Copy is "Sign in to view", never implied-clean, and there is a named regression test.

**Empty is not clean.** An absent SBOM inventory renders as its own state. A zero-row component table would read as "this artifact has no dependencies", which the data cannot support.

**Unresolvable paths.** A repository with no catalog rows falls back to storage enumeration and can produce paths the endpoint cannot resolve. Those render as unknown, not clean.

## Test Checklist

- [x] Lint
- [x] Typecheck — no new errors
- [x] Unit tests — 3217 passing across 177 files
- [x] Verified against a live backend

## API Changes

Consumes two new backend endpoints (`/security/proxy-scans`, `/security/proxy-sbom`). No UI API surface changed.
