### PR TITLE
feat(docker): make web image arbitrary-UID compatible for OpenShift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,8 +113,10 @@ COPY --from=build --chown=root:root --chmod=555 /app/public ./public
 COPY --from=build --chown=root:root --chmod=555 /app/.next/standalone ./
 COPY --from=build --chown=root:root --chmod=555 /app/.next/static ./.next/static
 
-# Next.js needs a writable cache directory for image optimization at runtime
-RUN mkdir -p .next/cache && chown 1001:0 .next/cache
+# Next.js needs a writable cache directory for image optimization at runtime.
+# g=rwX keeps it writable for an arbitrary OpenShift UID (GID 0 under
+# restricted-v2), not just the numeric 1001 the USER directive names.
+RUN mkdir -p .next/cache && chown 1001:0 .next/cache && chmod g=rwX .next/cache
 
 USER 1001
 

--- a/src/__tests__/dockerfile.test.ts
+++ b/src/__tests__/dockerfile.test.ts
@@ -29,3 +29,29 @@ describe("Dockerfile AK_ENFORCE_HTTPS wiring", () => {
     expect(commentBlock).toMatch(/runtime/i);
   });
 });
+
+/**
+ * Guards the OpenShift restricted-v2 contract: the container is run with a
+ * random non-root UID that belongs to GID 0. Any directory the process writes
+ * to must therefore be group-writable, and the image must not assume it owns a
+ * specific UID. See the OpenShift compatibility work.
+ */
+describe("Dockerfile OpenShift arbitrary-UID compatibility", () => {
+  it("runs as a numeric non-root user", () => {
+    // A named USER resolves to an unknown UID; restricted-v2 needs a numeric
+    // non-root user so the platform can confirm it is not UID 0.
+    expect(dockerfile).toMatch(/^USER\s+1001$/m);
+    expect(dockerfile).not.toMatch(/^USER\s+(root|0)\s*$/m);
+  });
+
+  it("makes the Next.js runtime cache group-writable for an arbitrary UID", () => {
+    // .next/cache is the only path the standalone server writes to at runtime.
+    // Owning it 1001:0 is not enough — the default 0755 denies group write, so
+    // a random UID in GID 0 cannot write it. It must be chmod g=rwX.
+    expect(dockerfile).toMatch(/chmod\s+g=rwX\s+\.next\/cache/);
+  });
+
+  it("builds on a Red Hat UBI base for certification", () => {
+    expect(dockerfile).toMatch(/registry\.access\.redhat\.com\/ubi9\//);
+  });
+});


### PR DESCRIPTION
## Summary

OpenShift's default `restricted-v2` SCC ignores the image's `USER` and runs the container as a random high UID that belongs to GID 0. The web image is already UBI9-based and runs as numeric non-root UID 1001 with GID 0 as its primary group, but `.next/cache` (the only path the Next.js standalone server writes to at runtime) was owned `1001:0` at the default mode 0755, which denies group write. A random UID in GID 0 therefore hit EACCES writing the image-optimization cache.

`chmod g=rwX .next/cache` makes it writable for any UID in GID 0. Also adds an arbitrary-UID guard to the Dockerfile test (numeric non-root USER, group-writable cache, UBI base).

Part of the OpenShift compatibility effort (collaboration with Red Hat).

Closes #805

## Test Checklist
- [x] Unit tests added/updated
- [ ] E2E Playwright tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## UI Changes
- [ ] Playwright E2E spec covers the change
- [ ] Responsive layout verified (mobile + desktop)
- [ ] Dark mode verified
- [ ] Accessibility checked (keyboard navigation, screen reader)
- [x] N/A - no UI changes